### PR TITLE
fix: redesign review diff row layout — checkbox left, stacked timestamp/file/diff

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/DiffPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/DiffPanel.java
@@ -306,9 +306,10 @@ public final class DiffPanel extends JPanel implements Disposable {
 
     private static int hitTestZone(int relativeX, int cellWidth) {
         int btn = JBUI.scale(BUTTON_SIZE);
-        int rightPad = JBUI.scale(4);
+        int leftPad = JBUI.scale(8);   // matches empty(6, 8, 6, 4) left inset
+        int rightPad = JBUI.scale(4);  // matches empty(6, 8, 6, 4) right inset
+        if (relativeX < leftPad + btn) return ZONE_APPROVE;
         if (relativeX >= cellWidth - rightPad - btn) return ZONE_REMOVE;
-        if (relativeX >= cellWidth - rightPad - 2 * btn) return ZONE_APPROVE;
         return ZONE_FILE;
     }
 
@@ -478,35 +479,46 @@ public final class DiffPanel extends JPanel implements Disposable {
     }
 
     /**
-     * Renders a single review row: timestamp + status-colored filename + animated diff counts
-     * on the left, approve badge + remove/reject icon on the right.
-     *
-     * <p>Uses {@link SimpleColoredComponent} for the text area, which handles selection
-     * color overrides, ellipsis truncation, and theme-aware rendering natively.</p>
+     * Renders a single review row with a two-column layout:
+     * <ul>
+     *   <li>LEFT: approve badge</li>
+     *   <li>CENTER: timestamp (top), status-coloured filename (middle), animated diff counts (bottom)</li>
+     *   <li>RIGHT: remove/reject icon</li>
+     * </ul>
      */
     private final class ReviewRowRenderer extends JPanel implements ListCellRenderer<ReviewItem> {
-        private final SimpleColoredComponent text = new SimpleColoredComponent();
         private final BadgeLabel approveLabel = new BadgeLabel();
+        private final SimpleColoredComponent timestampText = new SimpleColoredComponent();
+        private final SimpleColoredComponent fileText = new SimpleColoredComponent();
+        private final SimpleColoredComponent diffText = new SimpleColoredComponent();
         private final JLabel removeLabel = new JLabel();
 
         ReviewRowRenderer() {
             setLayout(new BorderLayout());
             setBorder(JBUI.Borders.empty(6, 8, 6, 4));
 
-            text.setOpaque(false);
-            add(text, BorderLayout.CENTER);
-
             Dimension btnDim = new Dimension(JBUI.scale(BUTTON_SIZE), JBUI.scale(BUTTON_SIZE));
+
             approveLabel.setHorizontalAlignment(SwingConstants.CENTER);
             approveLabel.setPreferredSize(btnDim);
-            removeLabel.setHorizontalAlignment(SwingConstants.CENTER);
-            removeLabel.setPreferredSize(btnDim);
+            add(approveLabel, BorderLayout.WEST);
 
-            JPanel actions = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, 0));
-            actions.setOpaque(false);
-            actions.add(approveLabel);
-            actions.add(removeLabel);
-            add(actions, BorderLayout.EAST);
+            JPanel textPanel = new JPanel();
+            textPanel.setOpaque(false);
+            textPanel.setLayout(new BoxLayout(textPanel, BoxLayout.Y_AXIS));
+            textPanel.setBorder(JBUI.Borders.emptyLeft(6));
+            timestampText.setOpaque(false);
+            fileText.setOpaque(false);
+            diffText.setOpaque(false);
+            textPanel.add(timestampText);
+            textPanel.add(fileText);
+            textPanel.add(diffText);
+            add(textPanel, BorderLayout.CENTER);
+
+            removeLabel.setHorizontalAlignment(SwingConstants.CENTER);
+            removeLabel.setVerticalAlignment(SwingConstants.CENTER);
+            removeLabel.setPreferredSize(btnDim);
+            add(removeLabel, BorderLayout.EAST);
         }
 
         @Override
