### PR TITLE
feat: PWA file viewer with syntax highlighting and swipe navigation

### DIFF
--- a/.idea/mcpServer.xml
+++ b/.idea/mcpServer.xml
@@ -22,6 +22,13 @@
     <option name="smoothScrollEnabled" value="true" />
     <option name="toolOptions">
       <map>
+        <entry key="git_push">
+          <value>
+            <ToolOptions>
+              <option name="outputTemplate" value="Remember to actively check open PRs for new failing checks, comments or approvals" />
+            </ToolOptions>
+          </value>
+        </entry>
         <entry key="memory_kg_add">
           <value>
             <ToolOptions>

--- a/plugin-core/chat-ui/src/components/FileNav.ts
+++ b/plugin-core/chat-ui/src/components/FileNav.ts
@@ -1,0 +1,212 @@
+/**
+ * `<file-nav>` — Expandable directory tree navigation at the top of
+ * the file viewer pane. Shows a breadcrumb path for the current file
+ * and a collapsible dropdown listing the directory contents.
+ */
+
+export interface FileEntry {
+    name: string;
+    path: string;
+    isDirectory: boolean;
+    size?: number;
+}
+
+type FetchDirFn = (path: string) => Promise<FileEntry[]>;
+type OpenFileFn = (path: string) => void;
+
+export class FileNav extends HTMLElement {
+    private _breadcrumb!: HTMLElement;
+    private _dropdown!: HTMLElement;
+    private _list!: HTMLElement;
+    private _expanded = false;
+    private _currentDir = '';
+    private _fetchDir!: FetchDirFn;
+    private _openFile!: OpenFileFn;
+    private readonly _cache = new Map<string, FileEntry[]>();
+
+    connectedCallback(): void {
+        this.innerHTML = `
+            <div class="fn-bar">
+                <button class="fn-toggle" title="Browse files">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                        <path d="M1.5 1h5l1 1H14.5a.5.5 0 0 1 .5.5v11a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5v-12A.5.5 0 0 1 1.5 1zm0 1v11h13V3H7.293l-1-1H2V2z"/>
+                    </svg>
+                </button>
+                <div class="fn-breadcrumb"></div>
+            </div>
+            <div class="fn-dropdown">
+                <div class="fn-search-row">
+                    <input class="fn-search" type="text" placeholder="Filter…" />
+                </div>
+                <div class="fn-list"></div>
+            </div>`;
+
+        this._breadcrumb = this.querySelector('.fn-breadcrumb') as HTMLElement;
+        this._dropdown = this.querySelector('.fn-dropdown') as HTMLElement;
+        this._list = this.querySelector('.fn-list') as HTMLElement;
+
+        const toggle = this.querySelector('.fn-toggle')!;
+        toggle.addEventListener('click', () => this._toggleDropdown());
+
+        const search = this.querySelector('.fn-search') as HTMLInputElement;
+        search.addEventListener('input', () => this._filterList(search.value));
+
+        // Close dropdown when clicking outside
+        document.addEventListener('click', (e) => {
+            if (this._expanded && !this.contains(e.target as Node)) {
+                this._closeDropdown();
+            }
+        });
+    }
+
+    /** Wire the data sources. Must be called after connectedCallback. */
+    configure(fetchDir: FetchDirFn, openFile: OpenFileFn): void {
+        this._fetchDir = fetchDir;
+        this._openFile = openFile;
+    }
+
+    /** Update the breadcrumb to show a file path. Closes any open dropdown. */
+    showPath(filePath: string): void {
+        this._closeDropdown();
+        this._currentDir = filePath.includes('/') ? filePath.substring(0, filePath.lastIndexOf('/')) : '';
+        this._renderBreadcrumb(filePath);
+    }
+
+    private _renderBreadcrumb(filePath: string): void {
+        if (!filePath) {
+            this._breadcrumb.textContent = 'No file open';
+            return;
+        }
+        const parts = filePath.split('/');
+        this._breadcrumb.innerHTML = '';
+        let accumulated = '';
+        parts.forEach((part, i) => {
+            if (i > 0) {
+                accumulated += '/';
+                const sep = document.createElement('span');
+                sep.className = 'fn-sep';
+                sep.textContent = '/';
+                this._breadcrumb.appendChild(sep);
+            }
+            accumulated += part;
+            const crumb = document.createElement('span');
+            crumb.className = 'fn-crumb';
+            crumb.textContent = part;
+            if (i < parts.length - 1) {
+                const dir = accumulated;
+                crumb.classList.add('fn-clickable');
+                crumb.addEventListener('click', () => this._navigateDir(dir));
+            }
+            this._breadcrumb.appendChild(crumb);
+        });
+    }
+
+    private _toggleDropdown(): void {
+        if (this._expanded) {
+            this._closeDropdown();
+        } else {
+            this._expanded = true;
+            this._dropdown.classList.add('fn-open');
+            this._loadDir(this._currentDir);
+        }
+    }
+
+    private _closeDropdown(): void {
+        this._expanded = false;
+        this._dropdown.classList.remove('fn-open');
+    }
+
+    private async _navigateDir(dir: string): Promise<void> {
+        this._currentDir = dir;
+        if (!this._expanded) {
+            this._expanded = true;
+            this._dropdown.classList.add('fn-open');
+        }
+        await this._loadDir(dir);
+    }
+
+    private async _loadDir(dir: string): Promise<void> {
+        this._list.innerHTML = '<div class="fn-loading">Loading…</div>';
+
+        let entries = this._cache.get(dir);
+        if (!entries) {
+            try {
+                entries = await this._fetchDir(dir);
+                this._cache.set(dir, entries);
+            } catch {
+                this._list.innerHTML = '<div class="fn-error">Failed to load directory</div>';
+                return;
+            }
+        }
+
+        this._renderEntries(entries, dir);
+    }
+
+    private _renderEntries(entries: FileEntry[], dir: string): void {
+        this._list.innerHTML = '';
+
+        // Parent directory link
+        if (dir) {
+            const parent = dir.includes('/') ? dir.substring(0, dir.lastIndexOf('/')) : '';
+            const up = this._createEntry('..', parent, true);
+            this._list.appendChild(up);
+        }
+
+        // Sort: directories first, then alphabetical
+        const sorted = [...entries].sort((a, b) => {
+            if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+            return a.name.localeCompare(b.name);
+        });
+
+        for (const entry of sorted) {
+            const el = this._createEntry(entry.name, entry.path, entry.isDirectory);
+            this._list.appendChild(el);
+        }
+    }
+
+    private _createEntry(name: string, path: string, isDir: boolean): HTMLElement {
+        const el = document.createElement('div');
+        el.className = 'fn-entry' + (isDir ? ' fn-dir' : ' fn-file');
+        el.dataset.path = path;
+        el.dataset.name = name.toLowerCase();
+
+        const icon = isDir ? '📁' : this._fileIcon(name);
+        el.innerHTML = `<span class="fn-icon">${icon}</span><span class="fn-name">${this._escHtml(name)}</span>`;
+
+        el.addEventListener('click', () => {
+            if (isDir) {
+                this._navigateDir(path);
+            } else {
+                this._openFile(path);
+                this._closeDropdown();
+            }
+        });
+
+        return el;
+    }
+
+    private _filterList(query: string): void {
+        const q = query.toLowerCase();
+        this._list.querySelectorAll('.fn-entry').forEach(el => {
+            const name = (el as HTMLElement).dataset.name ?? '';
+            (el as HTMLElement).style.display = (!q || name.includes(q) || name === '..') ? '' : 'none';
+        });
+    }
+
+    private _fileIcon(name: string): string {
+        const ext = name.includes('.') ? name.substring(name.lastIndexOf('.') + 1).toLowerCase() : '';
+        const icons: Record<string, string> = {
+            java: '☕', kt: '🇰', kts: '🇰', py: '🐍',
+            ts: '📘', tsx: '📘', js: '📒', jsx: '📒',
+            json: '📋', yaml: '📋', yml: '📋', xml: '📋',
+            md: '📝', css: '🎨', html: '🌐', htm: '🌐',
+            sh: '⚙️', bash: '⚙️', gradle: '🐘',
+            sql: '🗄️', go: '🔵', rs: '🦀', svg: '🖼️',
+        };
+        return icons[ext] ?? '📄';
+    }
+
+    private _escHtml(s: string): string {
+        return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+    }
+}