@@ -519,28 +531,18 @@ public final class DiffPanel extends JPanel implements Disposable {
             setBackground(bg);
             setOpaque(true);
 
-            text.clear();
-            text.setFont(jList.getFont());
-            appendTimestamp(item);
-            appendFileName(item, isSelected, fg);
-            appendDiffCounts(item, isSelected, fg);
-
-            approveLabel.setIcon(AllIcons.Actions.Checked);
-            approveLabel.setHighlighted(item.approved());
-            removeLabel.setIcon(item.approved() ? AllIcons.Actions.Close : AllIcons.Actions.Rollback);
-
-            return this;
-        }
-
-        private void appendTimestamp(ReviewItem item) {
+            timestampText.clear();
             if (item.lastEditedMillis() > 0) {
-                text.append(
-                    TimestampDisplayFormatter.formatEpochMillis(item.lastEditedMillis()) + "  ",
-                    new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, JBColor.GRAY));
+                timestampText.append(
+                    TimestampDisplayFormatter.formatEpochMillis(item.lastEditedMillis()),
+                    new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, isSelected ? fg : JBColor.GRAY));
+                timestampText.setVisible(true);
+            } else {
+                timestampText.setVisible(false);
             }
-        }
 
-        private void appendFileName(ReviewItem item, boolean isSelected, Color fg) {
+            fileText.clear();
+            fileText.setFont(jList.getFont());
             Path p = Path.of(item.path());
             String fileName = p.getFileName() != null ? p.getFileName().toString() : item.path();
             Color fileColor = isSelected ? fg : switch (item.status()) {
@@ -548,26 +550,33 @@ public final class DiffPanel extends JPanel implements Disposable {
                 case MODIFIED -> STATUS_MODIFIED;
                 case DELETED -> STATUS_DELETED;
             };
-            text.append(fileName, new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, fileColor));
-        }
+            fileText.append(fileName, new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, fileColor));
 
-        private void appendDiffCounts(ReviewItem item, boolean isSelected, Color fg) {
+            diffText.clear();
             long now = System.currentTimeMillis();
             ReviewDiffCountAnimator.DiffCounts counts = diffCountAnimator.displayCounts(item, now);
-            if (counts.added() <= 0 && counts.removed() <= 0) return;
+            if (counts.added() > 0 || counts.removed() > 0) {
+                if (counts.added() > 0) {
+                    Color c = isSelected ? fg : DIFF_GREEN;
+                    diffText.append("+" + counts.added(),
+                        new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, c));
+                }
+                if (counts.removed() > 0) {
+                    if (counts.added() > 0) diffText.append(" ", SimpleTextAttributes.REGULAR_ATTRIBUTES);
+                    Color c = isSelected ? fg : DIFF_RED;
+                    diffText.append("-" + counts.removed(),
+                        new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, c));
+                }
+                diffText.setVisible(true);
+            } else {
+                diffText.setVisible(false);
+            }
 
-            text.append("  ", SimpleTextAttributes.REGULAR_ATTRIBUTES);
-            if (counts.added() > 0) {
-                Color c = isSelected ? fg : DIFF_GREEN;
-                text.append("+" + counts.added(),
-                    new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, c));
-            }
-            if (counts.removed() > 0) {
-                if (counts.added() > 0) text.append(" ", SimpleTextAttributes.REGULAR_ATTRIBUTES);
-                Color c = isSelected ? fg : DIFF_RED;
-                text.append("-" + counts.removed(),
-                    new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, c));
-            }
+            approveLabel.setIcon(AllIcons.Actions.Checked);
+            approveLabel.setHighlighted(item.approved());
+            removeLabel.setIcon(item.approved() ? AllIcons.Actions.Close : AllIcons.Actions.Rollback);
+
+            return this;
         }
     }
 


### PR DESCRIPTION
Single-file redesign of `DiffPanel.java` review row layout.

## Changes
- Approve checkbox moved to the **left** of each row
- Center column stacks timestamp / filename / diff-counts vertically with `BoxLayout.Y_AXIS`
- Reject/remove button remains on the right
- `hitTestZone` updated to match new layout

No logic changes — purely visual improvement.