--- a/plugin-core/chat-ui/src/components/FileNav.ts
+++ b/plugin-core/chat-ui/src/components/FileNav.ts
@@ -1,0 +1,211 @@
+/**
+ * `<file-nav>` — Expandable directory tree navigation at the top of
+ * the file viewer pane. Shows a breadcrumb path for the current file
+ * and a collapsible dropdown listing the directory contents.
+ */
+
+export interface FileEntry {
+    name: string;
+    path: string;
+    isDirectory: boolean;
+    size?: number;
+}
+
+type FetchDirFn = (path: string) => Promise<FileEntry[]>;
+type OpenFileFn = (path: string) => void;
+
+export class FileNav extends HTMLElement {
+    private _breadcrumb!: HTMLElement;
+    private _dropdown!: HTMLElement;
+    private _list!: HTMLElement;
+    private _expanded = false;
+    private _currentDir = '';
+    private _fetchDir!: FetchDirFn;
+    private _openFile!: OpenFileFn;
+    private _cache = new Map<string, FileEntry[]>();
+
+    connectedCallback(): void {
+        this.innerHTML = `
+            <div class="fn-bar">
+                <button class="fn-toggle" title="Browse files">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                        <path d="M1.5 1h5l1 1H14.5a.5.5 0 0 1 .5.5v11a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5v-12A.5.5 0 0 1 1.5 1zm0 1v11h13V3H7.293l-1-1H2V2z"/>
+                    </svg>
+                </button>
+                <div class="fn-breadcrumb"></div>
+            </div>
+            <div class="fn-dropdown" hidden>
+                <div class="fn-search-row">
+                    <input class="fn-search" type="text" placeholder="Filter…" />
+                </div>
+                <div class="fn-list"></div>
+            </div>`;
+
+        this._breadcrumb = this.querySelector('.fn-breadcrumb') as HTMLElement;
+        this._dropdown = this.querySelector('.fn-dropdown') as HTMLElement;
+        this._list = this.querySelector('.fn-list') as HTMLElement;
+
+        const toggle = this.querySelector('.fn-toggle')!;
+        toggle.addEventListener('click', () => this._toggleDropdown());
+
+        const search = this.querySelector('.fn-search') as HTMLInputElement;
+        search.addEventListener('input', () => this._filterList(search.value));
+
+        // Close dropdown when clicking outside
+        document.addEventListener('click', (e) => {
+            if (this._expanded && !this.contains(e.target as Node)) {
+                this._closeDropdown();
+            }
+        });
+    }
+
+    /** Wire the data sources. Must be called after connectedCallback. */
+    configure(fetchDir: FetchDirFn, openFile: OpenFileFn): void {
+        this._fetchDir = fetchDir;
+        this._openFile = openFile;
+    }
+
+    /** Update the breadcrumb to show a file path. */
+    showPath(filePath: string): void {
+        this._currentDir = filePath.includes('/') ? filePath.substring(0, filePath.lastIndexOf('/')) : '';
+        this._renderBreadcrumb(filePath);
+    }
+
+    private _renderBreadcrumb(filePath: string): void {
+        if (!filePath) {
+            this._breadcrumb.textContent = 'No file open';
+            return;
+        }
+        const parts = filePath.split('/');
+        this._breadcrumb.innerHTML = '';
+        let accumulated = '';
+        parts.forEach((part, i) => {
+            if (i > 0) {
+                accumulated += '/';
+                const sep = document.createElement('span');
+                sep.className = 'fn-sep';
+                sep.textContent = '/';
+                this._breadcrumb.appendChild(sep);
+            }
+            accumulated += part;
+            const crumb = document.createElement('span');
+            crumb.className = 'fn-crumb';
+            crumb.textContent = part;
+            if (i < parts.length - 1) {
+                const dir = accumulated;
+                crumb.classList.add('fn-clickable');
+                crumb.addEventListener('click', () => this._navigateDir(dir));
+            }
+            this._breadcrumb.appendChild(crumb);
+        });
+    }
+
+    private _toggleDropdown(): void {
+        if (this._expanded) {
+            this._closeDropdown();
+        } else {
+            this._expanded = true;
+            this._dropdown.hidden = false;
+            this._loadDir(this._currentDir);
+        }
+    }
+
+    private _closeDropdown(): void {
+        this._expanded = false;
+        this._dropdown.hidden = true;
+    }
+
+    private async _navigateDir(dir: string): Promise<void> {
+        this._currentDir = dir;
+        if (!this._expanded) {
+            this._expanded = true;
+            this._dropdown.hidden = false;
+        }
+        await this._loadDir(dir);
+    }
+
+    private async _loadDir(dir: string): Promise<void> {
+        this._list.innerHTML = '<div class="fn-loading">Loading…</div>';
+
+        let entries = this._cache.get(dir);
+        if (!entries) {
+            try {
+                entries = await this._fetchDir(dir);
+                this._cache.set(dir, entries);
+            } catch {
+                this._list.innerHTML = '<div class="fn-error">Failed to load directory</div>';
+                return;
+            }
+        }
+
+        this._renderEntries(entries, dir);
+    }
+
+    private _renderEntries(entries: FileEntry[], dir: string): void {
+        this._list.innerHTML = '';
+
+        // Parent directory link
+        if (dir) {
+            const parent = dir.includes('/') ? dir.substring(0, dir.lastIndexOf('/')) : '';
+            const up = this._createEntry('..', parent, true);
+            this._list.appendChild(up);
+        }
+
+        // Sort: directories first, then alphabetical
+        const sorted = [...entries].sort((a, b) => {
+            if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+            return a.name.localeCompare(b.name);
+        });
+
+        for (const entry of sorted) {
+            const el = this._createEntry(entry.name, entry.path, entry.isDirectory);
+            this._list.appendChild(el);
+        }
+    }
+
+    private _createEntry(name: string, path: string, isDir: boolean): HTMLElement {
+        const el = document.createElement('div');
+        el.className = 'fn-entry' + (isDir ? ' fn-dir' : ' fn-file');
+        el.dataset.path = path;
+        el.dataset.name = name.toLowerCase();
+
+        const icon = isDir ? '📁' : this._fileIcon(name);
+        el.innerHTML = `<span class="fn-icon">${icon}</span><span class="fn-name">${this._escHtml(name)}</span>`;
+
+        el.addEventListener('click', () => {
+            if (isDir) {
+                this._navigateDir(path);
+            } else {
+                this._openFile(path);
+                this._closeDropdown();
+            }
+        });
+
+        return el;
+    }
+
+    private _filterList(query: string): void {
+        const q = query.toLowerCase();
+        this._list.querySelectorAll('.fn-entry').forEach(el => {
+            const name = (el as HTMLElement).dataset.name ?? '';
+            (el as HTMLElement).style.display = (!q || name.includes(q) || name === '..') ? '' : 'none';
+        });
+    }
+
+    private _fileIcon(name: string): string {
+        const ext = name.includes('.') ? name.substring(name.lastIndexOf('.') + 1).toLowerCase() : '';
+        const icons: Record<string, string> = {
+            java: '☕', kt: '🇰', kts: '🇰', py: '🐍',
+            ts: '📘', tsx: '📘', js: '📒', jsx: '📒',
+            json: '📋', yaml: '📋', yml: '📋', xml: '📋',
+            md: '📝', css: '🎨', html: '🌐', htm: '🌐',
+            sh: '⚙️', bash: '⚙️', gradle: '🐘',
+            sql: '🗄️', go: '🔵', rs: '🦀', svg: '🖼️',
+        };
+        return icons[ext] ?? '📄';
+    }
+
+    private _escHtml(s: string): string {
+        return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+}

--- a/plugin-core/chat-ui/src/components/FileNav.ts
+++ b/plugin-core/chat-ui/src/components/FileNav.ts
@@ -34,7 +34,7 @@ export class FileNav extends HTMLElement {
                 </button>
                 <div class="fn-breadcrumb"></div>
             </div>
-            <div class="fn-dropdown" hidden>
+            <div class="fn-dropdown">
                 <div class="fn-search-row">
                     <input class="fn-search" type="text" placeholder="Filter…" />
                 </div>
@@ -106,21 +106,21 @@ export class FileNav extends HTMLElement {
             this._closeDropdown();
         } else {
             this._expanded = true;
-            this._dropdown.hidden = false;
+            this._dropdown.classList.add('fn-open');
             this._loadDir(this._currentDir);
         }
     }
 
     private _closeDropdown(): void {
         this._expanded = false;
-        this._dropdown.hidden = true;
+        this._dropdown.classList.remove('fn-open');
     }
 
     private async _navigateDir(dir: string): Promise<void> {
         this._currentDir = dir;
         if (!this._expanded) {
             this._expanded = true;
-            this._dropdown.hidden = false;
+            this._dropdown.classList.add('fn-open');
         }
         await this._loadDir(dir);
     }

--- a/plugin-core/chat-ui/src/components/FileNav.ts
+++ b/plugin-core/chat-ui/src/components/FileNav.ts
@@ -22,7 +22,7 @@ export class FileNav extends HTMLElement {
     private _currentDir = '';
     private _fetchDir!: FetchDirFn;
     private _openFile!: OpenFileFn;
-    private _cache = new Map<string, FileEntry[]>();
+    private readonly _cache = new Map<string, FileEntry[]>();
 
     connectedCallback(): void {
         this.innerHTML = `
@@ -65,8 +65,9 @@ export class FileNav extends HTMLElement {
         this._openFile = openFile;
     }
 
-    /** Update the breadcrumb to show a file path. */
+    /** Update the breadcrumb to show a file path. Closes any open dropdown. */
     showPath(filePath: string): void {
+        this._closeDropdown();
         this._currentDir = filePath.includes('/') ? filePath.substring(0, filePath.lastIndexOf('/')) : '';
         this._renderBreadcrumb(filePath);
     }
@@ -206,6 +207,6 @@ export class FileNav extends HTMLElement {
     }
 
     private _escHtml(s: string): string {
-        return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
     }
 }

--- a/plugin-core/chat-ui/src/components/FileViewer.ts
+++ b/plugin-core/chat-ui/src/components/FileViewer.ts
@@ -1,0 +1,164 @@
+/**
+ * `<file-viewer>` — Read-only file content viewer with line numbers,
+ * syntax highlighting, and Markdown rendering.
+ *
+ * PWA-only component: in JCEF, file links open directly in the IDE editor.
+ */
+
+import { highlight, detectLanguage } from '../syntaxHighlight';
+import { renderMarkdown } from '../renderMarkdown';
+
+export class FileViewer extends HTMLElement {
+    private _nav!: HTMLElement;
+    private _content!: HTMLElement;
+    private _emptyState!: HTMLElement;
+    private _pathDisplay!: HTMLElement;
+    private _currentPath = '';
+
+    /** Recently opened file paths (newest first). */
+    private _recent: string[] = [];
+    private _recentList!: HTMLElement;
+
+    connectedCallback(): void {
+        this.innerHTML = `
+            <div class="fv-container">
+                <div class="fv-nav-slot"></div>
+                <div class="fv-toolbar">
+                    <span class="fv-path"></span>
+                    <button class="fv-copy-btn" title="Copy path" hidden>📋</button>
+                </div>
+                <div class="fv-content-area">
+                    <div class="fv-empty">
+                        <div class="fv-empty-icon">📂</div>
+                        <div class="fv-empty-title">File Viewer</div>
+                        <div class="fv-empty-hint">Click a file link in the chat or browse files above</div>
+                        <div class="fv-recent-list"></div>
+                    </div>
+                    <div class="fv-content" hidden></div>
+                </div>
+            </div>`;
+
+        this._nav = this.querySelector('.fv-nav-slot') as HTMLElement;
+        this._content = this.querySelector('.fv-content') as HTMLElement;
+        this._emptyState = this.querySelector('.fv-empty') as HTMLElement;
+        this._pathDisplay = this.querySelector('.fv-path') as HTMLElement;
+        this._recentList = this.querySelector('.fv-recent-list') as HTMLElement;
+
+        const copyBtn = this.querySelector('.fv-copy-btn') as HTMLButtonElement;
+        copyBtn.addEventListener('click', () => {
+            navigator.clipboard.writeText(this._currentPath);
+            copyBtn.textContent = '✓';
+            setTimeout(() => { copyBtn.textContent = '📋'; }, 1500);
+        });
+    }
+
+    /** The slot where the `<file-nav>` should be inserted. */
+    get navSlot(): HTMLElement { return this._nav; }
+
+    get currentPath(): string { return this._currentPath; }
+
+    /** Display file content with syntax highlighting or Markdown rendering. */
+    showFile(path: string, content: string): void {
+        this._currentPath = path;
+        this._pathDisplay.textContent = path;
+        const copyBtn = this.querySelector('.fv-copy-btn') as HTMLElement;
+        copyBtn.hidden = false;
+
+        this._addToRecent(path);
+
+        const lang = detectLanguage(path);
+
+        if (lang === 'markdown') {
+            this._content.innerHTML = `<div class="fv-markdown">${renderMarkdown(content)}</div>`;
+        } else {
+            const lines = content.split('\n');
+            const highlighted = lang ? highlight(content, lang) : this._escHtml(content);
+            const highlightedLines = highlighted.split('\n');
+
+            const gutterHtml = lines.map((_, i) =>
+                `<span class="fv-ln">${i + 1}</span>`
+            ).join('\n');
+
+            const codeHtml = highlightedLines.join('\n');
+
+            this._content.innerHTML = `
+                <div class="fv-code-wrap">
+                    <pre class="fv-gutter">${gutterHtml}</pre>
+                    <pre class="fv-code"><code>${codeHtml}</code></pre>
+                </div>`;
+        }
+
+        this._emptyState.hidden = true;
+        this._content.hidden = false;
+        this._content.scrollTop = 0;
+    }
+
+    /** Scroll to a specific line number. */
+    scrollToLine(line: number): void {
+        const ln = this._content.querySelector(`.fv-ln:nth-child(${line})`);
+        if (ln) {
+            ln.scrollIntoView({ block: 'center', behavior: 'smooth' });
+            // Briefly highlight the target line
+            const idx = line - 1;
+            const codeLines = this._content.querySelectorAll('.fv-code code');
+            if (codeLines.length > 0) {
+                const codePre = this._content.querySelector('.fv-code') as HTMLElement;
+                if (codePre) {
+                    const lineHeight = parseFloat(getComputedStyle(codePre).lineHeight) || 18;
+                    const highlight = document.createElement('div');
+                    highlight.className = 'fv-line-highlight';
+                    highlight.style.top = `${idx * lineHeight}px`;
+                    highlight.style.height = `${lineHeight}px`;
+                    const wrap = this._content.querySelector('.fv-code-wrap');
+                    wrap?.appendChild(highlight);
+                    setTimeout(() => highlight.remove(), 2000);
+                }
+            }
+        }
+    }
+
+    /** Reset to empty state. */
+    clear(): void {
+        this._currentPath = '';
+        this._pathDisplay.textContent = '';
+        this._content.hidden = true;
+        this._emptyState.hidden = false;
+        (this.querySelector('.fv-copy-btn') as HTMLElement).hidden = true;
+    }
+
+    private _addToRecent(path: string): void {
+        this._recent = [path, ...this._recent.filter(p => p !== path)].slice(0, 10);
+        this._renderRecent();
+    }
+
+    private _renderRecent(): void {
+        if (this._recent.length === 0) {
+            this._recentList.innerHTML = '';
+            return;
+        }
+        this._recentList.innerHTML = `
+            <div class="fv-recent-title">Recent files</div>
+            ${this._recent.map(p => {
+                const name = p.includes('/') ? p.substring(p.lastIndexOf('/') + 1) : p;
+                return `<div class="fv-recent-item" data-path="${this._escAttr(p)}">
+                    <span class="fv-recent-name">${this._escHtml(name)}</span>
+                    <span class="fv-recent-path">${this._escHtml(p)}</span>
+                </div>`;
+            }).join('')}`;
+
+        this._recentList.querySelectorAll('.fv-recent-item').forEach(el => {
+            el.addEventListener('click', () => {
+                const path = (el as HTMLElement).dataset.path;
+                if (path) this.dispatchEvent(new CustomEvent('open-file', { detail: { path } }));
+            });
+        });
+    }
+
+    private _escHtml(s: string): string {
+        return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    private _escAttr(s: string): string {
+        return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+    }
+}

--- a/plugin-core/chat-ui/src/components/FileViewer.ts
+++ b/plugin-core/chat-ui/src/components/FileViewer.ts
@@ -1,0 +1,164 @@
+/**
+ * `<file-viewer>` — Read-only file content viewer with line numbers,
+ * syntax highlighting, and Markdown rendering.
+ *
+ * PWA-only component: in JCEF, file links open directly in the IDE editor.
+ */
+
+import { highlight, detectLanguage } from '../syntaxHighlight';
+import { renderMarkdown } from '../renderMarkdown';
+
+export class FileViewer extends HTMLElement {
+    private _nav!: HTMLElement;
+    private _content!: HTMLElement;
+    private _emptyState!: HTMLElement;
+    private _pathDisplay!: HTMLElement;
+    private _currentPath = '';
+
+    /** Recently opened file paths (newest first). */
+    private _recent: string[] = [];
+    private _recentList!: HTMLElement;
+
+    connectedCallback(): void {
+        this.innerHTML = `
+            <div class="fv-container">
+                <div class="fv-nav-slot"></div>
+                <div class="fv-toolbar">
+                    <span class="fv-path"></span>
+                    <button class="fv-copy-btn" title="Copy path" hidden>📋</button>
+                </div>
+                <div class="fv-content-area">
+                    <div class="fv-empty">
+                        <div class="fv-empty-icon">📂</div>
+                        <div class="fv-empty-title">File Viewer</div>
+                        <div class="fv-empty-hint">Click a file link in the chat or browse files above</div>
+                        <div class="fv-recent-list"></div>
+                    </div>
+                    <div class="fv-content" hidden></div>
+                </div>
+            </div>`;
+
+        this._nav = this.querySelector('.fv-nav-slot') as HTMLElement;
+        this._content = this.querySelector('.fv-content') as HTMLElement;
+        this._emptyState = this.querySelector('.fv-empty') as HTMLElement;
+        this._pathDisplay = this.querySelector('.fv-path') as HTMLElement;
+        this._recentList = this.querySelector('.fv-recent-list') as HTMLElement;
+
+        const copyBtn = this.querySelector('.fv-copy-btn') as HTMLButtonElement;
+        copyBtn.addEventListener('click', () => {
+            navigator.clipboard.writeText(this._currentPath);
+            copyBtn.textContent = '✓';
+            setTimeout(() => { copyBtn.textContent = '📋'; }, 1500);
+        });
+    }
+
+    /** The slot where the `<file-nav>` should be inserted. */
+    get navSlot(): HTMLElement { return this._nav; }
+
+    get currentPath(): string { return this._currentPath; }
+
+    /** Display file content with syntax highlighting or Markdown rendering. */
+    showFile(path: string, content: string): void {
+        this._currentPath = path;
+        this._pathDisplay.textContent = path;
+        const copyBtn = this.querySelector('.fv-copy-btn') as HTMLElement;
+        copyBtn.hidden = false;
+
+        this._addToRecent(path);
+
+        const lang = detectLanguage(path);
+
+        if (lang === 'markdown') {
+            this._content.innerHTML = `<div class="fv-markdown">${renderMarkdown(content)}</div>`;
+        } else {
+            const lines = content.split('\n');
+            const highlighted = lang ? highlight(content, lang) : this._escHtml(content);
+            const highlightedLines = highlighted.split('\n');
+
+            const gutterHtml = lines.map((_, i) =>
+                `<span class="fv-ln">${i + 1}</span>`
+            ).join('\n');
+
+            const codeHtml = highlightedLines.join('\n');
+
+            this._content.innerHTML = `
+                <div class="fv-code-wrap">
+                    <pre class="fv-gutter">${gutterHtml}</pre>
+                    <pre class="fv-code"><code>${codeHtml}</code></pre>
+                </div>`;
+        }
+
+        this._emptyState.hidden = true;
+        this._content.hidden = false;
+        this._content.scrollTop = 0;
+    }
+
+    /** Scroll to a specific line number. */
+    scrollToLine(line: number): void {
+        const ln = this._content.querySelector(`.fv-ln:nth-child(${line})`);
+        if (ln) {
+            ln.scrollIntoView({ block: 'center', behavior: 'smooth' });
+            // Briefly highlight the target line
+            const idx = line - 1;
+            const codeLines = this._content.querySelectorAll('.fv-code code');
+            if (codeLines.length > 0) {
+                const codePre = this._content.querySelector('.fv-code') as HTMLElement;
+                if (codePre) {
+                    const lineHeight = Number.parseFloat(getComputedStyle(codePre).lineHeight) || 18;
+                    const highlight = document.createElement('div');
+                    highlight.className = 'fv-line-highlight';
+                    highlight.style.top = `${idx * lineHeight}px`;
+                    highlight.style.height = `${lineHeight}px`;
+                    const wrap = this._content.querySelector('.fv-code-wrap');
+                    wrap?.appendChild(highlight);
+                    setTimeout(() => highlight.remove(), 2000);
+                }
+            }
+        }
+    }
+
+    /** Reset to empty state. */
+    clear(): void {
+        this._currentPath = '';
+        this._pathDisplay.textContent = '';
+        this._content.hidden = true;
+        this._emptyState.hidden = false;
+        (this.querySelector('.fv-copy-btn') as HTMLElement).hidden = true;
+    }
+
+    private _addToRecent(path: string): void {
+        this._recent = [path, ...this._recent.filter(p => p !== path)].slice(0, 10);
+        this._renderRecent();
+    }
+
+    private _renderRecent(): void {
+        if (this._recent.length === 0) {
+            this._recentList.innerHTML = '';
+            return;
+        }
+        this._recentList.innerHTML = `
+            <div class="fv-recent-title">Recent files</div>
+            ${this._recent.map(p => {
+                const name = p.includes('/') ? p.substring(p.lastIndexOf('/') + 1) : p;
+                return `<div class="fv-recent-item" data-path="${this._escAttr(p)}">
+                    <span class="fv-recent-name">${this._escHtml(name)}</span>
+                    <span class="fv-recent-path">${this._escHtml(p)}</span>
+                </div>`;
+            }).join('')}`;
+
+        this._recentList.querySelectorAll('.fv-recent-item').forEach(el => {
+            el.addEventListener('click', () => {
+                const path = (el as HTMLElement).dataset.path;
+                if (path) this.dispatchEvent(new CustomEvent('open-file', { detail: { path } }));
+            });
+        });
+    }
+
+    private _escHtml(s: string): string {
+        return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+    }
+
+    private _escAttr(s: string): string {
+        return s.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;');
+    }
+}

--- a/plugin-core/chat-ui/src/components/PaneSwiper.ts
+++ b/plugin-core/chat-ui/src/components/PaneSwiper.ts
@@ -1,0 +1,147 @@
+/**
+ * `<pane-swiper>` — Two-pane horizontal container with touch swipe
+ * and programmatic switching. The left pane holds the file viewer,
+ * the right pane holds the chat.
+ *
+ * Both panes are always mounted — switching is purely visual via
+ * CSS transform on the inner track.
+ */
+
+const SWIPE_THRESHOLD = 50;   // px minimum to trigger pane switch
+const VELOCITY_THRESHOLD = 0.3; // px/ms — fast flick overrides distance
+
+export class PaneSwiper extends HTMLElement {
+    private _track!: HTMLElement;
+    private _leftPane!: HTMLElement;
+    private _rightPane!: HTMLElement;
+    private _dots!: HTMLElement;
+
+    /** 0 = file viewer (left), 1 = chat (right) */
+    private _activeIndex = 1;
+
+    // Touch tracking
+    private _startX = 0;
+    private _startY = 0;
+    private _startTime = 0;
+    private _tracking = false;
+    private _horizontal = false;
+    private _currentOffset = 0;
+
+    connectedCallback(): void {
+        this.innerHTML = `
+            <div class="ps-track">
+                <div class="ps-pane ps-left"></div>
+                <div class="ps-pane ps-right"></div>
+            </div>
+            <div class="ps-dots">
+                <span class="ps-dot" data-index="0"></span>
+                <span class="ps-dot active" data-index="1"></span>
+            </div>`;
+        this._track = this.querySelector('.ps-track')!;
+        this._leftPane = this.querySelector('.ps-left')!;
+        this._rightPane = this.querySelector('.ps-right')!;
+        this._dots = this.querySelector('.ps-dots')!;
+
+        this._applyTransform(false);
+
+        // Touch events for swipe
+        this.addEventListener('touchstart', this._onTouchStart.bind(this), { passive: true });
+        this.addEventListener('touchmove', this._onTouchMove.bind(this), { passive: false });
+        this.addEventListener('touchend', this._onTouchEnd.bind(this), { passive: true });
+
+        // Dot click
+        this._dots.addEventListener('click', (e) => {
+            const dot = (e.target as HTMLElement).closest('.ps-dot') as HTMLElement | null;
+            if (dot?.dataset.index) this.switchTo(Number(dot.dataset.index));
+        });
+    }
+
+    get leftPane(): HTMLElement { return this._leftPane; }
+    get rightPane(): HTMLElement { return this._rightPane; }
+    get activeIndex(): number { return this._activeIndex; }
+
+    /** Switch to pane by index (0=left/files, 1=right/chat). */
+    switchTo(index: number): void {
+        if (index < 0 || index > 1) return;
+        this._activeIndex = index;
+        this._applyTransform(true);
+        this._updateDots();
+        this.dispatchEvent(new CustomEvent('pane-changed', { detail: { index } }));
+    }
+
+    private _applyTransform(animate: boolean): void {
+        this._track.style.transition = animate ? 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)' : 'none';
+        this._track.style.transform = `translateX(${-this._activeIndex * 50}%)`;
+    }
+
+    private _updateDots(): void {
+        this._dots.querySelectorAll('.ps-dot').forEach((dot, i) => {
+            dot.classList.toggle('active', i === this._activeIndex);
+        });
+    }
+
+    // ── Touch handling ──────────────────────────────────────────────────
+
+    private _onTouchStart(e: TouchEvent): void {
+        if (e.touches.length !== 1) return;
+        this._startX = e.touches[0].clientX;
+        this._startY = e.touches[0].clientY;
+        this._startTime = Date.now();
+        this._tracking = true;
+        this._horizontal = false;
+        this._currentOffset = 0;
+    }
+
+    private _onTouchMove(e: TouchEvent): void {
+        if (!this._tracking || e.touches.length !== 1) return;
+        const dx = e.touches[0].clientX - this._startX;
+        const dy = e.touches[0].clientY - this._startY;
+
+        // Lock direction after first significant movement
+        if (!this._horizontal && Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 10) {
+            this._tracking = false; // Vertical scroll — let it pass through
+            return;
+        }
+        if (Math.abs(dx) > 10) {
+            this._horizontal = true;
+        }
+        if (!this._horizontal) return;
+
+        e.preventDefault();
+
+        // Clamp: don't drag past the edges
+        const paneWidth = this.offsetWidth;
+        const baseOffset = -this._activeIndex * paneWidth;
+        let targetOffset = baseOffset + dx;
+        targetOffset = Math.max(targetOffset, -paneWidth); // don't go past right
+        targetOffset = Math.min(targetOffset, 0);           // don't go past left
+
+        const pct = (targetOffset / (paneWidth * 2)) * 100;
+        this._track.style.transition = 'none';
+        this._track.style.transform = `translateX(${pct}%)`;
+        this._currentOffset = dx;
+    }
+
+    private _onTouchEnd(): void {
+        if (!this._tracking || !this._horizontal) {
+            this._tracking = false;
+            return;
+        }
+        this._tracking = false;
+
+        const elapsed = Date.now() - this._startTime;
+        const velocity = Math.abs(this._currentOffset) / Math.max(elapsed, 1);
+        const dx = this._currentOffset;
+
+        if (dx > SWIPE_THRESHOLD || (dx > 20 && velocity > VELOCITY_THRESHOLD)) {
+            // Swiped right → show left pane (files)
+            if (this._activeIndex > 0) this._activeIndex--;
+        } else if (dx < -SWIPE_THRESHOLD || (dx < -20 && velocity > VELOCITY_THRESHOLD)) {
+            // Swiped left → show right pane (chat)
+            if (this._activeIndex < 1) this._activeIndex++;
+        }
+        this._applyTransform(true);
+        this._updateDots();
+        this.dispatchEvent(new CustomEvent('pane-changed', { detail: { index: this._activeIndex } }));
+    }
+}

--- a/plugin-core/chat-ui/src/components/PaneSwiper.ts
+++ b/plugin-core/chat-ui/src/components/PaneSwiper.ts
@@ -1,0 +1,279 @@
+/**
+ * `<pane-swiper>` — N-pane horizontal container with touch swipe,
+ * tab bar navigation, dot indicators, and programmatic switching.
+ *
+ * All panes are always mounted — switching is purely visual via
+ * CSS transform on the inner track.
+ *
+ * Backward-compatible: `leftPane` and `rightPane` getters alias panes[0] and panes[1].
+ */
+
+const SWIPE_THRESHOLD = 50;   // px minimum to trigger pane switch
+const VELOCITY_THRESHOLD = 0.3; // px/ms — fast flick overrides distance
+
+export class PaneSwiper extends HTMLElement {
+    private _track!: HTMLElement;
+    private _dots!: HTMLElement;
+    private _tabBar!: HTMLElement;
+    private _panes: HTMLElement[] = [];
+    private _tabLabels: string[] = [];
+
+    /** Currently visible pane index */
+    private _activeIndex = 1;
+
+    // Touch tracking
+    private _startX = 0;
+    private _startY = 0;
+    private _startTime = 0;
+    private _tracking = false;
+    private _horizontal = false;
+    private _currentOffset = 0;
+    private _scrollerEl: HTMLElement | null = null;
+
+    connectedCallback(): void {
+        this.innerHTML = `
+            <div class="ps-tab-bar"></div>
+            <div class="ps-track"></div>
+            <div class="ps-dots"></div>`;
+        this._tabBar = this.querySelector('.ps-tab-bar') as HTMLElement;
+        this._track = this.querySelector('.ps-track') as HTMLElement;
+        this._dots = this.querySelector('.ps-dots') as HTMLElement;
+
+        // Create the two default panes for backward compatibility
+        this._addPaneInternal('ps-left');
+        this._addPaneInternal('ps-right');
+
+        this._updateTrackWidth();
+        this._applyTransform(false);
+        this._rebuildDots();
+        this._rebuildTabs();
+
+        // Touch events for swipe
+        this.addEventListener('touchstart', this._onTouchStart.bind(this), {passive: true});
+        this.addEventListener('touchmove', this._onTouchMove.bind(this), {passive: false});
+        this.addEventListener('touchend', this._onTouchEnd.bind(this), {passive: true});
+
+        // Dot click
+        this._dots.addEventListener('click', (e) => {
+            const dot = (e.target as HTMLElement).closest('.ps-dot') as HTMLElement | null;
+            if (dot?.dataset.index != null) this.switchTo(Number(dot.dataset.index));
+        });
+
+        // Tab click
+        this._tabBar.addEventListener('click', (e) => {
+            const tab = (e.target as HTMLElement).closest('.ps-tab') as HTMLElement | null;
+            if (tab?.dataset.index != null) this.switchTo(Number(tab.dataset.index));
+        });
+    }
+
+    // ── Public API ──────────────────────────────────────────────────────
+
+    /** Backward-compat alias for panes[0] */
+    get leftPane(): HTMLElement {
+        return this._panes[0];
+    }
+
+    /** Backward-compat alias for panes[1] */
+    get rightPane(): HTMLElement {
+        return this._panes[1];
+    }
+
+    /** All pane elements in order */
+    get panes(): readonly HTMLElement[] {
+        return this._panes;
+    }
+
+    get paneCount(): number {
+        return this._panes.length;
+    }
+
+    get activeIndex(): number {
+        return this._activeIndex;
+    }
+
+    /**
+     * Add a new pane and return its container div.
+     * The pane is appended to the end of the track.
+     */
+    addPane(label?: string): HTMLElement {
+        const pane = this._addPaneInternal();
+        if (label) this._tabLabels[this._panes.length - 1] = label;
+        this._updateTrackWidth();
+        this._rebuildDots();
+        this._rebuildTabs();
+        return pane;
+    }
+
+    /**
+     * Set the tab label for a pane at the given index.
+     */
+    setTabLabel(index: number, label: string): void {
+        if (index < 0 || index >= this._panes.length) return;
+        this._tabLabels[index] = label;
+        this._rebuildTabs();
+    }
+
+    /** Switch to pane by index. */
+    switchTo(index: number): void {
+        if (index < 0 || index >= this._panes.length) return;
+        this._activeIndex = index;
+        this._applyTransform(true);
+        this._updateDots();
+        this._updateTabs();
+        this.dispatchEvent(new CustomEvent('pane-changed', {detail: {index}}));
+    }
+
+    // ── Internal helpers ────────────────────────────────────────────────
+
+    private _addPaneInternal(extraClass?: string): HTMLElement {
+        const pane = document.createElement('div');
+        pane.className = 'ps-pane' + (extraClass ? ` ${extraClass}` : '');
+        this._track.appendChild(pane);
+        this._panes.push(pane);
+        this._tabLabels.push('');
+        return pane;
+    }
+
+    private _updateTrackWidth(): void {
+        // Track width = N * 100% of the container
+        this._track.style.width = `${this._panes.length * 100}%`;
+        // Each pane takes 1/N of the track
+        this._panes.forEach(p => {
+            p.style.width = `${100 / this._panes.length}%`;
+        });
+    }
+
+    private _applyTransform(animate: boolean): void {
+        this._track.style.transition = animate ? 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)' : 'none';
+        // Each pane is (100/N)% of the track, so offset = index * (100/N)%
+        const pct = -this._activeIndex * (100 / this._panes.length);
+        this._track.style.transform = `translateX(${pct}%)`;
+    }
+
+    private _rebuildDots(): void {
+        this._dots.innerHTML = this._panes
+            .map((_, i) => `<span class="ps-dot${i === this._activeIndex ? ' active' : ''}" data-index="${i}"></span>`)
+            .join('');
+    }
+
+    private _updateDots(): void {
+        this._dots.querySelectorAll('.ps-dot').forEach((dot, i) => {
+            dot.classList.toggle('active', i === this._activeIndex);
+        });
+    }
+
+    private _rebuildTabs(): void {
+        this._tabBar.innerHTML = this._panes
+            .map((_, i) => {
+                const label = this._tabLabels[i] || `Pane ${i + 1}`;
+                const active = i === this._activeIndex ? ' active' : '';
+                return `<button class="ps-tab${active}" data-index="${i}">${label}</button>`;
+            })
+            .join('');
+    }
+
+    private _updateTabs(): void {
+        this._tabBar.querySelectorAll('.ps-tab').forEach((tab, i) => {
+            tab.classList.toggle('active', i === this._activeIndex);
+        });
+    }
+
+    // ── Touch handling ──────────────────────────────────────────────────
+
+    private _onTouchStart(e: TouchEvent): void {
+        if (e.touches.length !== 1) return;
+        this._startX = e.touches[0].clientX;
+        this._startY = e.touches[0].clientY;
+        this._startTime = Date.now();
+        this._tracking = true;
+        this._horizontal = false;
+        this._currentOffset = 0;
+        this._scrollerEl = this._findHorizontalScroller(e.target as HTMLElement | null);
+    }
+
+    private _onTouchMove(e: TouchEvent): void {
+        if (!this._tracking || e.touches.length !== 1) return;
+        const dx = e.touches[0].clientX - this._startX;
+        const dy = e.touches[0].clientY - this._startY;
+
+        // Lock direction after first significant movement
+        if (!this._horizontal && Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 10) {
+            this._tracking = false; // Vertical scroll — let it pass through
+            return;
+        }
+        if (Math.abs(dx) > 10) {
+            this._horizontal = true;
+        }
+        if (!this._horizontal) return;
+
+        // Inside a horizontally scrollable element — defer to native scroll
+        // unless already scrolled all the way in the swipe direction
+        if (this._scrollerEl) {
+            const el = this._scrollerEl;
+            const atLeftEdge = el.scrollLeft <= 0;
+            const atRightEdge = el.scrollLeft + el.clientWidth >= el.scrollWidth - 1;
+
+            if (dx > 0 && !atLeftEdge) {
+                this._tracking = false;
+                return;
+            }
+            if (dx < 0 && !atRightEdge) {
+                this._tracking = false;
+                return;
+            }
+            this._scrollerEl = null;
+        }
+
+        e.preventDefault();
+
+        // Clamp: don't drag past the first or last pane
+        const paneWidth = this.offsetWidth;
+        const maxIndex = this._panes.length - 1;
+        const baseOffset = -this._activeIndex * paneWidth;
+        let targetOffset = baseOffset + dx;
+        targetOffset = Math.max(targetOffset, -maxIndex * paneWidth); // don't go past last pane
+        targetOffset = Math.min(targetOffset, 0);                     // don't go past first pane
+
+        // Convert pixel offset to percentage of track width
+        const trackWidth = paneWidth * this._panes.length;
+        const pct = (targetOffset / trackWidth) * 100;
+        this._track.style.transition = 'none';
+        this._track.style.transform = `translateX(${pct}%)`;
+        this._currentOffset = dx;
+    }
+
+    private _onTouchEnd(): void {
+        if (!this._tracking || !this._horizontal) {
+            this._tracking = false;
+            return;
+        }
+        this._tracking = false;
+
+        const elapsed = Date.now() - this._startTime;
+        const velocity = Math.abs(this._currentOffset) / Math.max(elapsed, 1);
+        const dx = this._currentOffset;
+        const maxIndex = this._panes.length - 1;
+
+        if (dx > SWIPE_THRESHOLD || (dx > 20 && velocity > VELOCITY_THRESHOLD)) {
+            // Swiped right → go to previous pane
+            if (this._activeIndex > 0) this._activeIndex--;
+        } else if (dx < -SWIPE_THRESHOLD || (dx < -20 && velocity > VELOCITY_THRESHOLD)) {
+            // Swiped left → go to next pane
+            if (this._activeIndex < maxIndex) this._activeIndex++;
+        }
+        this._applyTransform(true);
+        this._updateDots();
+        this._updateTabs();
+        this.dispatchEvent(new CustomEvent('pane-changed', {detail: {index: this._activeIndex}}));
+    }
+
+    /** Find the nearest ancestor with horizontal overflow, or null. */
+    private _findHorizontalScroller(target: HTMLElement | null): HTMLElement | null {
+        let el = target;
+        while (el && el !== this) {
+            if (el.scrollWidth > el.clientWidth + 1) return el;
+            el = el.parentElement;
+        }
+        return null;
+    }
+}

--- a/plugin-core/chat-ui/src/components/PaneSwiper.ts
+++ b/plugin-core/chat-ui/src/components/PaneSwiper.ts
@@ -26,6 +26,7 @@ export class PaneSwiper extends HTMLElement {
     private _tracking = false;
     private _horizontal = false;
     private _currentOffset = 0;
+    private _startedInScroller = false;
 
     connectedCallback(): void {
         this.innerHTML = `
@@ -90,6 +91,7 @@ export class PaneSwiper extends HTMLElement {
         this._tracking = true;
         this._horizontal = false;
         this._currentOffset = 0;
+        this._startedInScroller = this._hasHorizontalScroll(e.target as HTMLElement | null);
     }
 
     private _onTouchMove(e: TouchEvent): void {
@@ -106,6 +108,12 @@ export class PaneSwiper extends HTMLElement {
             this._horizontal = true;
         }
         if (!this._horizontal) return;
+
+        // Let native horizontal scroll handle the gesture inside scrollable elements
+        if (this._startedInScroller) {
+            this._tracking = false;
+            return;
+        }
 
         e.preventDefault();
 
@@ -143,5 +151,15 @@ export class PaneSwiper extends HTMLElement {
         this._applyTransform(true);
         this._updateDots();
         this.dispatchEvent(new CustomEvent('pane-changed', { detail: { index: this._activeIndex } }));
+    }
+
+    /** Check if any ancestor of the target has horizontal overflow. */
+    private _hasHorizontalScroll(target: HTMLElement | null): boolean {
+        let el = target;
+        while (el && el !== this) {
+            if (el.scrollWidth > el.clientWidth + 1) return true;
+            el = el.parentElement;
+        }
+        return false;
     }
 }

--- a/plugin-core/chat-ui/src/components/PaneSwiper.ts
+++ b/plugin-core/chat-ui/src/components/PaneSwiper.ts
@@ -26,7 +26,7 @@ export class PaneSwiper extends HTMLElement {
     private _tracking = false;
     private _horizontal = false;
     private _currentOffset = 0;
-    private _startedInScroller = false;
+    private _scrollerEl: HTMLElement | null = null;
 
     connectedCallback(): void {
         this.innerHTML = `
@@ -38,17 +38,17 @@ export class PaneSwiper extends HTMLElement {
                 <span class="ps-dot" data-index="0"></span>
                 <span class="ps-dot active" data-index="1"></span>
             </div>`;
-        this._track = this.querySelector('.ps-track')!;
-        this._leftPane = this.querySelector('.ps-left')!;
-        this._rightPane = this.querySelector('.ps-right')!;
-        this._dots = this.querySelector('.ps-dots')!;
+        this._track = this.querySelector('.ps-track') as HTMLElement;
+        this._leftPane = this.querySelector('.ps-left') as HTMLElement;
+        this._rightPane = this.querySelector('.ps-right') as HTMLElement;
+        this._dots = this.querySelector('.ps-dots') as HTMLElement;
 
         this._applyTransform(false);
 
         // Touch events for swipe
-        this.addEventListener('touchstart', this._onTouchStart.bind(this), { passive: true });
-        this.addEventListener('touchmove', this._onTouchMove.bind(this), { passive: false });
-        this.addEventListener('touchend', this._onTouchEnd.bind(this), { passive: true });
+        this.addEventListener('touchstart', this._onTouchStart.bind(this), {passive: true});
+        this.addEventListener('touchmove', this._onTouchMove.bind(this), {passive: false});
+        this.addEventListener('touchend', this._onTouchEnd.bind(this), {passive: true});
 
         // Dot click
         this._dots.addEventListener('click', (e) => {
@@ -57,9 +57,17 @@ export class PaneSwiper extends HTMLElement {
         });
     }
 
-    get leftPane(): HTMLElement { return this._leftPane; }
-    get rightPane(): HTMLElement { return this._rightPane; }
-    get activeIndex(): number { return this._activeIndex; }
+    get leftPane(): HTMLElement {
+        return this._leftPane;
+    }
+
+    get rightPane(): HTMLElement {
+        return this._rightPane;
+    }
+
+    get activeIndex(): number {
+        return this._activeIndex;
+    }
 
     /** Switch to pane by index (0=left/files, 1=right/chat). */
     switchTo(index: number): void {
@@ -67,7 +75,7 @@ export class PaneSwiper extends HTMLElement {
         this._activeIndex = index;
         this._applyTransform(true);
         this._updateDots();
-        this.dispatchEvent(new CustomEvent('pane-changed', { detail: { index } }));
+        this.dispatchEvent(new CustomEvent('pane-changed', {detail: {index}}));
     }
 
     private _applyTransform(animate: boolean): void {
@@ -91,7 +99,7 @@ export class PaneSwiper extends HTMLElement {
         this._tracking = true;
         this._horizontal = false;
         this._currentOffset = 0;
-        this._startedInScroller = this._hasHorizontalScroll(e.target as HTMLElement | null);
+        this._scrollerEl = this._findHorizontalScroller(e.target as HTMLElement | null);
     }
 
     private _onTouchMove(e: TouchEvent): void {
@@ -109,10 +117,25 @@ export class PaneSwiper extends HTMLElement {
         }
         if (!this._horizontal) return;
 
-        // Let native horizontal scroll handle the gesture inside scrollable elements
-        if (this._startedInScroller) {
-            this._tracking = false;
-            return;
+        // Inside a horizontally scrollable element — defer to native scroll
+        // unless already scrolled all the way in the swipe direction
+        if (this._scrollerEl) {
+            const el = this._scrollerEl;
+            const atLeftEdge = el.scrollLeft <= 0;
+            const atRightEdge = el.scrollLeft + el.clientWidth >= el.scrollWidth - 1;
+
+            if (dx > 0 && !atLeftEdge) {
+                // Swiping right but scroller can still scroll left → native scroll
+                this._tracking = false;
+                return;
+            }
+            if (dx < 0 && !atRightEdge) {
+                // Swiping left but scroller can still scroll right → native scroll
+                this._tracking = false;
+                return;
+            }
+            // At boundary in swipe direction — take over as pane swipe
+            this._scrollerEl = null;
         }
 
         e.preventDefault();
@@ -150,16 +173,16 @@ export class PaneSwiper extends HTMLElement {
         }
         this._applyTransform(true);
         this._updateDots();
-        this.dispatchEvent(new CustomEvent('pane-changed', { detail: { index: this._activeIndex } }));
+        this.dispatchEvent(new CustomEvent('pane-changed', {detail: {index: this._activeIndex}}));
     }
 
-    /** Check if any ancestor of the target has horizontal overflow. */
-    private _hasHorizontalScroll(target: HTMLElement | null): boolean {
+    /** Find the nearest ancestor with horizontal overflow, or null. */
+    private _findHorizontalScroller(target: HTMLElement | null): HTMLElement | null {
         let el = target;
         while (el && el !== this) {
-            if (el.scrollWidth > el.clientWidth + 1) return true;
+            if (el.scrollWidth > el.clientWidth + 1) return el;
             el = el.parentElement;
         }
-        return false;
+        return null;
     }
 }

--- a/plugin-core/chat-ui/src/components/ReviewView.ts
+++ b/plugin-core/chat-ui/src/components/ReviewView.ts
@@ -1,0 +1,63 @@
+export class ReviewView extends HTMLElement {
+    private _list!: HTMLElement;
+    private _empty!: HTMLElement;
+    private _pollTimer: number | null = null;
+
+    connectedCallback(): void {
+        this.innerHTML = `
+            <div class="rv-container">
+                <div class="rv-empty">No agent edits to review</div>
+                <div class="rv-list"></div>
+            </div>`;
+        this._list = this.querySelector('.rv-list')!;
+        this._empty = this.querySelector('.rv-empty')!;
+        this.refresh();
+        this._pollTimer = window.setInterval(() => this.refresh(), 3000);
+    }
+
+    disconnectedCallback(): void {
+        if (this._pollTimer) clearInterval(this._pollTimer);
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const resp = await fetch('/review-items');
+            if (!resp.ok) return;
+            const data = await resp.json() as { items: Array<{ path: string; status: string; approved: boolean; linesAdded: number; linesRemoved: number }> };
+            this._render(data.items);
+        } catch (e) {
+            // Silently ignore fetch errors (server may be restarting)
+        }
+    }
+
+    private _render(items: Array<{ path: string; status: string; approved: boolean; linesAdded: number; linesRemoved: number }>): void {
+        if (items.length === 0) {
+            this._empty.style.display = '';
+            this._list.style.display = 'none';
+            return;
+        }
+        this._empty.style.display = 'none';
+        this._list.style.display = '';
+
+        this._list.innerHTML = items.map(item => {
+            const statusClass = item.status === 'ADDED' ? 'rv-added' : item.status === 'DELETED' ? 'rv-deleted' : 'rv-modified';
+            const statusIcon = item.status === 'ADDED' ? '+' : item.status === 'DELETED' ? '−' : '~';
+            const approvedClass = item.approved ? 'rv-approved' : '';
+            const fileName = item.path.split('/').pop() || item.path;
+            const dir = item.path.substring(0, item.path.length - fileName.length);
+            return `<div class="rv-item ${statusClass} ${approvedClass}">
+                <span class="rv-status">${statusIcon}</span>
+                <span class="rv-path"><span class="rv-dir">${this._esc(dir)}</span>${this._esc(fileName)}</span>
+                <span class="rv-diff">
+                    ${item.linesAdded > 0 ? `<span class="rv-add">+${item.linesAdded}</span>` : ''}
+                    ${item.linesRemoved > 0 ? `<span class="rv-rem">-${item.linesRemoved}</span>` : ''}
+                </span>
+                ${item.approved ? '<span class="rv-check">✓</span>' : ''}
+            </div>`;
+        }).join('');
+    }
+
+    private _esc(s: string): string {
+        return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+    }
+}

--- a/plugin-core/chat-ui/src/components/SearchView.ts
+++ b/plugin-core/chat-ui/src/components/SearchView.ts
@@ -1,0 +1,84 @@
+type PromptItem = {
+    id: string;
+    text: string;
+    timestamp: string;
+};
+
+export class SearchView extends HTMLElement {
+    private _input!: HTMLInputElement;
+    private _list!: HTMLElement;
+    private _empty!: HTMLElement;
+    private _items: PromptItem[] = [];
+    private _pollTimer: number | null = null;
+
+    connectedCallback(): void {
+        this.innerHTML = `
+            <div class="pv-container">
+                <input class="pv-search" type="search" placeholder="Search prompts…" aria-label="Search prompts">
+                <div class="pv-empty">No prompts yet</div>
+                <div class="pv-list"></div>
+            </div>`;
+        this._input = this.querySelector<HTMLInputElement>('.pv-search')!;
+        this._list = this.querySelector<HTMLElement>('.pv-list')!;
+        this._empty = this.querySelector<HTMLElement>('.pv-empty')!;
+        this._input.addEventListener('input', () => this._render());
+        this._list.addEventListener('click', (event) => {
+            const row = (event.target as HTMLElement).closest<HTMLElement>('.pv-item');
+            const id = row?.dataset.id;
+            if (!id) return;
+            document.getElementById(id)?.scrollIntoView({block: 'center', behavior: 'smooth'});
+        });
+        void this.refresh();
+        this._pollTimer = globalThis.setInterval(() => void this.refresh(), 3000);
+    }
+
+    disconnectedCallback(): void {
+        if (this._pollTimer) clearInterval(this._pollTimer);
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const resp = await fetch('/prompts');
+            if (!resp.ok) {
+                console.error(`[AB] Prompt fetch failed: HTTP ${resp.status}`);
+                return;
+            }
+            const data = await resp.json() as { items: PromptItem[] };
+            this._items = data.items;
+            this._render();
+        } catch (error) {
+            console.error('[AB] Failed to refresh prompts:', error);
+        }
+    }
+
+    private _render(): void {
+        const query = this._input.value.trim().toLowerCase();
+        const filtered = query
+            ? this._items.filter(item => item.text.toLowerCase().includes(query))
+            : this._items;
+        const visible = filtered.slice(-100).reverse();
+        if (visible.length === 0) {
+            this._empty.style.display = '';
+            this._list.style.display = 'none';
+            return;
+        }
+        this._empty.style.display = 'none';
+        this._list.style.display = '';
+        this._list.innerHTML = visible.map(item => `
+            <button class="pv-item" data-id="${this._esc(item.id)}" type="button">
+                <span class="pv-time">${this._esc(this._formatTime(item.timestamp))}</span>
+                <span class="pv-text">${this._esc(item.text)}</span>
+            </button>`).join('');
+    }
+
+    private _formatTime(timestamp: string): string {
+        if (!timestamp) return '';
+        const date = new Date(timestamp);
+        if (Number.isNaN(date.getTime())) return timestamp;
+        return date.toLocaleString([], {month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'});
+    }
+
+    private _esc(s: string): string {
+        return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
+    }
+}

--- a/plugin-core/chat-ui/src/components/SessionView.ts
+++ b/plugin-core/chat-ui/src/components/SessionView.ts
@@ -1,0 +1,44 @@
+export class SessionView extends HTMLElement {
+    private _content!: HTMLElement;
+    private _pollTimer: number | null = null;
+
+    connectedCallback(): void {
+        this.innerHTML = `<div class="sv-container"><div class="sv-content"></div></div>`;
+        this._content = this.querySelector('.sv-content')!;
+        this.refresh();
+        this._pollTimer = window.setInterval(() => this.refresh(), 2000);
+    }
+
+    disconnectedCallback(): void {
+        if (this._pollTimer) clearInterval(this._pollTimer);
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const resp = await fetch('/session-stats');
+            if (!resp.ok) return;
+            const data = await resp.json() as { isRunning: boolean; model: string; connected: boolean };
+            this._render(data);
+        } catch (e) {
+            this._content.innerHTML = '<div class="sv-row sv-offline">IDE disconnected</div>';
+        }
+    }
+
+    private _render(data: { isRunning: boolean; model: string; connected: boolean }): void {
+        const statusClass = data.isRunning ? 'sv-running' : data.connected ? 'sv-idle' : 'sv-offline';
+        const statusText = data.isRunning ? 'Agent running' : data.connected ? 'Connected' : 'Disconnected';
+        const dot = data.isRunning ? '🟢' : data.connected ? '🔵' : '🔴';
+
+        this._content.innerHTML = `
+            <div class="sv-row ${statusClass}">
+                <span class="sv-dot">${dot}</span>
+                <span class="sv-label">${this._esc(statusText)}</span>
+            </div>
+            ${data.model ? `<div class="sv-row"><span class="sv-key">Model</span><span class="sv-val">${this._esc(data.model)}</span></div>` : ''}
+        `;
+    }
+
+    private _esc(s: string): string {
+        return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+    }
+}

--- a/plugin-core/chat-ui/src/components/TodoView.ts
+++ b/plugin-core/chat-ui/src/components/TodoView.ts
@@ -1,19 +1,40 @@
+type TodoItem = {
+    id: string;
+    title: string;
+    description: string | null;
+    status: string;
+    updatedAt: string | null;
+};
+
 export class TodoView extends HTMLElement {
-    private _content!: HTMLElement;
-    private _empty!: HTMLElement;
+    private _planContent!: HTMLElement;
+    private _planEmpty!: HTMLElement;
+    private _dbContent!: HTMLElement;
+    private _dbEmpty!: HTMLElement;
     private _pollTimer: number | null = null;
-    private _lastContent: string | null = null;
+    private _lastPlanContent: string | null = null;
+    private _lastTodoJson = '';
 
     connectedCallback(): void {
         this.innerHTML = `
             <div class="tv-container">
-                <div class="tv-empty">No plan file yet. The agent creates plan.md during complex tasks.</div>
-                <div class="tv-content"></div>
+                <section class="tv-section">
+                    <h2>Plan</h2>
+                    <div class="tv-empty tv-plan-empty">No plan file yet. The agent creates plan.md during complex tasks.</div>
+                    <div class="tv-content tv-plan-content"></div>
+                </section>
+                <section class="tv-section">
+                    <h2>Todo Database</h2>
+                    <div class="tv-empty tv-db-empty">No structured todo database for this session.</div>
+                    <div class="tv-db-content"></div>
+                </section>
             </div>`;
-        this._content = this.querySelector('.tv-content')!;
-        this._empty = this.querySelector('.tv-empty')!;
-        this.refresh();
-        this._pollTimer = window.setInterval(() => this.refresh(), 2000);
+        this._planContent = this.querySelector<HTMLElement>('.tv-plan-content')!;
+        this._planEmpty = this.querySelector<HTMLElement>('.tv-plan-empty')!;
+        this._dbContent = this.querySelector<HTMLElement>('.tv-db-content')!;
+        this._dbEmpty = this.querySelector<HTMLElement>('.tv-db-empty')!;
+        void this.refresh();
+        this._pollTimer = globalThis.setInterval(() => void this.refresh(), 2000);
     }
 
     disconnectedCallback(): void {
@@ -21,98 +42,142 @@ export class TodoView extends HTMLElement {
     }
 
     async refresh(): Promise<void> {
+        await Promise.all([this._refreshPlan(), this._refreshTodos()]);
+    }
+
+    private async _refreshPlan(): Promise<void> {
         try {
             const resp = await fetch('/plan');
-            if (!resp.ok) return;
-            const data = await resp.json() as { content: string | null };
-            if (data.content === this._lastContent) return;
-            this._lastContent = data.content;
-
-            if (!data.content) {
-                this._empty.style.display = '';
-                this._content.style.display = 'none';
+            if (!resp.ok) {
+                console.error(`[AB] Plan fetch failed: HTTP ${resp.status}`);
                 return;
             }
-            this._empty.style.display = 'none';
-            this._content.style.display = '';
-            this._content.innerHTML = this._renderMarkdown(data.content);
-        } catch (e) {
-            // Silently ignore
+            const data = await resp.json() as { content: string | null };
+            if (data.content === this._lastPlanContent) return;
+            this._lastPlanContent = data.content;
+
+            if (!data.content) {
+                this._planEmpty.style.display = '';
+                this._planContent.style.display = 'none';
+                return;
+            }
+            this._planEmpty.style.display = 'none';
+            this._planContent.style.display = '';
+            this._planContent.innerHTML = this._renderMarkdown(data.content);
+        } catch (error) {
+            console.error('[AB] Plan refresh failed:', error);
+        }
+    }
+
+    private async _refreshTodos(): Promise<void> {
+        try {
+            const resp = await fetch('/todos');
+            if (!resp.ok) {
+                console.error(`[AB] Todo fetch failed: HTTP ${resp.status}`);
+                return;
+            }
+            const data = await resp.json() as { items: TodoItem[] };
+            const json = JSON.stringify(data.items);
+            if (json === this._lastTodoJson) return;
+            this._lastTodoJson = json;
+            this._renderTodos(data.items);
+        } catch (error) {
+            console.error('[AB] Todo refresh failed:', error);
+        }
+    }
+
+    private _renderTodos(items: TodoItem[]): void {
+        if (items.length === 0) {
+            this._dbEmpty.style.display = '';
+            this._dbContent.style.display = 'none';
+            return;
+        }
+        this._dbEmpty.style.display = 'none';
+        this._dbContent.style.display = '';
+        const done = items.filter(item => item.status === 'done').length;
+        this._dbContent.innerHTML = `
+            <div class="tv-db-summary">${done} / ${items.length} completed</div>
+            ${items.map(item => this._renderTodoItem(item)).join('')}`;
+    }
+
+    private _renderTodoItem(item: TodoItem): string {
+        const status = item.status || 'pending';
+        const cls = status.replaceAll(/[^a-z0-9_-]/g, '-');
+        const description = item.description ? `<div class="tv-db-desc">${this._esc(item.description)}</div>` : '';
+        return `<div class="tv-db-item ${cls}">
+            <span class="tv-db-status">${this._statusIcon(status)}</span>
+            <span class="tv-db-main">
+                <span class="tv-db-title">${this._esc(item.title)}</span>
+                ${description}
+            </span>
+            <span class="tv-db-id">${this._esc(item.id)}</span>
+        </div>`;
+    }
+
+    private _statusIcon(status: string): string {
+        switch (status) {
+            case 'in_progress':
+                return '▶';
+            case 'done':
+                return '✓';
+            case 'blocked':
+                return '✖';
+            default:
+                return '○';
         }
     }
 
     private _renderMarkdown(md: string): string {
-        // Simple markdown rendering: headings, checkboxes, code blocks, bold, italic, links
-        const lines = md.split('\n');
         const out: string[] = [];
         let inCodeBlock = false;
 
-        for (const line of lines) {
+        for (const line of md.split('\n')) {
             if (line.startsWith('```')) {
-                if (inCodeBlock) {
-                    out.push('</code></pre>');
-                    inCodeBlock = false;
-                } else {
-                    out.push('<pre><code>');
-                    inCodeBlock = true;
-                }
-                continue;
-            }
-            if (inCodeBlock) {
+                out.push(inCodeBlock ? '</code></pre>' : '<pre><code>');
+                inCodeBlock = !inCodeBlock;
+            } else if (inCodeBlock) {
                 out.push(this._esc(line) + '\n');
-                continue;
+            } else {
+                out.push(this._renderMarkdownLine(line));
             }
-
-            // Headings
-            const headingMatch = line.match(/^(#{1,6})\s+(.*)/);
-            if (headingMatch) {
-                const level = headingMatch[1].length;
-                out.push(`<h${level}>${this._inline(headingMatch[2])}</h${level}>`);
-                continue;
-            }
-
-            // Checkboxes
-            const checkMatch = line.match(/^(\s*[-*])\s+\[([ xX])]\s+(.*)/);
-            if (checkMatch) {
-                const checked = checkMatch[2] !== ' ';
-                const cls = checked ? 'tv-done' : 'tv-pending';
-                out.push(`<div class="tv-check ${cls}">${checked ? '☑' : '☐'} ${this._inline(checkMatch[3])}</div>`);
-                continue;
-            }
-
-            // List items
-            const listMatch = line.match(/^(\s*[-*])\s+(.*)/);
-            if (listMatch) {
-                out.push(`<div class="tv-li">• ${this._inline(listMatch[2])}</div>`);
-                continue;
-            }
-
-            // Empty lines
-            if (line.trim() === '') {
-                out.push('<br>');
-                continue;
-            }
-
-            // Regular paragraph
-            out.push(`<p>${this._inline(line)}</p>`);
         }
 
         if (inCodeBlock) out.push('</code></pre>');
         return out.join('\n');
     }
 
+    private _renderMarkdownLine(line: string): string {
+        const headingMatch = /^(#{1,6})\s+(.*)/.exec(line);
+        if (headingMatch) {
+            const level = headingMatch[1].length;
+            return `<h${level}>${this._inline(headingMatch[2])}</h${level}>`;
+        }
+
+        const checkMatch = /^(\s*[-*])\s+\[([ xX])]\s+(.*)/.exec(line);
+        if (checkMatch) {
+            const checked = checkMatch[2] !== ' ';
+            const cls = checked ? 'tv-done' : 'tv-pending';
+            return `<div class="tv-check ${cls}">${checked ? '☑' : '☐'} ${this._inline(checkMatch[3])}</div>`;
+        }
+
+        const listMatch = /^(\s*[-*])\s+(.*)/.exec(line);
+        if (listMatch) {
+            return `<div class="tv-li">• ${this._inline(listMatch[2])}</div>`;
+        }
+
+        if (line.trim() === '') return '<br>';
+        return `<p>${this._inline(line)}</p>`;
+    }
+
     private _inline(text: string): string {
         let s = this._esc(text);
-        // Bold
         s = s.replaceAll(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-        // Italic
         s = s.replaceAll(/\*(.+?)\*/g, '<em>$1</em>');
-        // Inline code
         s = s.replaceAll(/`(.+?)`/g, '<code>$1</code>');
         return s;
     }
 
     private _esc(s: string): string {
-        return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+        return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
     }
 }

--- a/plugin-core/chat-ui/src/components/TodoView.ts
+++ b/plugin-core/chat-ui/src/components/TodoView.ts
@@ -1,0 +1,118 @@
+export class TodoView extends HTMLElement {
+    private _content!: HTMLElement;
+    private _empty!: HTMLElement;
+    private _pollTimer: number | null = null;
+    private _lastContent: string | null = null;
+
+    connectedCallback(): void {
+        this.innerHTML = `
+            <div class="tv-container">
+                <div class="tv-empty">No plan file yet. The agent creates plan.md during complex tasks.</div>
+                <div class="tv-content"></div>
+            </div>`;
+        this._content = this.querySelector('.tv-content')!;
+        this._empty = this.querySelector('.tv-empty')!;
+        this.refresh();
+        this._pollTimer = window.setInterval(() => this.refresh(), 2000);
+    }
+
+    disconnectedCallback(): void {
+        if (this._pollTimer) clearInterval(this._pollTimer);
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const resp = await fetch('/plan');
+            if (!resp.ok) return;
+            const data = await resp.json() as { content: string | null };
+            if (data.content === this._lastContent) return;
+            this._lastContent = data.content;
+
+            if (!data.content) {
+                this._empty.style.display = '';
+                this._content.style.display = 'none';
+                return;
+            }
+            this._empty.style.display = 'none';
+            this._content.style.display = '';
+            this._content.innerHTML = this._renderMarkdown(data.content);
+        } catch (e) {
+            // Silently ignore
+        }
+    }
+
+    private _renderMarkdown(md: string): string {
+        // Simple markdown rendering: headings, checkboxes, code blocks, bold, italic, links
+        const lines = md.split('\n');
+        const out: string[] = [];
+        let inCodeBlock = false;
+
+        for (const line of lines) {
+            if (line.startsWith('```')) {
+                if (inCodeBlock) {
+                    out.push('</code></pre>');
+                    inCodeBlock = false;
+                } else {
+                    out.push('<pre><code>');
+                    inCodeBlock = true;
+                }
+                continue;
+            }
+            if (inCodeBlock) {
+                out.push(this._esc(line) + '\n');
+                continue;
+            }
+
+            // Headings
+            const headingMatch = line.match(/^(#{1,6})\s+(.*)/);
+            if (headingMatch) {
+                const level = headingMatch[1].length;
+                out.push(`<h${level}>${this._inline(headingMatch[2])}</h${level}>`);
+                continue;
+            }
+
+            // Checkboxes
+            const checkMatch = line.match(/^(\s*[-*])\s+\[([ xX])]\s+(.*)/);
+            if (checkMatch) {
+                const checked = checkMatch[2] !== ' ';
+                const cls = checked ? 'tv-done' : 'tv-pending';
+                out.push(`<div class="tv-check ${cls}">${checked ? '☑' : '☐'} ${this._inline(checkMatch[3])}</div>`);
+                continue;
+            }
+
+            // List items
+            const listMatch = line.match(/^(\s*[-*])\s+(.*)/);
+            if (listMatch) {
+                out.push(`<div class="tv-li">• ${this._inline(listMatch[2])}</div>`);
+                continue;
+            }
+
+            // Empty lines
+            if (line.trim() === '') {
+                out.push('<br>');
+                continue;
+            }
+
+            // Regular paragraph
+            out.push(`<p>${this._inline(line)}</p>`);
+        }
+
+        if (inCodeBlock) out.push('</code></pre>');
+        return out.join('\n');
+    }
+
+    private _inline(text: string): string {
+        let s = this._esc(text);
+        // Bold
+        s = s.replaceAll(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+        // Italic
+        s = s.replaceAll(/\*(.+?)\*/g, '<em>$1</em>');
+        // Inline code
+        s = s.replaceAll(/`(.+?)`/g, '<code>$1</code>');
+        return s;
+    }
+
+    private _esc(s: string): string {
+        return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+    }
+}

--- a/plugin-core/chat-ui/src/components/ToolCallsView.ts
+++ b/plugin-core/chat-ui/src/components/ToolCallsView.ts
@@ -1,0 +1,107 @@
+type ToolCallItem = {
+    id: string;
+    title: string;
+    kind: string;
+    status: string | null;
+    timestamp: string;
+    arguments: string | null;
+    result: string | null;
+};
+
+export class ToolCallsView extends HTMLElement {
+    private _list!: HTMLElement;
+    private _empty!: HTMLElement;
+    private _pollTimer: number | null = null;
+    private _items: ToolCallItem[] = [];
+    private _expandedId: string | null = null;
+
+    connectedCallback(): void {
+        this.innerHTML = `
+            <div class="tcv-container">
+                <div class="tcv-empty">No tool calls yet</div>
+                <div class="tcv-list"></div>
+            </div>`;
+        this._list = this.querySelector<HTMLElement>('.tcv-list')!;
+        this._empty = this.querySelector<HTMLElement>('.tcv-empty')!;
+        this._list.addEventListener('click', (event) => {
+            const row = (event.target as HTMLElement).closest<HTMLElement>('.tcv-item');
+            if (!row) return;
+            this._expandedId = this._expandedId === row.dataset.id ? null : row.dataset.id ?? null;
+            this._render();
+        });
+        void this.refresh();
+        this._pollTimer = globalThis.setInterval(() => void this.refresh(), 2000);
+    }
+
+    disconnectedCallback(): void {
+        if (this._pollTimer) clearInterval(this._pollTimer);
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const resp = await fetch('/tool-calls');
+            if (!resp.ok) {
+                console.error(`[AB] Tool call fetch failed: HTTP ${resp.status}`);
+                return;
+            }
+            const data = await resp.json() as { items: ToolCallItem[] };
+            this._items = data.items.slice().reverse();
+            this._render();
+        } catch (error) {
+            console.error('[AB] Failed to refresh tool calls:', error);
+        }
+    }
+
+    private _render(): void {
+        if (this._items.length === 0) {
+            this._empty.style.display = '';
+            this._list.style.display = 'none';
+            return;
+        }
+        this._empty.style.display = 'none';
+        this._list.style.display = '';
+        this._list.innerHTML = this._items.map(item => this._renderItem(item)).join('');
+    }
+
+    private _renderItem(item: ToolCallItem): string {
+        const expanded = item.id === this._expandedId;
+        const kind = this._kindClass(item.kind);
+        const status = item.status || 'running';
+        const statusClass = status.toLowerCase().replaceAll(/[^a-z0-9_-]/g, '-');
+        const detail = expanded ? `
+            <div class="tcv-detail">
+                <div class="tcv-label">Input</div>
+                <pre>${this._esc(item.arguments || '')}</pre>
+                <div class="tcv-label">Output</div>
+                <pre>${this._esc(item.result || (status === 'running' ? '(still running)' : ''))}</pre>
+            </div>` : '';
+        return `<div class="tcv-item" data-id="${this._esc(item.id)}">
+            <div class="tcv-summary">
+                <span class="tcv-kind ${kind}">${this._esc(item.kind || 'other')}</span>
+                <span class="tcv-title">${this._esc(item.title)}</span>
+                <span class="tcv-status ${statusClass}">${this._esc(status)}</span>
+            </div>
+            <div class="tcv-time">${this._esc(this._formatTime(item.timestamp))}</div>
+            ${detail}
+        </div>`;
+    }
+
+    private _kindClass(kind: string): string {
+        const normalized = (kind || '').toLowerCase();
+        if (normalized.includes('read')) return 'tcv-read';
+        if (normalized.includes('edit') || normalized.includes('write')) return 'tcv-edit';
+        if (normalized.includes('execute')) return 'tcv-execute';
+        return 'tcv-other';
+    }
+
+    private _formatTime(timestamp: string): string {
+        if (!timestamp) return '';
+        const date = new Date(timestamp);
+        if (Number.isNaN(date.getTime())) return timestamp;
+        return date.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit', second: '2-digit'});
+    }
+
+    private _esc(s: string): string {
+        return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
+    }
+}

--- a/plugin-core/chat-ui/src/syntaxHighlight.ts
+++ b/plugin-core/chat-ui/src/syntaxHighlight.ts
@@ -1,0 +1,272 @@
+/**
+ * Minimal syntax highlighter — tokenizes source code into spans for
+ * keyword, string, comment, number, and punctuation highlighting.
+ *
+ * No external dependencies. Covers the most common languages found in
+ * IDE projects: Java, Kotlin, JS/TS, Python, Go, Rust, C/C++, shell,
+ * SQL, HTML/XML, CSS, JSON, YAML, TOML, and properties files.
+ */
+
+const KEYWORDS: Record<string, Set<string>> = {
+    java: new Set('abstract assert boolean break byte case catch char class const continue default do double else enum extends final finally float for goto if implements import instanceof int interface long native new package private protected public return short static strictfp super switch synchronized this throw throws transient try void volatile while var record sealed permits yield'.split(' ')),
+    kotlin: new Set('abstract annotation as break by catch class companion const constructor continue crossinline data do else enum expect external false final finally for fun if import in infix init inline inner interface internal is lateinit noinline null object open operator out override package private protected public reified return sealed super suspend this throw true try typealias val var vararg when where while yield'.split(' ')),
+    typescript: new Set('abstract as async await break case catch class const continue debugger declare default delete do else enum export extends false finally for from function get if implements import in infer instanceof interface is keyof let module namespace never new null of package private protected public readonly return set static super switch this throw true try type typeof undefined var void while with yield'.split(' ')),
+    python: new Set('False None True and as assert async await break class continue def del elif else except finally for from global if import in is lambda nonlocal not or pass raise return try while with yield'.split(' ')),
+    go: new Set('break case chan const continue default defer else fallthrough for func go goto if import interface map package range return select struct switch type var'.split(' ')),
+    rust: new Set('as async await break const continue crate dyn else enum extern false fn for if impl in let loop match mod move mut pub ref return self Self static struct super trait true type unsafe use where while'.split(' ')),
+    c: new Set('auto break case char const continue default do double else enum extern float for goto if inline int long register restrict return short signed sizeof static struct switch typedef union unsigned void volatile while _Bool _Complex _Imaginary'.split(' ')),
+    shell: new Set('if then else elif fi case esac for while until do done in function select time coproc'.split(' ')),
+    sql: new Set('select from where and or not in is null like between exists insert into values update set delete create drop alter table index view as join inner outer left right on order by group having union all distinct limit offset asc desc primary key foreign references default constraint unique check grant revoke'.split(' ')),
+    css: new Set('important'.split(' ')),
+};
+// Reuse sets for language aliases
+KEYWORDS.javascript = KEYWORDS.typescript;
+KEYWORDS.tsx = KEYWORDS.typescript;
+KEYWORDS.jsx = KEYWORDS.typescript;
+KEYWORDS.kt = KEYWORDS.kotlin;
+KEYWORDS.kts = KEYWORDS.kotlin;
+KEYWORDS.py = KEYWORDS.python;
+KEYWORDS.rs = KEYWORDS.rust;
+KEYWORDS.cpp = KEYWORDS.c;
+KEYWORDS.h = KEYWORDS.c;
+KEYWORDS.sh = KEYWORDS.shell;
+KEYWORDS.bash = KEYWORDS.shell;
+KEYWORDS.zsh = KEYWORDS.shell;
+
+const LANG_FOR_EXT: Record<string, string> = {
+    java: 'java', kt: 'kotlin', kts: 'kotlin',
+    js: 'javascript', mjs: 'javascript', cjs: 'javascript',
+    ts: 'typescript', tsx: 'typescript', jsx: 'javascript',
+    py: 'python', go: 'go', rs: 'rust',
+    c: 'c', cpp: 'c', h: 'c', hpp: 'c',
+    sh: 'shell', bash: 'shell', zsh: 'shell',
+    sql: 'sql', css: 'css',
+    json: 'json', yaml: 'yaml', yml: 'yaml', toml: 'toml',
+    xml: 'xml', html: 'xml', htm: 'xml', svg: 'xml',
+    properties: 'properties', ini: 'properties', cfg: 'properties',
+    md: 'markdown', markdown: 'markdown',
+    gradle: 'kotlin', groovy: 'java',
+};
+
+/** Detect language from file path extension. */
+export function detectLanguage(path: string): string {
+    const dot = path.lastIndexOf('.');
+    if (dot < 0) return '';
+    const ext = path.substring(dot + 1).toLowerCase();
+    return LANG_FOR_EXT[ext] ?? '';
+}
+
+// ── Escape helpers ──────────────────────────────────────────────────────
+
+function esc(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function span(cls: string, text: string): string {
+    return `<span class="sh-${cls}">${esc(text)}</span>`;
+}
+
+// ── Main highlighter ────────────────────────────────────────────────────
+
+/**
+ * Highlight source code, returning an HTML string with `<span class="sh-*">`
+ * wrappers. Unknown languages get plain escaped output.
+ */
+export function highlight(code: string, lang: string): string {
+    if (!lang) return esc(code);
+
+    switch (lang) {
+        case 'json': return highlightJson(code);
+        case 'xml': return highlightXml(code);
+        case 'yaml': case 'toml': return highlightYaml(code, lang);
+        case 'properties': return highlightProperties(code);
+        case 'css': return highlightCss(code);
+        default: return highlightCode(code, lang);
+    }
+}
+
+/** Generic C-family / scripting language highlighter. */
+function highlightCode(code: string, lang: string): string {
+    const kw = KEYWORDS[lang];
+    const isPython = lang === 'python';
+    const isShell = lang === 'shell';
+    const out: string[] = [];
+    let i = 0;
+    const n = code.length;
+
+    while (i < n) {
+        const ch = code[i];
+
+        // Line comment: // or #
+        if ((ch === '/' && code[i + 1] === '/') || ((isPython || isShell) && ch === '#')) {
+            const end = code.indexOf('\n', i);
+            const slice = end < 0 ? code.substring(i) : code.substring(i, end);
+            out.push(span('cmt', slice));
+            i += slice.length;
+            continue;
+        }
+
+        // Block comment: /* ... */
+        if (ch === '/' && code[i + 1] === '*') {
+            const end = code.indexOf('*/', i + 2);
+            const slice = end < 0 ? code.substring(i) : code.substring(i, end + 2);
+            out.push(span('cmt', slice));
+            i += slice.length;
+            continue;
+        }
+
+        // Strings: " ' `
+        if (ch === '"' || ch === "'" || ch === '`') {
+            let j = i + 1;
+            while (j < n && code[j] !== ch) {
+                if (code[j] === '\\') j++; // skip escaped char
+                j++;
+            }
+            if (j < n) j++; // include closing quote
+            out.push(span('str', code.substring(i, j)));
+            i = j;
+            continue;
+        }
+
+        // Python triple-quotes
+        if (isPython && (code.substring(i, i + 3) === '"""' || code.substring(i, i + 3) === "'''")) {
+            const q3 = code.substring(i, i + 3);
+            let j = code.indexOf(q3, i + 3);
+            j = j < 0 ? n : j + 3;
+            out.push(span('str', code.substring(i, j)));
+            i = j;
+            continue;
+        }
+
+        // Numbers
+        if (/[0-9]/.test(ch) && (i === 0 || /[\s,;()\[\]{}=+\-*/<>!&|^~%]/.test(code[i - 1]))) {
+            let j = i;
+            if (code[j] === '0' && (code[j + 1] === 'x' || code[j + 1] === 'X')) {
+                j += 2;
+                while (j < n && /[0-9a-fA-F_]/.test(code[j])) j++;
+            } else {
+                while (j < n && /[0-9._eE]/.test(code[j])) j++;
+            }
+            if (j < n && /[lLfFdDnuU]/.test(code[j])) j++;
+            out.push(span('num', code.substring(i, j)));
+            i = j;
+            continue;
+        }
+
+        // Words (identifiers / keywords)
+        if (/[a-zA-Z_$]/.test(ch)) {
+            let j = i + 1;
+            while (j < n && /[a-zA-Z0-9_$]/.test(code[j])) j++;
+            const word = code.substring(i, j);
+            if (kw?.has(word)) {
+                out.push(span('kw', word));
+            } else {
+                out.push(esc(word));
+            }
+            i = j;
+            continue;
+        }
+
+        // Annotations: @word
+        if (ch === '@') {
+            let j = i + 1;
+            while (j < n && /[a-zA-Z0-9_.]/.test(code[j])) j++;
+            out.push(span('attr', code.substring(i, j)));
+            i = j;
+            continue;
+        }
+
+        // Punctuation
+        if ('(){}[]<>;:.,=+-*/%!&|^~?'.includes(ch)) {
+            out.push(span('pun', ch));
+            i++;
+            continue;
+        }
+
+        // Default: plain character
+        out.push(esc(ch));
+        i++;
+    }
+
+    return out.join('');
+}
+
+// ── JSON highlighter ────────────────────────────────────────────────────
+
+function highlightJson(code: string): string {
+    return code.replace(
+        /("(?:[^"\\]|\\.)*")\s*(:)?|(\btrue\b|\bfalse\b|\bnull\b)|(-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)/g,
+        (m, str, colon, literal, num) => {
+            if (str) return span(colon ? 'key' : 'str', str) + (colon ? esc(':') : '');
+            if (literal) return span('kw', literal);
+            if (num) return span('num', num);
+            return esc(m);
+        }
+    );
+}
+
+// ── XML/HTML highlighter ────────────────────────────────────────────────
+
+function highlightXml(code: string): string {
+    return code.replace(
+        /<!--[\s\S]*?-->|<\/?[\w:.-]+|\/?>|[\w:.-]+="[^"]*"|[\w:.-]+='[^']*'/g,
+        (m) => {
+            if (m.startsWith('<!--')) return span('cmt', m);
+            if (m.startsWith('</') || m.startsWith('<')) return span('tag', m);
+            if (m === '/>' || m === '>') return span('tag', m);
+            const eq = m.indexOf('=');
+            if (eq > 0) return span('attr', m.substring(0, eq)) + esc('=') + span('str', m.substring(eq + 1));
+            return esc(m);
+        }
+    );
+}
+
+// ── YAML / TOML highlighter ────────────────────────────────────────────
+
+function highlightYaml(code: string, lang: string): string {
+    const lines = code.split('\n');
+    return lines.map(line => {
+        // Comments
+        if (/^\s*#/.test(line)) return span('cmt', line);
+
+        // Key: value or [section]
+        const kv = lang === 'toml'
+            ? line.match(/^(\s*\[[\w.-]+]|\s*[\w.-]+)\s*(=)(.*)/)
+            : line.match(/^(\s*[\w.-]+)\s*(:)(.*)/);
+        if (kv) {
+            const val = kv[3].trim();
+            let valHtml = esc(kv[3]);
+            if (/^".*"$/.test(val) || /^'.*'$/.test(val)) valHtml = span('str', kv[3].trim());
+            else if (/^-?\d/.test(val)) valHtml = span('num', kv[3].trim());
+            else if (/^(true|false|null|~)$/i.test(val)) valHtml = span('kw', kv[3].trim());
+            return span('key', kv[1]) + esc(kv[2]) + valHtml;
+        }
+        return esc(line);
+    }).join('\n');
+}
+
+// ── Properties / INI highlighter ────────────────────────────────────────
+
+function highlightProperties(code: string): string {
+    return code.split('\n').map(line => {
+        if (/^\s*[#!]/.test(line)) return span('cmt', line);
+        const eq = line.match(/^(\s*[\w.-]+)\s*([=:])(.*)/);
+        if (eq) return span('key', eq[1]) + esc(eq[2]) + span('str', eq[3]);
+        return esc(line);
+    }).join('\n');
+}
+
+// ── CSS highlighter ─────────────────────────────────────────────────────
+
+function highlightCss(code: string): string {
+    return code.replace(
+        /\/\*[\s\S]*?\*\/|([.#]?[\w-]+)\s*\{|:\s*([\w#-]+(?:\([\w%,.\s-]*\))?)|"[^"]*"|'[^']*'/g,
+        (m, selector, value) => {
+            if (m.startsWith('/*')) return span('cmt', m);
+            if (selector) return span('tag', selector) + esc(' {');
+            if (value) return esc(': ') + span('str', value);
+            if (m.startsWith('"') || m.startsWith("'")) return span('str', m);
+            return esc(m);
+        }
+    );
+}

--- a/plugin-core/chat-ui/src/syntaxHighlight.ts
+++ b/plugin-core/chat-ui/src/syntaxHighlight.ts
@@ -1,0 +1,342 @@
+/**
+ * Minimal syntax highlighter — tokenizes source code into spans for
+ * keyword, string, comment, number, and punctuation highlighting.
+ *
+ * No external dependencies. Covers the most common languages found in
+ * IDE projects: Java, Kotlin, JS/TS, Python, Go, Rust, C/C++, shell,
+ * SQL, HTML/XML, CSS, JSON, YAML, TOML, and properties files.
+ */
+
+const KEYWORDS: Record<string, Set<string>> = {
+    java: new Set('abstract assert boolean break byte case catch char class const continue default do double else enum extends final finally float for goto if implements import instanceof int interface long native new package private protected public return short static strictfp super switch synchronized this throw throws transient try void volatile while var record sealed permits yield'.split(' ')),
+    kotlin: new Set('abstract annotation as break by catch class companion const constructor continue crossinline data do else enum expect external false final finally for fun if import in infix init inline inner interface internal is lateinit noinline null object open operator out override package private protected public reified return sealed super suspend this throw true try typealias val var vararg when where while yield'.split(' ')),
+    typescript: new Set('abstract as async await break case catch class const continue debugger declare default delete do else enum export extends false finally for from function get if implements import in infer instanceof interface is keyof let module namespace never new null of package private protected public readonly return set static super switch this throw true try type typeof undefined var void while with yield'.split(' ')),
+    python: new Set('False None True and as assert async await break class continue def del elif else except finally for from global if import in is lambda nonlocal not or pass raise return try while with yield'.split(' ')),
+    go: new Set('break case chan const continue default defer else fallthrough for func go goto if import interface map package range return select struct switch type var'.split(' ')),
+    rust: new Set('as async await break const continue crate dyn else enum extern false fn for if impl in let loop match mod move mut pub ref return self Self static struct super trait true type unsafe use where while'.split(' ')),
+    c: new Set('auto break case char const continue default do double else enum extern float for goto if inline int long register restrict return short signed sizeof static struct switch typedef union unsigned void volatile while _Bool _Complex _Imaginary'.split(' ')),
+    shell: new Set('if then else elif fi case esac for while until do done in function select time coproc'.split(' ')),
+    sql: new Set('select from where and or not in is null like between exists insert into values update set delete create drop alter table index view as join inner outer left right on order by group having union all distinct limit offset asc desc primary key foreign references default constraint unique check grant revoke'.split(' ')),
+    css: new Set('important'.split(' ')),
+};
+// Reuse sets for language aliases
+KEYWORDS.javascript = KEYWORDS.typescript;
+KEYWORDS.tsx = KEYWORDS.typescript;
+KEYWORDS.jsx = KEYWORDS.typescript;
+KEYWORDS.kt = KEYWORDS.kotlin;
+KEYWORDS.kts = KEYWORDS.kotlin;
+KEYWORDS.py = KEYWORDS.python;
+KEYWORDS.rs = KEYWORDS.rust;
+KEYWORDS.cpp = KEYWORDS.c;
+KEYWORDS.h = KEYWORDS.c;
+KEYWORDS.sh = KEYWORDS.shell;
+KEYWORDS.bash = KEYWORDS.shell;
+KEYWORDS.zsh = KEYWORDS.shell;
+
+const LANG_FOR_EXT: Record<string, string> = {
+    java: 'java', kt: 'kotlin', kts: 'kotlin',
+    js: 'javascript', mjs: 'javascript', cjs: 'javascript',
+    ts: 'typescript', tsx: 'typescript', jsx: 'javascript',
+    py: 'python', go: 'go', rs: 'rust',
+    c: 'c', cpp: 'c', h: 'c', hpp: 'c',
+    sh: 'shell', bash: 'shell', zsh: 'shell',
+    sql: 'sql', css: 'css',
+    json: 'json', yaml: 'yaml', yml: 'yaml', toml: 'toml',
+    xml: 'xml', html: 'xml', htm: 'xml', svg: 'xml',
+    properties: 'properties', ini: 'properties', cfg: 'properties',
+    md: 'markdown', markdown: 'markdown',
+    gradle: 'kotlin', groovy: 'java',
+};
+
+/** Detect language from file path extension. */
+export function detectLanguage(path: string): string {
+    const dot = path.lastIndexOf('.');
+    if (dot < 0) return '';
+    const ext = path.substring(dot + 1).toLowerCase();
+    return LANG_FOR_EXT[ext] ?? '';
+}
+
+// ── Escape helpers ──────────────────────────────────────────────────────
+
+function esc(s: string): string {
+    return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function span(cls: string, text: string): string {
+    return `<span class="sh-${cls}">${esc(text)}</span>`;
+}
+
+// ── Token match helpers for highlightCode ───────────────────────────────
+
+interface TokenMatch {
+    html: string;
+    advance: number;
+}
+
+function matchLineComment(code: string, i: number, isPython: boolean, isShell: boolean): TokenMatch | null {
+    const ch = code[i];
+    if ((ch === '/' && code[i + 1] === '/') || ((isPython || isShell) && ch === '#')) {
+        const end = code.indexOf('\n', i);
+        const slice = end < 0 ? code.substring(i) : code.substring(i, end);
+        return {html: span('cmt', slice), advance: slice.length};
+    }
+    return null;
+}
+
+function matchBlockComment(code: string, i: number): TokenMatch | null {
+    if (code[i] === '/' && code[i + 1] === '*') {
+        const end = code.indexOf('*/', i + 2);
+        const slice = end < 0 ? code.substring(i) : code.substring(i, end + 2);
+        return {html: span('cmt', slice), advance: slice.length};
+    }
+    return null;
+}
+
+function matchString(code: string, i: number, n: number): TokenMatch | null {
+    const ch = code[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+        let j = i + 1;
+        while (j < n && code[j] !== ch) {
+            if (code[j] === '\\') j++;
+            j++;
+        }
+        if (j < n) j++;
+        return {html: span('str', code.substring(i, j)), advance: j - i};
+    }
+    return null;
+}
+
+function matchPythonTripleQuote(code: string, i: number, n: number, isPython: boolean): TokenMatch | null {
+    if (isPython && (code.substring(i, i + 3) === '"""' || code.substring(i, i + 3) === "'''")) {
+        const q3 = code.substring(i, i + 3);
+        let j = code.indexOf(q3, i + 3);
+        j = j < 0 ? n : j + 3;
+        return {html: span('str', code.substring(i, j)), advance: j - i};
+    }
+    return null;
+}
+
+/** Scan a numeric literal starting at position i, returning the end position. */
+function scanNumberLiteral(code: string, i: number, n: number): number {
+    let j = i;
+    if (code[j] === '0' && (code[j + 1] === 'x' || code[j + 1] === 'X')) {
+        j += 2;
+        while (j < n && /[\da-fA-F_]/.test(code[j])) j++;
+    } else {
+        while (j < n && /[\d._eE]/.test(code[j])) j++;
+    }
+    if (j < n && /[lLfFdDnuU]/.test(code[j])) j++;
+    return j;
+}
+
+function matchNumber(code: string, i: number, n: number): TokenMatch | null {
+    const ch = code[i];
+    if (/\d/.test(ch) && (i === 0 || /[\s,;()[\]{}=+\-*/<>!&|^~%]/.test(code[i - 1]))) {
+        const j = scanNumberLiteral(code, i, n);
+        return {html: span('num', code.substring(i, j)), advance: j - i};
+    }
+    return null;
+}
+
+function matchIdentifier(code: string, i: number, n: number, kw: Set<string> | undefined): TokenMatch | null {
+    const ch = code[i];
+    if (/[a-zA-Z_$]/.test(ch)) {
+        let j = i + 1;
+        while (j < n && /[a-zA-Z0-9_$]/.test(code[j])) j++;
+        const word = code.substring(i, j);
+        const html = kw?.has(word) ? span('kw', word) : esc(word);
+        return {html, advance: j - i};
+    }
+    return null;
+}
+
+function matchAnnotation(code: string, i: number, n: number): TokenMatch | null {
+    if (code[i] === '@') {
+        let j = i + 1;
+        while (j < n && /[a-zA-Z0-9_.]/.test(code[j])) j++;
+        return {html: span('attr', code.substring(i, j)), advance: j - i};
+    }
+    return null;
+}
+
+// ── Main highlighter ────────────────────────────────────────────────────
+
+/**
+ * Highlight source code, returning an HTML string with `<span class="sh-*">`
+ * wrappers. Unknown languages get plain escaped output.
+ */
+export function highlight(code: string, lang: string): string {
+    if (!lang) return esc(code);
+
+    switch (lang) {
+        case 'json':
+            return highlightJson(code);
+        case 'xml':
+            return highlightXml(code);
+        case 'yaml':
+        case 'toml':
+            return highlightYaml(code, lang);
+        case 'properties':
+            return highlightProperties(code);
+        case 'css':
+            return highlightCss(code);
+        default:
+            return highlightCode(code, lang);
+    }
+}
+
+/** Generic C-family / scripting language highlighter. */
+function highlightCode(code: string, lang: string): string {
+    const kw = KEYWORDS[lang];
+    const isPython = lang === 'python';
+    const isShell = lang === 'shell';
+    const out: string[] = [];
+    let i = 0;
+    const n = code.length;
+
+    while (i < n) {
+        const ch = code[i];
+
+        const token =
+            matchLineComment(code, i, isPython, isShell) ??
+            matchBlockComment(code, i) ??
+            matchPythonTripleQuote(code, i, n, isPython) ??
+            matchString(code, i, n) ??
+            matchNumber(code, i, n) ??
+            matchIdentifier(code, i, n, kw) ??
+            matchAnnotation(code, i, n);
+
+        if (token) {
+            out.push(token.html);
+            i += token.advance;
+            continue;
+        }
+
+        // Punctuation
+        if ('(){}[]<>;:.,=+-*/%!&|^~?'.includes(ch)) {
+            out.push(span('pun', ch));
+            i++;
+            continue;
+        }
+
+        // Default: plain character
+        out.push(esc(ch));
+        i++;
+    }
+
+    return out.join('');
+}
+
+// ── JSON highlighter ────────────────────────────────────────────────────
+
+const JSON_STRING_RE = /("(?:[^"\\]|\\.)*")\s*(:)?/g;
+const JSON_LITERAL_RE = /\b(true|false|null)\b/g;
+const JSON_NUMBER_RE = /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/g;
+
+function highlightJson(code: string): string {
+    let result = code.replaceAll(JSON_STRING_RE,
+        (m, str, colon) => {
+            if (str) return span(colon ? 'key' : 'str', str) + (colon ? esc(':') : '');
+            return esc(m);
+        }
+    );
+    result = result.replaceAll(JSON_LITERAL_RE,
+        (m) => span('kw', m)
+    );
+    result = result.replaceAll(JSON_NUMBER_RE,
+        (m) => {
+            // Avoid replacing numbers already inside spans
+            return span('num', m);
+        }
+    );
+    return result;
+}
+
+// ── XML/HTML highlighter ────────────────────────────────────────────────
+
+const XML_COMMENT_RE = /<!--[\s\S]*?-->/g;
+const XML_TAG_RE = /<\/?[\w:.-]+|\/?>/g;
+const XML_ATTR_RE = /[\w:.-]+="[^"]*"|[\w:.-]+='[^']*'/g;
+
+function highlightXml(code: string): string {
+    let result = code.replaceAll(XML_COMMENT_RE,
+        (m) => span('cmt', m)
+    );
+    result = result.replaceAll(XML_TAG_RE,
+        (m) => {
+            if (m.startsWith('</') || m.startsWith('<')) return span('tag', m);
+            if (m === '/>' || m === '>') return span('tag', m);
+            return esc(m);
+        }
+    );
+    result = result.replaceAll(XML_ATTR_RE,
+        (m) => {
+            const eq = m.indexOf('=');
+            if (eq > 0) return span('attr', m.substring(0, eq)) + esc('=') + span('str', m.substring(eq + 1));
+            return esc(m);
+        }
+    );
+    return result;
+}
+
+// ── YAML / TOML highlighter ────────────────────────────────────────────
+
+const TOML_KV_RE = /^(\s*\[[\w.-]+]|\s*[\w.-]+)\s*(=)(.*)/;
+const YAML_KV_RE = /^(\s*[\w.-]+)\s*(:)(.*)/;
+
+function highlightYaml(code: string, lang: string): string {
+    const lines = code.split('\n');
+    return lines.map(line => {
+        // Comments
+        if (/^\s*#/.test(line)) return span('cmt', line);
+
+        // Key: value or [section]
+        const kvRe = lang === 'toml' ? TOML_KV_RE : YAML_KV_RE;
+        const kv = kvRe.exec(line);
+        if (kv) {
+            const val = kv[3].trim();
+            let valHtml = esc(kv[3]);
+            if (/^".*"$/.test(val) || /^'.*'$/.test(val)) valHtml = span('str', kv[3].trim());
+            else if (/^-?\d/.test(val)) valHtml = span('num', kv[3].trim());
+            else if (/^(true|false|null|~)$/i.test(val)) valHtml = span('kw', kv[3].trim());
+            return span('key', kv[1]) + esc(kv[2]) + valHtml;
+        }
+        return esc(line);
+    }).join('\n');
+}
+
+// ── Properties / INI highlighter ────────────────────────────────────────
+
+const PROPS_KV_RE = /^(\s*[\w.-]+)\s*([=:])(.*)/;
+
+function highlightProperties(code: string): string {
+    return code.split('\n').map(line => {
+        if (/^\s*[#!]/.test(line)) return span('cmt', line);
+        const eq = PROPS_KV_RE.exec(line);
+        if (eq) return span('key', eq[1]) + esc(eq[2]) + span('str', eq[3]);
+        return esc(line);
+    }).join('\n');
+}
+
+// ── CSS highlighter ─────────────────────────────────────────────────────
+
+const CSS_COMMENT_RE = /\/\*[\s\S]*?\*\//g;
+const CSS_SELECTOR_RE = /([.#]?[\w-]+)\s*\{/g;
+const CSS_VALUE_RE = /:\s*([\w#-]+(?:\([\w%,.\s-]*\))?)/g;
+const CSS_STRING_RE = /"[^"]*"|'[^']*'/g;
+
+function highlightCss(code: string): string {
+    let result = code.replaceAll(CSS_COMMENT_RE,
+        (m) => span('cmt', m)
+    );
+    result = result.replaceAll(CSS_STRING_RE,
+        (m) => span('str', m)
+    );
+    result = result.replaceAll(CSS_SELECTOR_RE,
+        (_m, selector) => span('tag', selector) + esc(' {')
+    );
+    result = result.replaceAll(CSS_VALUE_RE,
+        (_m, value) => esc(': ') + span('str', value)
+    );
+    return result;
+}

--- a/plugin-core/chat-ui/src/web-app.css
+++ b/plugin-core/chat-ui/src/web-app.css
@@ -1163,6 +1163,221 @@ file-nav {
     padding: 2px 0 2px 8px;
 }
 
+.tv-section {
+    margin-bottom: 18px;
+}
+
+.tv-section h2 {
+    font-size: 14px;
+    margin: 0 0 8px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.tv-db-summary {
+    color: var(--muted);
+    font-size: 12px;
+    margin-bottom: 8px;
+}
+
+.tv-db-item {
+    display: grid;
+    grid-template-columns: 20px minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: start;
+    padding: 8px;
+    border: 1px solid var(--border, #30363d);
+    border-radius: 8px;
+    background: var(--input-bg, #161b22);
+    margin-bottom: 6px;
+}
+
+.tv-db-status {
+    font-weight: bold;
+}
+
+.tv-db-item.in_progress .tv-db-status {
+    color: var(--blue, #388bfd);
+}
+
+.tv-db-item.done .tv-db-status {
+    color: var(--green, #2ea043);
+}
+
+.tv-db-item.blocked .tv-db-status {
+    color: var(--red, #f85149);
+}
+
+.tv-db-main {
+    min-width: 0;
+}
+
+.tv-db-title {
+    display: block;
+    overflow-wrap: anywhere;
+}
+
+.tv-db-desc {
+    color: var(--muted);
+    font-size: 12px;
+    margin-top: 3px;
+    overflow-wrap: anywhere;
+}
+
+.tv-db-id {
+    color: var(--muted);
+    font-size: 11px;
+    font-style: italic;
+}
+
+/* ── Tool Calls View ───────────────────────────────────── */
+.tcv-container,
+.pv-container {
+    padding: 12px;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.tcv-empty,
+.pv-empty {
+    color: var(--muted);
+    text-align: center;
+    padding: 40px 16px;
+}
+
+.tcv-item {
+    border: 1px solid var(--border, #30363d);
+    border-radius: 8px;
+    background: var(--input-bg, #161b22);
+    margin-bottom: 8px;
+    padding: 8px;
+    cursor: pointer;
+}
+
+.tcv-summary {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: center;
+}
+
+.tcv-kind {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.tcv-read {
+    color: var(--tool-read, #64b9b9);
+}
+
+.tcv-edit {
+    color: var(--tool-edit, #cd9b5f);
+}
+
+.tcv-execute {
+    color: var(--tool-execute, #82be82);
+}
+
+.tcv-other {
+    color: var(--muted);
+}
+
+.tcv-title {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tcv-status {
+    color: var(--muted);
+    font-size: 11px;
+}
+
+.tcv-status.success,
+.tcv-status.completed,
+.tcv-status.done {
+    color: var(--green, #2ea043);
+}
+
+.tcv-status.error,
+.tcv-status.failed {
+    color: var(--red, #f85149);
+}
+
+.tcv-time {
+    color: var(--muted);
+    font-size: 11px;
+    margin-top: 3px;
+}
+
+.tcv-detail {
+    margin-top: 8px;
+}
+
+.tcv-label {
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 700;
+    margin: 8px 0 4px;
+    text-transform: uppercase;
+}
+
+.tcv-detail pre {
+    max-height: 160px;
+    overflow: auto;
+    background: var(--bg, #0d1117);
+    border-radius: 6px;
+    padding: 8px;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+/* ── Prompt Search View ────────────────────────────────── */
+.pv-search {
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid var(--border, #30363d);
+    border-radius: 8px;
+    background: var(--input-bg, #161b22);
+    color: var(--fg, #e6edf3);
+    padding: 8px 10px;
+    margin-bottom: 10px;
+}
+
+.pv-item {
+    all: unset;
+    box-sizing: border-box;
+    display: block;
+    width: 100%;
+    padding: 8px;
+    border-radius: 8px;
+    cursor: pointer;
+    border: 1px solid transparent;
+}
+
+.pv-item:hover {
+    background: var(--input-bg, #161b22);
+    border-color: var(--border, #30363d);
+}
+
+.pv-time {
+    display: block;
+    color: var(--muted);
+    font-size: 11px;
+    margin-bottom: 3px;
+}
+
+.pv-text {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    overflow-wrap: anywhere;
+}
+
 /* ── Session View ──────────────────────────────────────── */
 .sv-container {
     padding: 12px;

--- a/plugin-core/chat-ui/src/web-app.css
+++ b/plugin-core/chat-ui/src/web-app.css
@@ -478,6 +478,396 @@ tool-chip .chip-expand {
     pointer-events: none;
 }
 
+/* ── Pane Swiper ────────────────────────────────────────────────────────── */
+
+pane-swiper {
+    flex: 1;
+    overflow: hidden;
+    position: relative;
+}
+
+.ps-track {
+    display: flex;
+    width: 200%;
+    height: 100%;
+    will-change: transform;
+}
+
+.ps-pane {
+    width: 50%;
+    height: 100%;
+    overflow: hidden;
+    position: relative;
+}
+
+.ps-dots {
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 6px;
+    z-index: 10;
+    pointer-events: auto;
+}
+
+.ps-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--fg-a16);
+    cursor: pointer;
+    transition: background .2s;
+}
+
+.ps-dot.active {
+    background: var(--user, #79c0ff);
+}
+
+/* ── File Viewer ───────────────────────────────────────────────────────── */
+
+file-viewer {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.fv-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.fv-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-bottom: 1px solid var(--fg-a08);
+    min-height: 28px;
+    font-size: .82em;
+    color: var(--fg-muted);
+}
+
+.fv-path {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.fv-copy-btn {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: .9em;
+    padding: 2px 4px;
+    border-radius: 3px;
+    color: var(--fg-muted);
+}
+
+.fv-copy-btn:hover {
+    background: var(--fg-a08);
+}
+
+.fv-content-area {
+    flex: 1;
+    overflow: hidden;
+    position: relative;
+}
+
+.fv-content {
+    position: absolute;
+    inset: 0;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.fv-empty {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    color: var(--fg-muted);
+    padding: 24px;
+}
+
+.fv-empty-icon { font-size: 2.4em; opacity: .5; }
+.fv-empty-title { font-size: 1.05em; font-weight: 600; }
+.fv-empty-hint { font-size: .85em; text-align: center; max-width: 260px; }
+
+.fv-recent-list {
+    margin-top: 12px;
+    width: 100%;
+    max-width: 300px;
+}
+
+.fv-recent-title {
+    font-size: .78em;
+    color: var(--fg-muted);
+    margin-bottom: 6px;
+    text-transform: uppercase;
+    letter-spacing: .5px;
+}
+
+.fv-recent-item {
+    display: flex;
+    flex-direction: column;
+    padding: 6px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    gap: 1px;
+}
+
+.fv-recent-item:hover {
+    background: var(--fg-a08);
+}
+
+.fv-recent-name {
+    font-size: .88em;
+    color: var(--fg);
+}
+
+.fv-recent-path {
+    font-size: .75em;
+    color: var(--fg-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* ── Code display ──────────────────────────────────────────────────────── */
+
+.fv-code-wrap {
+    display: flex;
+    min-height: 100%;
+}
+
+.fv-gutter {
+    flex: 0 0 auto;
+    padding: 8px 8px 8px 12px;
+    text-align: right;
+    color: var(--fg-muted);
+    opacity: .5;
+    user-select: none;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: .82em;
+    line-height: 1.55;
+    margin: 0;
+    border-right: 1px solid var(--fg-a08);
+}
+
+.fv-code {
+    flex: 1;
+    padding: 8px 12px;
+    margin: 0;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: .82em;
+    line-height: 1.55;
+    overflow-x: auto;
+    tab-size: 4;
+}
+
+.fv-code code {
+    font: inherit;
+}
+
+.fv-line-highlight {
+    position: absolute;
+    left: 0;
+    right: 0;
+    background: var(--user-a12);
+    pointer-events: none;
+    animation: fv-highlight-fade 2s forwards;
+}
+
+@keyframes fv-highlight-fade {
+    0% { opacity: 1; }
+    70% { opacity: 1; }
+    100% { opacity: 0; }
+}
+
+/* ── Markdown display ──────────────────────────────────────────────────── */
+
+.fv-markdown {
+    padding: 12px 16px;
+    line-height: 1.6;
+}
+
+.fv-markdown h1,
+.fv-markdown h2,
+.fv-markdown h3 {
+    margin-top: 1.2em;
+    margin-bottom: .5em;
+}
+
+.fv-markdown pre {
+    background: var(--fg-a05);
+    border-radius: 6px;
+    padding: 10px 12px;
+    overflow-x: auto;
+}
+
+.fv-markdown code {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: .88em;
+}
+
+.fv-markdown blockquote {
+    border-left: 3px solid var(--fg-a16);
+    margin: .8em 0;
+    padding: .4em .8em;
+    color: var(--fg-muted);
+}
+
+/* ── File Nav ──────────────────────────────────────────────────────────── */
+
+file-nav {
+    display: block;
+}
+
+.fn-bar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--fg-a08);
+    min-height: 32px;
+}
+
+.fn-toggle {
+    border: none;
+    background: transparent;
+    color: var(--fg-muted);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+}
+
+.fn-toggle:hover {
+    background: var(--fg-a08);
+    color: var(--fg);
+}
+
+.fn-breadcrumb {
+    flex: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: .82em;
+    color: var(--fg-muted);
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+
+.fn-sep { color: var(--fg-a16); margin: 0 1px; }
+
+.fn-crumb { color: var(--fg-muted); }
+
+.fn-clickable {
+    cursor: pointer;
+    color: var(--user, #79c0ff);
+}
+
+.fn-clickable:hover { text-decoration: underline; }
+
+.fn-dropdown {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 100%;
+    z-index: 50;
+    background: var(--bg);
+    border-bottom: 1px solid var(--fg-a16);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, .2);
+    max-height: 60vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.fn-search-row {
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--fg-a08);
+}
+
+.fn-search {
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid var(--fg-a16);
+    background: var(--fg-a05);
+    color: var(--fg);
+    padding: 4px 8px;
+    border-radius: 4px;
+    font: inherit;
+    font-size: .85em;
+    outline: none;
+}
+
+.fn-search:focus {
+    border-color: var(--user, #79c0ff);
+}
+
+.fn-list {
+    overflow-y: auto;
+    flex: 1;
+    padding: 4px 0;
+}
+
+.fn-entry {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 12px;
+    cursor: pointer;
+    font-size: .88em;
+}
+
+.fn-entry:hover {
+    background: var(--fg-a08);
+}
+
+.fn-icon { flex: 0 0 auto; font-size: .9em; }
+.fn-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.fn-dir .fn-name { color: var(--fg); font-weight: 500; }
+.fn-file .fn-name { color: var(--fg-muted); }
+
+.fn-loading, .fn-error {
+    padding: 12px;
+    text-align: center;
+    font-size: .85em;
+    color: var(--fg-muted);
+}
+
+.fn-error { color: var(--error, #e06c75); }
+
+/* ── Syntax highlighting theme ─────────────────────────────────────────── */
+
+.sh-kw  { color: var(--sh-keyword, #c678dd); }
+.sh-str { color: var(--sh-string, #98c379); }
+.sh-cmt { color: var(--sh-comment, #5c6370); font-style: italic; }
+.sh-num { color: var(--sh-number, #d19a66); }
+.sh-pun { color: var(--fg-muted); }
+.sh-tag { color: var(--sh-tag, #e06c75); }
+.sh-attr { color: var(--sh-attr, #d19a66); }
+.sh-key { color: var(--sh-key, #e06c75); }
+.sh-prop { color: var(--sh-prop, #61afef); }
+
+.light .sh-kw  { color: var(--sh-keyword, #a626a4); }
+.light .sh-str { color: var(--sh-string, #50a14f); }
+.light .sh-cmt { color: var(--sh-comment, #a0a1a7); font-style: italic; }
+.light .sh-num { color: var(--sh-number, #986801); }
+.light .sh-tag { color: var(--sh-tag, #e45649); }
+.light .sh-attr { color: var(--sh-attr, #986801); }
+.light .sh-key { color: var(--sh-key, #e45649); }
+.light .sh-prop { color: var(--sh-prop, #4078f2); }
+
 /* ── Narrow-screen header ───────────────────────────────────────────────── */
 
 @media (max-width: 480px) {

--- a/plugin-core/chat-ui/src/web-app.css
+++ b/plugin-core/chat-ui/src/web-app.css
@@ -819,8 +819,12 @@ file-nav {
     border-bottom: 1px solid var(--fg-a16);
     box-shadow: 0 4px 12px rgba(0, 0, 0, .2);
     max-height: 60vh;
-    display: flex;
+    display: none;
     flex-direction: column;
+}
+
+.fn-dropdown.fn-open {
+    display: flex;
 }
 
 .fn-search-row {

--- a/plugin-core/chat-ui/src/web-app.css
+++ b/plugin-core/chat-ui/src/web-app.css
@@ -86,14 +86,19 @@ body {
 }
 
 @keyframes ab-pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: .35; }
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: .35;
+    }
 }
 
 /* ── Chat area ─────────────────────────────────────────────────────────── */
 
 #ab-chat {
     flex: 1;
+    height: 100%;
     overflow: hidden;
     position: relative;
 }
@@ -596,9 +601,21 @@ file-viewer {
     padding: 24px;
 }
 
-.fv-empty-icon { font-size: 2.4em; opacity: .5; }
-.fv-empty-title { font-size: 1.05em; font-weight: 600; }
-.fv-empty-hint { font-size: .85em; text-align: center; max-width: 260px; }
+.fv-empty-icon {
+    font-size: 2.4em;
+    opacity: .5;
+}
+
+.fv-empty-title {
+    font-size: 1.05em;
+    font-weight: 600;
+}
+
+.fv-empty-hint {
+    font-size: .85em;
+    text-align: center;
+    max-width: 260px;
+}
 
 .fv-recent-list {
     margin-top: 12px;
@@ -686,9 +703,15 @@ file-viewer {
 }
 
 @keyframes fv-highlight-fade {
-    0% { opacity: 1; }
-    70% { opacity: 1; }
-    100% { opacity: 0; }
+    0% {
+        opacity: 1;
+    }
+    70% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
 }
 
 /* ── Markdown display ──────────────────────────────────────────────────── */
@@ -728,6 +751,7 @@ file-viewer {
 
 file-nav {
     display: block;
+    position: relative;
 }
 
 .fn-bar {
@@ -767,16 +791,23 @@ file-nav {
     gap: 2px;
 }
 
-.fn-sep { color: var(--fg-a16); margin: 0 1px; }
+.fn-sep {
+    color: var(--fg-a16);
+    margin: 0 1px;
+}
 
-.fn-crumb { color: var(--fg-muted); }
+.fn-crumb {
+    color: var(--fg-muted);
+}
 
 .fn-clickable {
     cursor: pointer;
     color: var(--user, #79c0ff);
 }
 
-.fn-clickable:hover { text-decoration: underline; }
+.fn-clickable:hover {
+    text-decoration: underline;
+}
 
 .fn-dropdown {
     position: absolute;
@@ -833,10 +864,25 @@ file-nav {
     background: var(--fg-a08);
 }
 
-.fn-icon { flex: 0 0 auto; font-size: .9em; }
-.fn-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.fn-dir .fn-name { color: var(--fg); font-weight: 500; }
-.fn-file .fn-name { color: var(--fg-muted); }
+.fn-icon {
+    flex: 0 0 auto;
+    font-size: .9em;
+}
+
+.fn-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.fn-dir .fn-name {
+    color: var(--fg);
+    font-weight: 500;
+}
+
+.fn-file .fn-name {
+    color: var(--fg-muted);
+}
 
 .fn-loading, .fn-error {
     padding: 12px;
@@ -845,28 +891,81 @@ file-nav {
     color: var(--fg-muted);
 }
 
-.fn-error { color: var(--error, #e06c75); }
+.fn-error {
+    color: var(--error, #e06c75);
+}
 
 /* ── Syntax highlighting theme ─────────────────────────────────────────── */
 
-.sh-kw  { color: var(--sh-keyword, #c678dd); }
-.sh-str { color: var(--sh-string, #98c379); }
-.sh-cmt { color: var(--sh-comment, #5c6370); font-style: italic; }
-.sh-num { color: var(--sh-number, #d19a66); }
-.sh-pun { color: var(--fg-muted); }
-.sh-tag { color: var(--sh-tag, #e06c75); }
-.sh-attr { color: var(--sh-attr, #d19a66); }
-.sh-key { color: var(--sh-key, #e06c75); }
-.sh-prop { color: var(--sh-prop, #61afef); }
+.sh-kw {
+    color: var(--sh-keyword, #c678dd);
+}
 
-.light .sh-kw  { color: var(--sh-keyword, #a626a4); }
-.light .sh-str { color: var(--sh-string, #50a14f); }
-.light .sh-cmt { color: var(--sh-comment, #a0a1a7); font-style: italic; }
-.light .sh-num { color: var(--sh-number, #986801); }
-.light .sh-tag { color: var(--sh-tag, #e45649); }
-.light .sh-attr { color: var(--sh-attr, #986801); }
-.light .sh-key { color: var(--sh-key, #e45649); }
-.light .sh-prop { color: var(--sh-prop, #4078f2); }
+.sh-str {
+    color: var(--sh-string, #98c379);
+}
+
+.sh-cmt {
+    color: var(--sh-comment, #5c6370);
+    font-style: italic;
+}
+
+.sh-num {
+    color: var(--sh-number, #d19a66);
+}
+
+.sh-pun {
+    color: var(--fg-muted);
+}
+
+.sh-tag {
+    color: var(--sh-tag, #e06c75);
+}
+
+.sh-attr {
+    color: var(--sh-attr, #d19a66);
+}
+
+.sh-key {
+    color: var(--sh-key, #e06c75);
+}
+
+.sh-prop {
+    color: var(--sh-prop, #61afef);
+}
+
+.light .sh-kw {
+    color: var(--sh-keyword, #a626a4);
+}
+
+.light .sh-str {
+    color: var(--sh-string, #50a14f);
+}
+
+.light .sh-cmt {
+    color: var(--sh-comment, #a0a1a7);
+    font-style: italic;
+}
+
+.light .sh-num {
+    color: var(--sh-number, #986801);
+}
+
+.light .sh-tag {
+    color: var(--sh-tag, #e45649);
+}
+
+.light .sh-attr {
+    color: var(--sh-attr, #986801);
+}
+
+.light .sh-key {
+    color: var(--sh-key, #e45649);
+}
+
+.light .sh-prop {
+    color: var(--sh-prop, #4078f2);
+}
 
 /* ── Narrow-screen header ───────────────────────────────────────────────── */
 

--- a/plugin-core/chat-ui/src/web-app.css
+++ b/plugin-core/chat-ui/src/web-app.css
@@ -86,14 +86,19 @@ body {
 }
 
 @keyframes ab-pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: .35; }
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: .35;
+    }
 }
 
 /* ── Chat area ─────────────────────────────────────────────────────────── */
 
 #ab-chat {
     flex: 1;
+    height: 100%;
     overflow: hidden;
     position: relative;
 }
@@ -478,10 +483,724 @@ tool-chip .chip-expand {
     pointer-events: none;
 }
 
+/* ── Pane Swiper ────────────────────────────────────────────────────────── */
+
+pane-swiper {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+    position: relative;
+}
+
+/* ── Tab bar ── */
+
+.ps-tab-bar {
+    display: flex;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+    background: var(--bg-secondary, transparent);
+    z-index: 10;
+    flex-shrink: 0;
+}
+
+.ps-tab-bar::-webkit-scrollbar {
+    display: none;
+}
+
+.ps-tab {
+    all: unset;
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--fg-muted, rgba(255, 255, 255, 0.5));
+    cursor: pointer;
+    white-space: nowrap;
+    border-bottom: 2px solid transparent;
+    transition: color 0.2s, border-color 0.2s;
+}
+
+.ps-tab:hover {
+    color: var(--fg, #e6edf3);
+}
+
+.ps-tab.active {
+    color: var(--user, #79c0ff);
+    border-bottom-color: var(--user, #79c0ff);
+}
+
+/* ── Track & panes ── */
+
+.ps-track {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    will-change: transform;
+}
+
+.ps-pane {
+    height: 100%;
+    overflow: hidden;
+    position: relative;
+    flex-shrink: 0;
+}
+
+/* ── Dot indicator ── */
+
+.ps-dots {
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 6px;
+    z-index: 10;
+    pointer-events: auto;
+}
+
+.ps-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--fg-a16);
+    cursor: pointer;
+    transition: background .2s;
+}
+
+.ps-dot.active {
+    background: var(--user, #79c0ff);
+}
+
+/* ── File Viewer ───────────────────────────────────────────────────────── */
+
+file-viewer {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.fv-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.fv-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-bottom: 1px solid var(--fg-a08);
+    min-height: 28px;
+    font-size: .82em;
+    color: var(--fg-muted);
+}
+
+.fv-path {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.fv-copy-btn {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: .9em;
+    padding: 2px 4px;
+    border-radius: 3px;
+    color: var(--fg-muted);
+}
+
+.fv-copy-btn:hover {
+    background: var(--fg-a08);
+}
+
+.fv-content-area {
+    flex: 1;
+    overflow: hidden;
+    position: relative;
+}
+
+.fv-content {
+    position: absolute;
+    inset: 0;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.fv-empty {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    color: var(--fg-muted);
+    padding: 24px;
+}
+
+.fv-empty-icon {
+    font-size: 2.4em;
+    opacity: .5;
+}
+
+.fv-empty-title {
+    font-size: 1.05em;
+    font-weight: 600;
+}
+
+.fv-empty-hint {
+    font-size: .85em;
+    text-align: center;
+    max-width: 260px;
+}
+
+.fv-recent-list {
+    margin-top: 12px;
+    width: 100%;
+    max-width: 300px;
+}
+
+.fv-recent-title {
+    font-size: .78em;
+    color: var(--fg-muted);
+    margin-bottom: 6px;
+    text-transform: uppercase;
+    letter-spacing: .5px;
+}
+
+.fv-recent-item {
+    display: flex;
+    flex-direction: column;
+    padding: 6px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    gap: 1px;
+}
+
+.fv-recent-item:hover {
+    background: var(--fg-a08);
+}
+
+.fv-recent-name {
+    font-size: .88em;
+    color: var(--fg);
+}
+
+.fv-recent-path {
+    font-size: .75em;
+    color: var(--fg-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* ── Code display ──────────────────────────────────────────────────────── */
+
+.fv-code-wrap {
+    display: flex;
+    min-height: 100%;
+}
+
+.fv-gutter {
+    flex: 0 0 auto;
+    padding: 8px 8px 8px 12px;
+    text-align: right;
+    color: var(--fg-muted);
+    opacity: .5;
+    user-select: none;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: .82em;
+    line-height: 1.55;
+    margin: 0;
+    border-right: 1px solid var(--fg-a08);
+}
+
+.fv-code {
+    flex: 1;
+    padding: 8px 12px;
+    margin: 0;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: .82em;
+    line-height: 1.55;
+    overflow-x: auto;
+    tab-size: 4;
+}
+
+.fv-code code {
+    font: inherit;
+}
+
+.fv-line-highlight {
+    position: absolute;
+    left: 0;
+    right: 0;
+    background: var(--user-a12);
+    pointer-events: none;
+    animation: fv-highlight-fade 2s forwards;
+}
+
+@keyframes fv-highlight-fade {
+    0% {
+        opacity: 1;
+    }
+    70% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+
+/* ── Markdown display ──────────────────────────────────────────────────── */
+
+.fv-markdown {
+    padding: 12px 16px;
+    line-height: 1.6;
+}
+
+.fv-markdown h1,
+.fv-markdown h2,
+.fv-markdown h3 {
+    margin-top: 1.2em;
+    margin-bottom: .5em;
+}
+
+.fv-markdown pre {
+    background: var(--fg-a05);
+    border-radius: 6px;
+    padding: 10px 12px;
+    overflow-x: auto;
+}
+
+.fv-markdown code {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: .88em;
+}
+
+.fv-markdown blockquote {
+    border-left: 3px solid var(--fg-a16);
+    margin: .8em 0;
+    padding: .4em .8em;
+    color: var(--fg-muted);
+}
+
+/* ── File Nav ──────────────────────────────────────────────────────────── */
+
+file-nav {
+    display: block;
+    position: relative;
+}
+
+.fn-bar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--fg-a08);
+    min-height: 32px;
+}
+
+.fn-toggle {
+    border: none;
+    background: transparent;
+    color: var(--fg-muted);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+}
+
+.fn-toggle:hover {
+    background: var(--fg-a08);
+    color: var(--fg);
+}
+
+.fn-breadcrumb {
+    flex: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: .82em;
+    color: var(--fg-muted);
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+
+.fn-sep {
+    color: var(--fg-a16);
+    margin: 0 1px;
+}
+
+.fn-crumb {
+    color: var(--fg-muted);
+}
+
+.fn-clickable {
+    cursor: pointer;
+    color: var(--user, #79c0ff);
+}
+
+.fn-clickable:hover {
+    text-decoration: underline;
+}
+
+.fn-dropdown {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 100%;
+    z-index: 50;
+    background: var(--bg);
+    border-bottom: 1px solid var(--fg-a16);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, .2);
+    max-height: 60vh;
+    display: none;
+    flex-direction: column;
+}
+
+.fn-dropdown.fn-open {
+    display: flex;
+}
+
+.fn-search-row {
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--fg-a08);
+}
+
+.fn-search {
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid var(--fg-a16);
+    background: var(--fg-a05);
+    color: var(--fg);
+    padding: 4px 8px;
+    border-radius: 4px;
+    font: inherit;
+    font-size: .85em;
+    outline: none;
+}
+
+.fn-search:focus {
+    border-color: var(--user, #79c0ff);
+}
+
+.fn-list {
+    overflow-y: auto;
+    flex: 1;
+    padding: 4px 0;
+}
+
+.fn-entry {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 12px;
+    cursor: pointer;
+    font-size: .88em;
+}
+
+.fn-entry:hover {
+    background: var(--fg-a08);
+}
+
+.fn-icon {
+    flex: 0 0 auto;
+    font-size: .9em;
+}
+
+.fn-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.fn-dir .fn-name {
+    color: var(--fg);
+    font-weight: 500;
+}
+
+.fn-file .fn-name {
+    color: var(--fg-muted);
+}
+
+.fn-loading, .fn-error {
+    padding: 12px;
+    text-align: center;
+    font-size: .85em;
+    color: var(--fg-muted);
+}
+
+.fn-error {
+    color: var(--error, #e06c75);
+}
+
+/* ── Syntax highlighting theme ─────────────────────────────────────────── */
+
+.sh-kw {
+    color: var(--sh-keyword, #c678dd);
+}
+
+.sh-str {
+    color: var(--sh-string, #98c379);
+}
+
+.sh-cmt {
+    color: var(--sh-comment, #5c6370);
+    font-style: italic;
+}
+
+.sh-num {
+    color: var(--sh-number, #d19a66);
+}
+
+.sh-pun {
+    color: var(--fg-muted);
+}
+
+.sh-tag {
+    color: var(--sh-tag, #e06c75);
+}
+
+.sh-attr {
+    color: var(--sh-attr, #d19a66);
+}
+
+.sh-key {
+    color: var(--sh-key, #e06c75);
+}
+
+.sh-prop {
+    color: var(--sh-prop, #61afef);
+}
+
+.light .sh-kw {
+    color: var(--sh-keyword, #a626a4);
+}
+
+.light .sh-str {
+    color: var(--sh-string, #50a14f);
+}
+
+.light .sh-cmt {
+    color: var(--sh-comment, #a0a1a7);
+    font-style: italic;
+}
+
+.light .sh-num {
+    color: var(--sh-number, #986801);
+}
+
+.light .sh-tag {
+    color: var(--sh-tag, #e45649);
+}
+
+.light .sh-attr {
+    color: var(--sh-attr, #986801);
+}
+
+.light .sh-key {
+    color: var(--sh-key, #e45649);
+}
+
+.light .sh-prop {
+    color: var(--sh-prop, #4078f2);
+}
+
 /* ── Narrow-screen header ───────────────────────────────────────────────── */
 
 @media (max-width: 480px) {
     #ab-model {
         display: none;
     }
+}
+
+/* ── Review View ───────────────────────────────────────── */
+.rv-container {
+    padding: 12px;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.rv-empty {
+    color: var(--muted);
+    text-align: center;
+    padding: 40px 16px;
+}
+
+.rv-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+    font-size: 13px;
+}
+
+.rv-status {
+    font-weight: bold;
+    width: 16px;
+    text-align: center;
+}
+
+.rv-added .rv-status {
+    color: var(--green, #2ea043);
+}
+
+.rv-modified .rv-status {
+    color: var(--blue, #388bfd);
+}
+
+.rv-deleted .rv-status {
+    color: var(--muted);
+}
+
+.rv-path {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.rv-dir {
+    color: var(--muted);
+}
+
+.rv-diff {
+    display: flex;
+    gap: 6px;
+    font-size: 12px;
+    font-family: monospace;
+}
+
+.rv-add {
+    color: var(--green, #2ea043);
+}
+
+.rv-rem {
+    color: var(--red, #f85149);
+}
+
+.rv-check {
+    color: var(--green, #2ea043);
+    font-weight: bold;
+}
+
+.rv-approved {
+    opacity: 0.7;
+}
+
+/* ── Todo View ─────────────────────────────────────────── */
+.tv-container {
+    padding: 12px;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.tv-empty {
+    color: var(--muted);
+    text-align: center;
+    padding: 40px 16px;
+}
+
+.tv-content {
+    line-height: 1.5;
+}
+
+.tv-content h1, .tv-content h2, .tv-content h3 {
+    margin: 16px 0 8px;
+}
+
+.tv-content h1 {
+    font-size: 20px;
+}
+
+.tv-content h2 {
+    font-size: 17px;
+}
+
+.tv-content h3 {
+    font-size: 15px;
+}
+
+.tv-content pre {
+    background: var(--input-bg, #161b22);
+    padding: 12px;
+    border-radius: 6px;
+    overflow-x: auto;
+    font-size: 13px;
+    margin: 8px 0;
+}
+
+.tv-content code {
+    font-size: 13px;
+}
+
+.tv-content p {
+    margin: 4px 0;
+}
+
+.tv-check {
+    padding: 2px 0;
+}
+
+.tv-done {
+    color: var(--muted);
+    text-decoration: line-through;
+}
+
+.tv-pending {
+}
+
+.tv-li {
+    padding: 2px 0 2px 8px;
+}
+
+/* ── Session View ──────────────────────────────────────── */
+.sv-container {
+    padding: 12px;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.sv-content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.sv-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--input-bg, #161b22);
+    border-radius: 8px;
+}
+
+.sv-dot {
+    font-size: 16px;
+}
+
+.sv-label {
+    font-weight: 600;
+}
+
+.sv-key {
+    color: var(--muted);
+    min-width: 80px;
+}
+
+.sv-val {
+}
+
+.sv-offline {
+    opacity: 0.6;
 }

--- a/plugin-core/chat-ui/src/web-app.ts
+++ b/plugin-core/chat-ui/src/web-app.ts
@@ -12,6 +12,8 @@ import {FileViewer} from './components/FileViewer';
 import {FileNav} from './components/FileNav';
 import {ReviewView} from './components/ReviewView';
 import {TodoView} from './components/TodoView';
+import {ToolCallsView} from './components/ToolCallsView';
+import {SearchView} from './components/SearchView';
 import {SessionView} from './components/SessionView';
 
 // Register PWA-only custom elements
@@ -20,6 +22,8 @@ customElements.define('file-viewer', FileViewer);
 customElements.define('file-nav', FileNav);
 customElements.define('review-view', ReviewView);
 customElements.define('todo-view', TodoView);
+customElements.define('tool-calls-view', ToolCallsView);
+customElements.define('search-view', SearchView);
 customElements.define('session-view', SessionView);
 
 // ── Bridge: replaces native Kotlin bridge with fetch-based implementations ──
@@ -173,17 +177,27 @@ requestAnimationFrame(() => {
         // Refresh the view when switching to it
         if (index === 2) reviewView.refresh();
         else if (index === 3) todoView.refresh();
-        else if (index === 4) sessionView.refresh();
+        else if (index === 4) toolCallsView.refresh();
+        else if (index === 5) searchView.refresh();
+        else if (index === 6) sessionView.refresh();
     });
 
-    // Add side panel panes
-    const reviewPane = swiper.addPane('Review');
+    // Add side panel panes mirroring the IDE side panel tabs.
+    const reviewPane = swiper.addPane('Diff');
     const reviewView = document.createElement('review-view') as ReviewView;
     reviewPane.appendChild(reviewView);
 
-    const todoPane = swiper.addPane('Plan');
+    const todoPane = swiper.addPane('Todo');
     const todoView = document.createElement('todo-view') as TodoView;
     todoPane.appendChild(todoView);
+
+    const toolsPane = swiper.addPane('Tools');
+    const toolCallsView = document.createElement('tool-calls-view') as ToolCallsView;
+    toolsPane.appendChild(toolCallsView);
+
+    const searchPane = swiper.addPane('Search');
+    const searchView = document.createElement('search-view') as SearchView;
+    searchPane.appendChild(searchView);
 
     const sessionPane = swiper.addPane('Session');
     const sessionView = document.createElement('session-view') as SessionView;

--- a/plugin-core/chat-ui/src/web-app.ts
+++ b/plugin-core/chat-ui/src/web-app.ts
@@ -7,6 +7,15 @@
 
 /// <reference path="./globals.d.ts" />
 
+import { PaneSwiper } from './components/PaneSwiper';
+import { FileViewer } from './components/FileViewer';
+import { FileNav } from './components/FileNav';
+
+// Register PWA-only custom elements
+customElements.define('pane-swiper', PaneSwiper);
+customElements.define('file-viewer', FileViewer);
+customElements.define('file-nav', FileNav);
+
 // ── Bridge: replaces native Kotlin bridge with fetch-based implementations ──
 
 globalThis._bridge = {
@@ -68,6 +77,88 @@ const mcpText = document.getElementById('ab-mcp-text')!;
 const chatAreaEl = document.getElementById('ab-chat')!;
 const footerEl = document.getElementById('ab-footer')!;
 const menuModelSection = document.getElementById('ab-menu-model-section')!;
+
+// ── Pane swiper: file viewer (left) + chat (right) ─────────────────────────
+
+const swiper = document.createElement('pane-swiper') as PaneSwiper;
+chatAreaEl.parentElement!.insertBefore(swiper, chatAreaEl);
+
+// Wait for custom element to initialize
+requestAnimationFrame(() => {
+    // Move chat area into the right pane
+    swiper.rightPane.appendChild(chatAreaEl);
+
+    // Create file viewer in the left pane
+    const fileViewer = document.createElement('file-viewer') as FileViewer;
+    swiper.leftPane.appendChild(fileViewer);
+
+    // Create and attach file nav inside the viewer
+    const fileNav = document.createElement('file-nav') as FileNav;
+    fileViewer.navSlot.appendChild(fileNav);
+
+    // Wire file nav to the server endpoints
+    fileNav.configure(
+        async (dir: string) => {
+            const resp = await fetch(`/list-files?path=${encodeURIComponent(dir)}`);
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            const data = await resp.json() as { entries: Array<{ name: string; path: string; isDirectory: boolean; size?: number }> };
+            return data.entries;
+        },
+        (path: string) => openFileInViewer(path),
+    );
+
+    // Handle clicks on recent files in the file viewer empty state
+    fileViewer.addEventListener('open-file', (e) => {
+        const path = (e as CustomEvent).detail?.path;
+        if (path) openFileInViewer(path);
+    });
+
+    // Override bridge.openFile to fetch and display in the viewer
+    globalThis._bridge!.openFile = (href: string) => {
+        let path = href;
+        let line: number | undefined;
+        if (path.startsWith('openfile://')) {
+            path = path.substring('openfile://'.length);
+        }
+        // Extract line number: path:42
+        const colonIdx = path.lastIndexOf(':');
+        if (colonIdx > 0) {
+            const maybeLine = Number.parseInt(path.substring(colonIdx + 1), 10);
+            if (!Number.isNaN(maybeLine)) {
+                line = maybeLine;
+                path = path.substring(0, colonIdx);
+            }
+        }
+        openFileInViewer(path, line);
+    };
+
+    async function openFileInViewer(path: string, line?: number): Promise<void> {
+        try {
+            const resp = await fetch(`/file?path=${encodeURIComponent(path)}`);
+            if (!resp.ok) {
+                console.error(`[AB] File fetch failed: HTTP ${resp.status} for ${path}`);
+                return;
+            }
+            const data = await resp.json() as { content: string; path: string };
+            fileViewer.showFile(data.path, data.content);
+            fileNav.showPath(data.path);
+            swiper.switchTo(0); // Switch to file viewer pane
+            if (line) {
+                requestAnimationFrame(() => fileViewer.scrollToLine(line));
+            }
+        } catch (e) {
+            console.error('[AB] File fetch error:', e);
+        }
+    }
+
+    // Listen for pane changes to re-focus appropriately
+    swiper.addEventListener('pane-changed', (e) => {
+        if ((e as CustomEvent).detail?.index === 1) {
+            // Switched back to chat — re-enable input focus
+            inputEl.focus();
+        }
+    });
+});
 
 // ── Auto-scroll: track whether user is near the bottom ──────────────────────
 

--- a/plugin-core/chat-ui/src/web-app.ts
+++ b/plugin-core/chat-ui/src/web-app.ts
@@ -153,8 +153,9 @@ requestAnimationFrame(() => {
 
     // Listen for pane changes to re-focus appropriately
     swiper.addEventListener('pane-changed', (e) => {
-        if ((e as CustomEvent).detail?.index === 1) {
-            // Switched back to chat — re-enable input focus
+        const index = (e as CustomEvent).detail?.index;
+        footerEl.style.display = index === 0 ? 'none' : '';
+        if (index === 1) {
             inputEl.focus();
         }
     });

--- a/plugin-core/chat-ui/src/web-app.ts
+++ b/plugin-core/chat-ui/src/web-app.ts
@@ -7,6 +7,21 @@
 
 /// <reference path="./globals.d.ts" />
 
+import {PaneSwiper} from './components/PaneSwiper';
+import {FileViewer} from './components/FileViewer';
+import {FileNav} from './components/FileNav';
+import {ReviewView} from './components/ReviewView';
+import {TodoView} from './components/TodoView';
+import {SessionView} from './components/SessionView';
+
+// Register PWA-only custom elements
+customElements.define('pane-swiper', PaneSwiper);
+customElements.define('file-viewer', FileViewer);
+customElements.define('file-nav', FileNav);
+customElements.define('review-view', ReviewView);
+customElements.define('todo-view', TodoView);
+customElements.define('session-view', SessionView);
+
 // ── Bridge: replaces native Kotlin bridge with fetch-based implementations ──
 
 globalThis._bridge = {
@@ -68,6 +83,112 @@ const mcpText = document.getElementById('ab-mcp-text')!;
 const chatAreaEl = document.getElementById('ab-chat')!;
 const footerEl = document.getElementById('ab-footer')!;
 const menuModelSection = document.getElementById('ab-menu-model-section')!;
+
+// ── Pane swiper: file viewer (left) + chat (right) ─────────────────────────
+
+const swiper = document.createElement('pane-swiper') as PaneSwiper;
+chatAreaEl.parentElement!.insertBefore(swiper, chatAreaEl);
+
+// Wait for custom element to initialize
+requestAnimationFrame(() => {
+    // Move chat area into the right pane
+    swiper.rightPane.appendChild(chatAreaEl);
+
+    // Set labels on existing panes
+    swiper.setTabLabel(0, 'Files');
+    swiper.setTabLabel(1, 'Chat');
+
+    // Create file viewer in the left pane
+    const fileViewer = document.createElement('file-viewer') as FileViewer;
+    swiper.leftPane.appendChild(fileViewer);
+
+    // Create and attach file nav inside the viewer
+    const fileNav = document.createElement('file-nav') as FileNav;
+    fileViewer.navSlot.appendChild(fileNav);
+
+    // Wire file nav to the server endpoints
+    fileNav.configure(
+        async (dir: string) => {
+            const resp = await fetch(`/list-files?path=${encodeURIComponent(dir)}`);
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            const data = await resp.json() as {
+                entries: Array<{ name: string; path: string; isDirectory: boolean; size?: number }>
+            };
+            return data.entries;
+        },
+        (path: string) => openFileInViewer(path),
+    );
+
+    // Handle clicks on recent files in the file viewer empty state
+    fileViewer.addEventListener('open-file', (e) => {
+        const path = (e as CustomEvent).detail?.path;
+        if (path) openFileInViewer(path);
+    });
+
+    // Override bridge.openFile to fetch and display in the viewer
+    globalThis._bridge!.openFile = (href: string) => {
+        let path = href;
+        let line: number | undefined;
+        if (path.startsWith('openfile://')) {
+            path = path.substring('openfile://'.length);
+        }
+        // Extract line number: path:42
+        const colonIdx = path.lastIndexOf(':');
+        if (colonIdx > 0) {
+            const maybeLine = Number.parseInt(path.substring(colonIdx + 1), 10);
+            if (!Number.isNaN(maybeLine)) {
+                line = maybeLine;
+                path = path.substring(0, colonIdx);
+            }
+        }
+        openFileInViewer(path, line);
+    };
+
+    async function openFileInViewer(path: string, line?: number): Promise<void> {
+        try {
+            const resp = await fetch(`/file?path=${encodeURIComponent(path)}`);
+            if (!resp.ok) {
+                console.error(`[AB] File fetch failed: HTTP ${resp.status} for ${path}`);
+                return;
+            }
+            const data = await resp.json() as { content: string; path: string };
+            fileViewer.showFile(data.path, data.content);
+            fileNav.showPath(data.path);
+            swiper.switchTo(0); // Switch to file viewer pane
+            if (line) {
+                requestAnimationFrame(() => fileViewer.scrollToLine(line));
+            }
+        } catch (e) {
+            console.error('[AB] File fetch error:', e);
+        }
+    }
+
+    // Listen for pane changes to re-focus appropriately
+    swiper.addEventListener('pane-changed', (e) => {
+        const index = (e as CustomEvent).detail?.index;
+        footerEl.style.display = index === 1 ? '' : 'none';
+        if (index === 1) {
+            inputEl.focus();
+        }
+        // Refresh the view when switching to it
+        if (index === 2) reviewView.refresh();
+        else if (index === 3) todoView.refresh();
+        else if (index === 4) sessionView.refresh();
+    });
+
+    // Add side panel panes
+    const reviewPane = swiper.addPane('Review');
+    const reviewView = document.createElement('review-view') as ReviewView;
+    reviewPane.appendChild(reviewView);
+
+    const todoPane = swiper.addPane('Plan');
+    const todoView = document.createElement('todo-view') as TodoView;
+    todoPane.appendChild(todoView);
+
+    const sessionPane = swiper.addPane('Session');
+    const sessionView = document.createElement('session-view') as SessionView;
+    sessionPane.appendChild(sessionView);
+});
 
 // ── Auto-scroll: track whether user is near the bottom ──────────────────────
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
@@ -2,10 +2,13 @@ package com.github.catatafishen.agentbridge.services;
 
 import com.github.catatafishen.agentbridge.BuildInfo;
 import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
+import com.github.catatafishen.agentbridge.session.v2.SessionStoreV2;
 import com.github.catatafishen.agentbridge.settings.ChatHistorySettings;
 import com.github.catatafishen.agentbridge.settings.ChatWebServerSettings;
 import com.github.catatafishen.agentbridge.ui.ChatTheme;
+import com.github.catatafishen.agentbridge.ui.EntryData;
 import com.github.catatafishen.agentbridge.ui.MessageFormatter;
+import com.github.catatafishen.agentbridge.ui.side.TodoDatabaseReader;
 import com.google.gson.Gson;
 import com.intellij.credentialStore.CredentialAttributes;
 import com.intellij.credentialStore.Credentials;
@@ -458,6 +461,9 @@ public final class ChatWebServer implements Disposable {
         server.createContext("/file", this::handleFileRead);
         server.createContext("/list-files", this::handleListFiles);
         server.createContext("/plan", this::handlePlan);
+        server.createContext("/todos", this::handleTodos);
+        server.createContext("/prompts", this::handlePrompts);
+        server.createContext("/tool-calls", this::handleToolCalls);
         server.createContext("/session-stats", this::handleSessionStats);
         server.createContext("/review-items", this::handleReviewItems);
     }
@@ -1718,6 +1724,105 @@ public final class ChatWebServer implements Disposable {
             LOG.warn("handlePlan error", e);
             sendJson(exchange, "{\"content\":null}");
         }
+    }
+
+    private void handleTodos(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().set(HDR_ACCESS_CONTROL_ORIGIN, "*");
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+            return;
+        }
+        try {
+            java.nio.file.Path sessionDir = resolveAgentSessionDir();
+            com.google.gson.JsonArray arr = new com.google.gson.JsonArray();
+            if (sessionDir != null) {
+                java.io.File dbFile = sessionDir.resolve("session.db").toFile();
+                for (TodoDatabaseReader.TodoItem item : TodoDatabaseReader.readTodos(dbFile)) {
+                    com.google.gson.JsonObject obj = new com.google.gson.JsonObject();
+                    obj.addProperty("id", item.id());
+                    obj.addProperty("title", item.title());
+                    obj.addProperty("description", item.description());
+                    obj.addProperty("status", item.status());
+                    obj.addProperty("createdAt", item.createdAt());
+                    obj.addProperty("updatedAt", item.updatedAt());
+                    arr.add(obj);
+                }
+            }
+            com.google.gson.JsonObject json = new com.google.gson.JsonObject();
+            json.add("items", arr);
+            sendJson(exchange, GSON.toJson(json));
+        } catch (Exception e) {
+            LOG.warn("handleTodos error", e);
+            sendJson(exchange, "{\"items\":[]}");
+        }
+    }
+
+    private void handlePrompts(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().set(HDR_ACCESS_CONTROL_ORIGIN, "*");
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+            return;
+        }
+        try {
+            com.google.gson.JsonArray arr = new com.google.gson.JsonArray();
+            for (EntryData entry : loadSessionEntries()) {
+                if (entry instanceof EntryData.Prompt prompt) {
+                    com.google.gson.JsonObject obj = new com.google.gson.JsonObject();
+                    obj.addProperty("id", prompt.getEntryId());
+                    obj.addProperty("text", prompt.getText());
+                    obj.addProperty("timestamp", prompt.getTimestamp());
+                    arr.add(obj);
+                }
+            }
+            com.google.gson.JsonObject json = new com.google.gson.JsonObject();
+            json.add("items", arr);
+            sendJson(exchange, GSON.toJson(json));
+        } catch (Exception e) {
+            LOG.warn("handlePrompts error", e);
+            sendJson(exchange, "{\"items\":[]}");
+        }
+    }
+
+    private void handleToolCalls(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().set(HDR_ACCESS_CONTROL_ORIGIN, "*");
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+            return;
+        }
+        try {
+            com.google.gson.JsonArray arr = new com.google.gson.JsonArray();
+            for (EntryData entry : loadSessionEntries()) {
+                if (entry instanceof EntryData.ToolCall toolCall) {
+                    com.google.gson.JsonObject obj = new com.google.gson.JsonObject();
+                    obj.addProperty("id", toolCall.getEntryId());
+                    obj.addProperty("title", toolCall.getTitle());
+                    obj.addProperty("kind", toolCall.getKind());
+                    obj.addProperty("status", toolCall.getStatus());
+                    obj.addProperty("timestamp", toolCall.getTimestamp());
+                    obj.addProperty("arguments", toolCall.getArguments());
+                    obj.addProperty("result", toolCall.getResult());
+                    arr.add(obj);
+                }
+            }
+            com.google.gson.JsonObject json = new com.google.gson.JsonObject();
+            json.add("items", arr);
+            sendJson(exchange, GSON.toJson(json));
+        } catch (Exception e) {
+            LOG.warn("handleToolCalls error", e);
+            sendJson(exchange, "{\"items\":[]}");
+        }
+    }
+
+    private @NotNull List<EntryData> loadSessionEntries() {
+        List<EntryData> entries = SessionStoreV2.getInstance(project).loadEntries(project.getBasePath());
+        return entries != null ? entries : Collections.emptyList();
+    }
+
+    private @Nullable java.nio.file.Path resolveAgentSessionDir() {
+        return ActiveAgentManager.getInstance(project).getClient().getSessionDirectory();
     }
 
     private void handleSessionStats(HttpExchange exchange) throws IOException {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
@@ -362,6 +362,8 @@ public final class ChatWebServer implements Disposable {
         server.createContext("/load-more", ex -> handleAction(ex, body -> {
             if (onLoadMore != null) onLoadMore.run();
         }));
+        server.createContext("/file", this::handleFileRead);
+        server.createContext("/list-files", this::handleListFiles);
     }
 
     private void registerCertOnlyContext(HttpServer server) {
@@ -1250,6 +1252,154 @@ public final class ChatWebServer implements Disposable {
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private void handleFileRead(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().set("Access-Control-Allow-Origin", "*");
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+            return;
+        }
+
+        String query = exchange.getRequestURI().getQuery();
+        String path = null;
+        if (query != null) {
+            for (String param : query.split("&")) {
+                if (param.startsWith("path=")) {
+                    path = java.net.URLDecoder.decode(param.substring(5), StandardCharsets.UTF_8);
+                }
+            }
+        }
+        if (path == null || path.isEmpty()) {
+            String error = "{\"error\":\"Missing 'path' query parameter\"}";
+            sendJson(exchange, error);
+            return;
+        }
+
+        String basePath = project.getBasePath();
+        if (basePath == null) {
+            sendJson(exchange, "{\"error\":\"Project base path not available\"}");
+            return;
+        }
+
+        java.nio.file.Path projectRoot = java.nio.file.Path.of(basePath);
+        java.nio.file.Path resolved = projectRoot.resolve(path).normalize();
+
+        // Security: prevent path traversal outside project root
+        if (!resolved.startsWith(projectRoot)) {
+            exchange.sendResponseHeaders(403, -1);
+            exchange.close();
+            return;
+        }
+
+        if (!java.nio.file.Files.isRegularFile(resolved)) {
+            String error = "{\"error\":\"File not found: " + path.replace("\"", "\\\"") + "\"}";
+            byte[] bytes = error.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+            exchange.sendResponseHeaders(404, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.close();
+            return;
+        }
+
+        // Limit file size to 1 MB to avoid memory issues
+        long size = java.nio.file.Files.size(resolved);
+        if (size > 1_048_576) {
+            sendJson(exchange, "{\"error\":\"File too large (max 1 MB)\"}");
+            return;
+        }
+
+        String content = java.nio.file.Files.readString(resolved, StandardCharsets.UTF_8);
+        String relativePath = projectRoot.relativize(resolved).toString().replace('\\', '/');
+
+        com.google.gson.JsonObject json = new com.google.gson.JsonObject();
+        json.addProperty("path", relativePath);
+        json.addProperty("content", content);
+        json.addProperty("size", size);
+        sendJson(exchange, GSON.toJson(json));
+    }
+
+    private void handleListFiles(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().set("Access-Control-Allow-Origin", "*");
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+            return;
+        }
+
+        String query = exchange.getRequestURI().getQuery();
+        String path = "";
+        if (query != null) {
+            for (String param : query.split("&")) {
+                if (param.startsWith("path=")) {
+                    path = java.net.URLDecoder.decode(param.substring(5), StandardCharsets.UTF_8);
+                }
+            }
+        }
+
+        String basePath = project.getBasePath();
+        if (basePath == null) {
+            sendJson(exchange, "{\"error\":\"Project base path not available\"}");
+            return;
+        }
+
+        java.nio.file.Path projectRoot = java.nio.file.Path.of(basePath);
+        java.nio.file.Path dir = path.isEmpty() ? projectRoot : projectRoot.resolve(path).normalize();
+
+        // Security: prevent path traversal outside project root
+        if (!dir.startsWith(projectRoot)) {
+            exchange.sendResponseHeaders(403, -1);
+            exchange.close();
+            return;
+        }
+
+        if (!java.nio.file.Files.isDirectory(dir)) {
+            sendJson(exchange, "{\"error\":\"Not a directory\"}");
+            return;
+        }
+
+        com.google.gson.JsonArray entries = new com.google.gson.JsonArray();
+        try (var stream = java.nio.file.Files.list(dir)) {
+            stream
+                .filter(p -> !p.getFileName().toString().startsWith("."))
+                .filter(p -> !isExcludedDir(p))
+                .sorted((a, b) -> {
+                    boolean aDir = java.nio.file.Files.isDirectory(a);
+                    boolean bDir = java.nio.file.Files.isDirectory(b);
+                    if (aDir != bDir) return aDir ? -1 : 1;
+                    return a.getFileName().toString().compareToIgnoreCase(b.getFileName().toString());
+                })
+                .forEach(p -> {
+                    com.google.gson.JsonObject entry = new com.google.gson.JsonObject();
+                    String name = p.getFileName().toString();
+                    String relPath = projectRoot.relativize(p).toString().replace('\\', '/');
+                    entry.addProperty("name", name);
+                    entry.addProperty("path", relPath);
+                    entry.addProperty("isDirectory", java.nio.file.Files.isDirectory(p));
+                    if (java.nio.file.Files.isRegularFile(p)) {
+                        try {
+                            entry.addProperty("size", java.nio.file.Files.size(p));
+                        } catch (IOException ignored) {
+                            // Size unavailable — omit
+                        }
+                    }
+                    entries.add(entry);
+                });
+        }
+
+        com.google.gson.JsonObject result = new com.google.gson.JsonObject();
+        result.addProperty("path", path.isEmpty() ? "." : path);
+        result.add("entries", entries);
+        sendJson(exchange, GSON.toJson(result));
+    }
+
+    private static boolean isExcludedDir(java.nio.file.Path p) {
+        if (!java.nio.file.Files.isDirectory(p)) return false;
+        String name = p.getFileName().toString();
+        return "node_modules".equals(name) || "build".equals(name) || "out".equals(name)
+            || ".gradle".equals(name) || ".git".equals(name) || ".idea".equals(name)
+            || "dist".equals(name) || "__pycache__".equals(name) || "target".equals(name);
+    }
 
     private void broadcast(String json) {
         for (SseClient c : sseClients) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
@@ -79,6 +79,7 @@ public final class ChatWebServer implements Disposable {
     private static final Logger LOG = Logger.getInstance(ChatWebServer.class);
     private static final Gson GSON = new Gson();
     private static final String JS_CONTENT_TYPE = "text/javascript; charset=utf-8";
+    private static final String JSON_CONTENT_TYPE = "application/json; charset=utf-8";
     private static final String SEQ_PREFIX = "{\"seq\":";
     private static final String HDR_CONTENT_TYPE = "Content-Type";
     private static final String HDR_CACHE_CONTROL = "Cache-Control";
@@ -396,7 +397,7 @@ public final class ChatWebServer implements Disposable {
         server.createContext("/icon-192.png", ex -> handleIconPng(ex, 192));
         server.createContext("/icon-512.png", ex -> handleIconPng(ex, 512));
         server.createContext("/badge-96.png", this::handleBadgePng);
-        server.createContext("/manifest.json", ex -> serveClasspath(ex, "/chat/manifest.json", "application/json; charset=utf-8"));
+        server.createContext("/manifest.json", ex -> serveClasspath(ex, "/chat/manifest.json", JSON_CONTENT_TYPE));
         server.createContext("/sw.js", ex -> serveClasspath(ex, "/chat/sw.js", JS_CONTENT_TYPE));
         server.createContext("/cert.crt", this::handleCert);
         server.createContext("/events", this::handleSse);
@@ -454,6 +455,11 @@ public final class ChatWebServer implements Disposable {
         server.createContext("/load-more", ex -> handleAction(ex, body -> {
             if (onLoadMore != null) onLoadMore.run();
         }));
+        server.createContext("/file", this::handleFileRead);
+        server.createContext("/list-files", this::handleListFiles);
+        server.createContext("/plan", this::handlePlan);
+        server.createContext("/session-stats", this::handleSessionStats);
+        server.createContext("/review-items", this::handleReviewItems);
     }
 
     private void registerCertOnlyContext(HttpServer server) {
@@ -1528,12 +1534,233 @@ public final class ChatWebServer implements Disposable {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
+    private void handleFileRead(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().set(HDR_ACCESS_CONTROL_ORIGIN, "*");
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+            return;
+        }
+
+        String query = exchange.getRequestURI().getQuery();
+        String path = null;
+        if (query != null) {
+            for (String param : query.split("&")) {
+                if (param.startsWith("path=")) {
+                    path = java.net.URLDecoder.decode(param.substring(5), StandardCharsets.UTF_8);
+                }
+            }
+        }
+        if (path == null || path.isEmpty()) {
+            String error = "{\"error\":\"Missing 'path' query parameter\"}";
+            sendJson(exchange, error);
+            return;
+        }
+
+        String basePath = project.getBasePath();
+        if (basePath == null) {
+            sendJson(exchange, "{\"error\":\"Project base path not available\"}");
+            return;
+        }
+
+        java.nio.file.Path projectRoot = java.nio.file.Path.of(basePath);
+        java.nio.file.Path resolved = projectRoot.resolve(path).normalize();
+
+        // Security: prevent path traversal outside project root
+        if (!resolved.startsWith(projectRoot)) {
+            exchange.sendResponseHeaders(403, -1);
+            exchange.close();
+            return;
+        }
+
+        if (!java.nio.file.Files.isRegularFile(resolved)) {
+            String error = "{\"error\":\"File not found: " + path.replace("\"", "\\\"") + "\"}";
+            byte[] bytes = error.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set(HDR_CONTENT_TYPE, JSON_CONTENT_TYPE);
+            exchange.sendResponseHeaders(404, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.close();
+            return;
+        }
+
+        // Limit file size to 1 MB to avoid memory issues
+        long size = java.nio.file.Files.size(resolved);
+        if (size > 1_048_576) {
+            sendJson(exchange, "{\"error\":\"File too large (max 1 MB)\"}");
+            return;
+        }
+
+        String content = java.nio.file.Files.readString(resolved, StandardCharsets.UTF_8);
+        String relativePath = projectRoot.relativize(resolved).toString().replace('\\', '/');
+
+        com.google.gson.JsonObject json = new com.google.gson.JsonObject();
+        json.addProperty("path", relativePath);
+        json.addProperty("content", content);
+        json.addProperty("size", size);
+        sendJson(exchange, GSON.toJson(json));
+    }
+
+    private void handleListFiles(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().set(HDR_ACCESS_CONTROL_ORIGIN, "*");
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+            return;
+        }
+
+        String query = exchange.getRequestURI().getQuery();
+        String path = "";
+        if (query != null) {
+            for (String param : query.split("&")) {
+                if (param.startsWith("path=")) {
+                    path = java.net.URLDecoder.decode(param.substring(5), StandardCharsets.UTF_8);
+                }
+            }
+        }
+
+        String basePath = project.getBasePath();
+        if (basePath == null) {
+            sendJson(exchange, "{\"error\":\"Project base path not available\"}");
+            return;
+        }
+
+        java.nio.file.Path projectRoot = java.nio.file.Path.of(basePath);
+        java.nio.file.Path dir = path.isEmpty() ? projectRoot : projectRoot.resolve(path).normalize();
+
+        // Security: prevent path traversal outside project root
+        if (!dir.startsWith(projectRoot)) {
+            exchange.sendResponseHeaders(403, -1);
+            exchange.close();
+            return;
+        }
+
+        if (!java.nio.file.Files.isDirectory(dir)) {
+            sendJson(exchange, "{\"error\":\"Not a directory\"}");
+            return;
+        }
+
+        com.google.gson.JsonArray entries = new com.google.gson.JsonArray();
+        try (var stream = java.nio.file.Files.list(dir)) {
+            stream
+                .filter(p -> !p.getFileName().toString().startsWith("."))
+                .filter(p -> !isExcludedDir(p))
+                .sorted((a, b) -> {
+                    boolean aDir = java.nio.file.Files.isDirectory(a);
+                    boolean bDir = java.nio.file.Files.isDirectory(b);
+                    if (aDir != bDir) return aDir ? -1 : 1;
+                    return a.getFileName().toString().compareToIgnoreCase(b.getFileName().toString());
+                })
+                .forEach(p -> {
+                    com.google.gson.JsonObject entry = new com.google.gson.JsonObject();
+                    String name = p.getFileName().toString();
+                    String relPath = projectRoot.relativize(p).toString().replace('\\', '/');
+                    entry.addProperty("name", name);
+                    entry.addProperty("path", relPath);
+                    entry.addProperty("isDirectory", java.nio.file.Files.isDirectory(p));
+                    if (java.nio.file.Files.isRegularFile(p)) {
+                        try {
+                            entry.addProperty("size", java.nio.file.Files.size(p));
+                        } catch (IOException ignored) {
+                            // Size unavailable — omit
+                        }
+                    }
+                    entries.add(entry);
+                });
+        }
+
+        com.google.gson.JsonObject result = new com.google.gson.JsonObject();
+        result.addProperty("path", path.isEmpty() ? "." : path);
+        result.add("entries", entries);
+        sendJson(exchange, GSON.toJson(result));
+    }
+
+    private static boolean isExcludedDir(java.nio.file.Path p) {
+        if (!java.nio.file.Files.isDirectory(p)) return false;
+        String name = p.getFileName().toString();
+        return "node_modules".equals(name) || "build".equals(name) || "out".equals(name)
+            || ".gradle".equals(name) || ".git".equals(name) || ".idea".equals(name)
+            || "dist".equals(name) || "__pycache__".equals(name) || "target".equals(name);
+    }
+
     private void broadcast(String json) {
         for (SseClient c : sseClients) {
             if (!c.offer(json)) {
                 LOG.info("SSE event dropped for a client — queue full (capacity 300). " +
                     "PWA may show stale or incomplete content.");
             }
+        }
+    }
+
+    private void handlePlan(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().set(HDR_ACCESS_CONTROL_ORIGIN, "*");
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+            return;
+        }
+        try {
+            ActiveAgentManager manager = ActiveAgentManager.getInstance(project);
+            java.nio.file.Path sessionDir = manager.getClient().getSessionDirectory();
+            if (sessionDir == null) {
+                sendJson(exchange, "{\"content\":null}");
+                return;
+            }
+            java.nio.file.Path planFile = sessionDir.resolve("plan.md");
+            if (!java.nio.file.Files.isRegularFile(planFile)) {
+                sendJson(exchange, "{\"content\":null}");
+                return;
+            }
+            String content = java.nio.file.Files.readString(planFile, java.nio.charset.StandardCharsets.UTF_8);
+            com.google.gson.JsonObject json = new com.google.gson.JsonObject();
+            json.addProperty("content", content);
+            sendJson(exchange, GSON.toJson(json));
+        } catch (Exception e) {
+            LOG.warn("handlePlan error", e);
+            sendJson(exchange, "{\"content\":null}");
+        }
+    }
+
+    private void handleSessionStats(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().set(HDR_ACCESS_CONTROL_ORIGIN, "*");
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+            return;
+        }
+        com.google.gson.JsonObject json = new com.google.gson.JsonObject();
+        json.addProperty("isRunning", agentRunning);
+        json.addProperty("model", currentModel);
+        json.addProperty("connected", connected);
+        sendJson(exchange, GSON.toJson(json));
+    }
+
+    private void handleReviewItems(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().set(HDR_ACCESS_CONTROL_ORIGIN, "*");
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+            return;
+        }
+        try {
+            com.github.catatafishen.agentbridge.psi.review.AgentEditSession editSession =
+                com.github.catatafishen.agentbridge.psi.review.AgentEditSession.getInstance(project);
+            java.util.List<com.github.catatafishen.agentbridge.psi.review.ReviewItem> items = editSession.getReviewItems();
+            com.google.gson.JsonArray arr = new com.google.gson.JsonArray();
+            for (com.github.catatafishen.agentbridge.psi.review.ReviewItem item : items) {
+                com.google.gson.JsonObject obj = new com.google.gson.JsonObject();
+                obj.addProperty("path", item.relativePath());
+                obj.addProperty("status", item.status().name());
+                obj.addProperty("approved", item.approved());
+                obj.addProperty("linesAdded", item.linesAdded());
+                obj.addProperty("linesRemoved", item.linesRemoved());
+                arr.add(obj);
+            }
+            com.google.gson.JsonObject json = new com.google.gson.JsonObject();
+            json.add("items", arr);
+            sendJson(exchange, GSON.toJson(json));
+        } catch (Exception e) {
+            LOG.warn("handleReviewItems error", e);
+            sendJson(exchange, "{\"items\":[]}");
         }
     }
 
@@ -1566,7 +1793,7 @@ public final class ChatWebServer implements Disposable {
 
     private void sendJson(HttpExchange exchange, String json) throws IOException {
         byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
-        exchange.getResponseHeaders().set(HDR_CONTENT_TYPE, "application/json; charset=utf-8");
+        exchange.getResponseHeaders().set(HDR_CONTENT_TYPE, JSON_CONTENT_TYPE);
         exchange.getResponseHeaders().set(HDR_ACCESS_CONTROL_ORIGIN, "*");
         exchange.sendResponseHeaders(200, bytes.length);
         exchange.getResponseBody().write(bytes);


### PR DESCRIPTION
## Summary

Adds a read-only file viewer to the PWA as a left pane, accessible by swiping left or clicking file links in chat responses. Resolves the gap where file links in the PWA were no-ops (since there's no IDE editor to open).

## Components

### Frontend (TypeScript, zero dependencies)
- **PaneSwiper** — two-pane container with CSS transform sliding + touch swipe gestures
- **FileViewer** — file content with line numbers, syntax highlighting, markdown rendering, recent files
- **FileNav** — directory browser with breadcrumb, search filter, file-type icons
- **syntaxHighlight** — minimal token-based highlighter for ~20 languages

### Backend (Java)
- `GET /file?path=` — read file content (path traversal protected, 1 MB limit)
- `GET /list-files?path=` — directory listing (hidden/build dirs excluded)

### Integration
- `bridge.openFile` override intercepts `openfile://` links → fetches content → displays in viewer
- Swipe/dots UX for mobile, keyboard shortcut potential for desktop

## What it looks like
- Chat is the default right pane (unchanged behavior)
- Swipe left → file viewer pane with navigation bar
- Click any file link in chat → auto-switches to file viewer with that file loaded
- Browse directories via the nav bar, click files to open
- Syntax highlighted code, fully rendered markdown