### PR TITLE
feat: relocate tool-stats.db to user storage directory (#351)

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemoryService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemoryService.java
@@ -7,6 +7,7 @@ import com.github.catatafishen.agentbridge.memory.validation.MemoryRefactorListe
 import com.github.catatafishen.agentbridge.memory.validation.MemoryStalenessTrigger;
 import com.github.catatafishen.agentbridge.memory.wal.WriteAheadLog;
 import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
+import com.github.catatafishen.agentbridge.settings.AgentBridgeStorageSettings;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.diagnostic.Logger;
@@ -16,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 @Service(Service.Level.PROJECT)
@@ -23,7 +25,6 @@ public final class MemoryService implements Disposable {
 
     private static final Logger LOG = Logger.getInstance(MemoryService.class);
 
-    private static final String MEMORY_DIR = "memory";
     private static final String LUCENE_INDEX_DIR = "lucene-index";
     private static final String WAL_DIR = "wal";
     private static final String KG_DB_FILE = "knowledge.sqlite3";
@@ -130,6 +131,7 @@ public final class MemoryService implements Disposable {
             if (initialized) return;
             try {
                 Path memoryDir = getMemoryBasePath();
+                migrateLegacyMemoryDir(project.getBasePath(), memoryDir);
 
                 // Initialize WAL
                 wal = new WriteAheadLog(memoryDir.resolve(WAL_DIR));
@@ -168,12 +170,21 @@ public final class MemoryService implements Disposable {
         }
     }
 
-    private @NotNull Path getMemoryBasePath() {
-        String basePath = project.getBasePath();
-        if (basePath == null) {
-            basePath = System.getProperty("user.home");
+    static void migrateLegacyMemoryDir(@Nullable String projectBasePath, @NotNull Path newMemoryDir) throws IOException {
+        if (projectBasePath == null) {
+            return;
         }
-        return Path.of(basePath, ".agent-work", MEMORY_DIR);
+        Path legacyMemoryDir = Path.of(projectBasePath, ".agent-work", "memory");
+        if (!Files.exists(legacyMemoryDir) || Files.exists(newMemoryDir)) {
+            return;
+        }
+        Files.createDirectories(newMemoryDir.getParent());
+        Files.move(legacyMemoryDir, newMemoryDir);
+        LOG.info("Migrated memory directory from " + legacyMemoryDir + " to " + newMemoryDir);
+    }
+
+    private @NotNull Path getMemoryBasePath() {
+        return AgentBridgeStorageSettings.getInstance().getProjectMemoryDir(project);
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemorySettingsConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemorySettingsConfigurable.java
@@ -3,6 +3,7 @@ package com.github.catatafishen.agentbridge.memory;
 import com.github.catatafishen.agentbridge.memory.mining.BackfillMiner;
 import com.github.catatafishen.agentbridge.memory.mining.MiningTracker;
 import com.github.catatafishen.agentbridge.session.v2.SessionStoreV2;
+import com.github.catatafishen.agentbridge.settings.AgentBridgeStorageSettings;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurationException;
@@ -11,12 +12,16 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
+import java.nio.file.Path;
 
 public final class MemorySettingsConfigurable implements Configurable {
 
@@ -30,6 +35,7 @@ public final class MemorySettingsConfigurable implements Configurable {
     private JTextField palaceWingField;
     private JButton backfillButton;
     private JLabel backfillStatusLabel;
+    private JLabel storageLocationLabel;
     private volatile boolean miningInProgress;
 
     private JLabel minChunkLabel;
@@ -59,18 +65,25 @@ public final class MemorySettingsConfigurable implements Configurable {
         gbc.gridy = 0;
         gbc.gridwidth = 2;
         JLabel desc = new JLabel(
-            "<html>Semantic memory powered by concepts from " +
+            "<html><body style='width: 420px'>Semantic memory powered by concepts from " +
                 "<a href=\"https://github.com/milla-jovovich/mempalace\">MemPalace</a>. " +
                 "Stores decisions, preferences, and milestones from conversations " +
-                "for cross-session recall.</html>");
+                "for cross-session recall.</body></html>");
         panel.add(desc, gbc);
 
         // ── Enabled ──
         gbc.gridy++;
         gbc.gridwidth = 2;
-        enabledCheckBox = new JCheckBox("Enable semantic memory (stores memories locally in .agent-work/memory/)");
+        enabledCheckBox = new JCheckBox("Enable semantic memory");
         enabledCheckBox.addItemListener(e -> updateSubOptionsEnabled());
         panel.add(enabledCheckBox, gbc);
+
+        gbc.gridy++;
+        storageLocationLabel = new JLabel();
+        storageLocationLabel.setForeground(UIUtil.getContextHelpForeground());
+        storageLocationLabel.setFont(JBUI.Fonts.smallFont());
+        updateStorageLocationLabel();
+        panel.add(storageLocationLabel, gbc);
 
         // ── Auto-mine on turn complete ──
         gbc.gridy++;
@@ -135,8 +148,8 @@ public final class MemorySettingsConfigurable implements Configurable {
 
         gbc.gridx = 1;
         JLabel backfillHint = new JLabel(
-            "<html><i>⚠ Can be slow if you have many sessions. " +
-                "Runs in the background.</i></html>");
+            "<html><body style='width: 280px'><i>⚠ Can be slow if you have many sessions. " +
+                "Runs in the background.</i></body></html>");
         backfillHint.setForeground(UIManager.getColor("Component.warningFocusColor"));
         panel.add(backfillHint, gbc);
 
@@ -167,6 +180,20 @@ public final class MemorySettingsConfigurable implements Configurable {
         backfillStatusLabel.setEnabled(enabled);
     }
 
+    private void updateStorageLocationLabel() {
+        Path memoryDir = AgentBridgeStorageSettings.getInstance().getProjectMemoryDir(project);
+        storageLocationLabel.setText(
+            "<html><body style='width: 420px'>Stored in <code>"
+                + formatPathForHtml(memoryDir)
+                + "</code>.</body></html>");
+    }
+
+    private static @NotNull String formatPathForHtml(@NotNull Path path) {
+        return StringUtil.escapeXmlEntities(path.toString())
+            .replace("/", "/<wbr>")
+            .replace("\\", "\\<wbr>");
+    }
+
     private void updateBackfillStatus() {
         if (miningInProgress) return;
         MemorySettings settings = MemorySettings.getInstance(project);
@@ -177,8 +204,8 @@ public final class MemorySettingsConfigurable implements Configurable {
                 .listSessions(project.getBasePath()).size();
             if (sessionCount > 0) {
                 backfillStatusLabel.setText(
-                    "<html><b>" + sessionCount + " past sessions</b> available to mine. " +
-                        "Click below to populate memory from your conversation history.</html>");
+                    "<html><body style='width: 420px'><b>" + sessionCount + " past sessions</b> available to mine. " +
+                        "Click below to populate memory from your conversation history.</body></html>");
             } else {
                 backfillStatusLabel.setText("No past sessions found.");
             }
@@ -298,6 +325,9 @@ public final class MemorySettingsConfigurable implements Configurable {
         minChunkLengthSpinner.setValue(settings.getMinChunkLength());
         maxDrawersPerTurnSpinner.setValue(settings.getMaxDrawersPerTurn());
         palaceWingField.setText(settings.getPalaceWing());
+        if (storageLocationLabel != null) {
+            updateStorageLocationLabel();
+        }
         if (backfillStatusLabel != null) {
             updateBackfillStatus();
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/layers/IdentityLayer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/layers/IdentityLayer.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.memory.layers;
 
+import com.github.catatafishen.agentbridge.settings.AgentBridgeStorageSettings;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
@@ -11,8 +12,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
- * L0 — Identity layer. Reads static identity facts from
- * {@code .agent-work/memory/identity.txt} in the project root.
+ * L0 — Identity layer. Reads static identity facts from {@code identity.txt}
+ * in the project's configured semantic-memory directory.
  *
  * <p>This file is user-managed and contains free-form identity statements
  * such as "This project is an IntelliJ plugin written in Java 21" or
@@ -25,17 +26,18 @@ public final class IdentityLayer implements MemoryStack {
     private static final Logger LOG = Logger.getInstance(IdentityLayer.class);
     private static final String IDENTITY_FILE = "identity.txt";
 
-    private final Path basePath;
+    private final Path memoryDir;
 
     public IdentityLayer(@NotNull Project project) {
-        this(project.getBasePath() != null ? Path.of(project.getBasePath()) : null);
+        this(AgentBridgeStorageSettings.getInstance().getProjectMemoryDir(project));
     }
 
     /**
-     * Package-private constructor for testing — accepts a base path directly.
+     * Package-private constructor for testing — accepts the resolved memory
+     * directory directly.
      */
-    IdentityLayer(@Nullable Path basePath) {
-        this.basePath = basePath;
+    IdentityLayer(@Nullable Path memoryDir) {
+        this.memoryDir = memoryDir;
     }
 
     @Override
@@ -65,7 +67,7 @@ public final class IdentityLayer implements MemoryStack {
     }
 
     private @Nullable Path getIdentityPath() {
-        if (basePath == null) return null;
-        return basePath.resolve(".agent-work").resolve("memory").resolve(IDENTITY_FILE);
+        if (memoryDir == null) return null;
+        return memoryDir.resolve(IDENTITY_FILE);
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/store/MemoryStore.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/store/MemoryStore.java
@@ -41,8 +41,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Wraps a Lucene index at {@code .agent-work/memory/lucene-index/} to store
- * and search memory drawers with 384-dimensional vector embeddings.
+ * Wraps a Lucene index in the project's configured semantic-memory directory,
+ * under {@code lucene-index/}, to store and search memory drawers with
+ * 384-dimensional vector embeddings.
  *
  * <p>Provides:
  * <ul>

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/wal/WriteAheadLog.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/wal/WriteAheadLog.java
@@ -17,7 +17,8 @@ import java.time.Instant;
  * JSONL write-ahead log for all memory write operations.
  * Each line is a JSON object with operation type, timestamp, and payload.
  *
- * <p>File location: {@code .agent-work/memory/wal/write_log.jsonl}
+ * <p>File location: the project's configured semantic-memory directory, under
+ * {@code wal/write_log.jsonl}
  *
  * <p><b>Attribution:</b> WAL pattern adapted from MemPalace's
  * {@code mcp_server.py _wal_log()} (MIT License).

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -2,6 +2,7 @@ package com.github.catatafishen.agentbridge.services;
 
 import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
 import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
+import com.github.catatafishen.agentbridge.settings.AgentBridgeStorageSettings;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
@@ -29,8 +30,12 @@ import java.util.Set;
 
 /**
  * Project-level service that records every MCP tool call in a SQLite database
- * ({@code {project}/.agentbridge/tool-stats.db}) and provides query methods for
- * the Tool Statistics UI panel.
+ * and provides query methods for the Tool Statistics UI panel.
+ *
+ * <p>The database location is resolved via {@link AgentBridgeStorageSettings},
+ * which defaults to {@code ~/.agentbridge/projects/<project>-<hash>/tool-stats.db}
+ * but can be overridden by the user. Stats collection can also be disabled
+ * entirely via the same settings page (see issue #351).</p>
  *
  * <p>Subscribes to {@link PsiBridgeService#TOOL_CALL_TOPIC} on the project
  * message bus. Records are appended on the calling thread (MCP handler threads)
@@ -61,36 +66,78 @@ public final class ToolCallStatisticsService implements Disposable {
         this.project = null;
     }
 
-    /**
-     * Initialize the SQLite database and subscribe to tool call events.
-     * Called lazily on first access via {@code getInstance()}.
-     *
-     * @throws RuntimeException if initialization fails (JDBC driver not found,
-     *                          database cannot be created, or subscription fails).
-     *                          The caller sets {@code initAttempted = true} regardless of
-     *                          success/failure to prevent retry loops — the service stays
-     *                          inert (connection == null) until the IDE is restarted.
-     */
     public void initialize() {
+        if (project == null || project.getBasePath() == null) {
+            throw new IllegalStateException(
+                "Cannot initialize ToolCallStatisticsService: project has no base path");
+        }
+        AgentBridgeStorageSettings storageSettings = AgentBridgeStorageSettings.getInstance();
+        // Compute the target path before the enabled check so migration runs unconditionally.
+        // Even when stats collection is disabled, the legacy {project}/.agentbridge/tool-stats.db
+        // must be moved out of the project tree so it no longer pollutes VCS views.
+        Path dbDir = storageSettings.getProjectStorageDir(project);
+        Path dbPath = dbDir.resolve(DB_FILENAME);
+        migrateLegacyDb(project.getBasePath(), dbPath);
+
+        if (!storageSettings.isToolStatsEnabled()) {
+            LOG.info("ToolCallStatisticsService: tool call statistics collection is disabled in settings — skipping init");
+            return;
+        }
         try {
             Class.forName("org.sqlite.JDBC");
         } catch (ClassNotFoundException e) {
             throw new IllegalStateException("SQLite JDBC driver not found on classpath", e);
         }
-        String basePath = project.getBasePath();
-        if (basePath == null) {
-            throw new IllegalStateException(
-                "Cannot initialize ToolCallStatisticsService: project has no base path");
-        }
         try {
-            Path dbDir = Path.of(basePath, ".agentbridge");
             Files.createDirectories(dbDir);
-            Path dbPath = dbDir.resolve(DB_FILENAME);
             initializeWithConnection(DriverManager.getConnection("jdbc:sqlite:" + dbPath));
             subscribeToToolCallEvents();
             LOG.info("ToolCallStatisticsService initialized at " + dbPath);
         } catch (SQLException | IOException e) {
             throw new IllegalStateException("Failed to initialize ToolCallStatisticsService", e);
+        }
+    }
+
+    /**
+     * If a legacy {@code {project}/.agentbridge/tool-stats.db} exists and the
+     * new location does not, move the file to the new location. Best-effort —
+     * failures are logged but never fatal so the service can still proceed
+     * with a fresh database.
+     *
+     * <p>Also attempts to delete the now-empty legacy directory so the project
+     * tree is left clean.</p>
+     */
+    static void migrateLegacyDb(@NotNull String projectBasePath, @NotNull Path newDbPath) {
+        Path legacyDir = Path.of(projectBasePath, ".agentbridge");
+        Path legacyDb = legacyDir.resolve(DB_FILENAME);
+        if (!Files.exists(legacyDb) || Files.exists(newDbPath)) {
+            return;
+        }
+        try {
+            Files.createDirectories(newDbPath.getParent());
+            Files.move(legacyDb, newDbPath);
+            LOG.info("Migrated tool-stats.db from " + legacyDb + " to " + newDbPath);
+            // SQLite may also have left -journal/-wal/-shm sidecar files alongside the DB.
+            for (String suffix : new String[]{"-journal", "-wal", "-shm"}) {
+                Path sidecar = legacyDir.resolve(DB_FILENAME + suffix);
+                if (Files.exists(sidecar)) {
+                    try {
+                        Files.move(sidecar, Path.of(newDbPath + suffix));
+                    } catch (IOException ignored) {
+                        // Sidecar files are recreated by SQLite as needed; safe to leave behind.
+                    }
+                }
+            }
+            try (var entries = Files.list(legacyDir)) {
+                if (entries.findAny().isEmpty()) {
+                    Files.delete(legacyDir);
+                }
+            } catch (IOException ignored) {
+                // Leaving the empty .agentbridge directory behind is harmless.
+            }
+        } catch (IOException e) {
+            LOG.warn("Failed to migrate legacy tool-stats.db from " + legacyDb
+                + " — a fresh database will be created at " + newDbPath, e);
         }
     }
 
@@ -282,9 +329,10 @@ public final class ToolCallStatisticsService implements Disposable {
         if (project == null) return false;
         closeConnectionQuietly();
         try {
-            String basePath = project.getBasePath();
-            if (basePath == null) return false;
-            Path dbPath = Path.of(basePath, ".agentbridge", DB_FILENAME);
+            if (project.getBasePath() == null) return false;
+            Path dbPath = AgentBridgeStorageSettings.getInstance()
+                .getProjectStorageDir(project)
+                .resolve(DB_FILENAME);
             initializeWithConnection(DriverManager.getConnection("jdbc:sqlite:" + dbPath));
             LOG.info("Reconnected to ToolCallStatisticsService database after file move");
             return true;
@@ -775,7 +823,9 @@ public final class ToolCallStatisticsService implements Disposable {
                     service.initAttempted = true;
                     try {
                         service.initialize();
-                        triggerBackfillIfNeeded(service, project);
+                        if (service.connection != null) {
+                            triggerBackfillIfNeeded(service, project);
+                        }
                     } catch (RuntimeException e) {
                         LOG.error("ToolCallStatisticsService initialization failed — "
                             + "tool call recording will be disabled until restart", e);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageConfigurable.java
@@ -1,0 +1,125 @@
+package com.github.catatafishen.agentbridge.settings;
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.ui.TextBrowseFolderListener;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.util.ui.FormBuilder;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+/**
+ * Root settings page for AgentBridge storage. Holds the shared storage root
+ * directory; child pages (Tool Statistics, Memory, Chat History) configure
+ * specific stores below it.
+ *
+ * <p>Addresses issue #351 — moves per-project AgentBridge data out of the
+ * project tree and into a user-configurable location.</p>
+ */
+public final class AgentBridgeStorageConfigurable implements Configurable {
+
+    public static final String ID = "com.github.catatafishen.agentbridge.storage";
+
+    private TextFieldWithBrowseButton storageRootField;
+    private AgentBridgeStorageSettings settings;
+    private JPanel mainPanel;
+
+    @Override
+    public @Nls(capitalization = Nls.Capitalization.Title) String getDisplayName() {
+        return "Storage";
+    }
+
+    @Override
+    public @NotNull JComponent createComponent() {
+        settings = AgentBridgeStorageSettings.getInstance();
+
+        storageRootField = new TextFieldWithBrowseButton();
+        configureBrowseButton(storageRootField);
+
+        JButton resetDefaultBtn = new JButton("Reset to default");
+        resetDefaultBtn.addActionListener(e -> storageRootField.setText(""));
+
+        JPanel pathRow = new JPanel();
+        pathRow.setLayout(new BoxLayout(pathRow, BoxLayout.X_AXIS));
+        pathRow.add(storageRootField);
+        pathRow.add(Box.createHorizontalStrut(6));
+        pathRow.add(resetDefaultBtn);
+
+        JBLabel defaultHint = new JBLabel(
+            "<html><body style='width: 420px'>Default: <code>" + AgentBridgeStorageSettings.getDefaultStorageRoot()
+                + "</code><br/>Per-project data lives under <code>&lt;root&gt;/projects/&lt;project-name&gt;-&lt;hash&gt;/</code>.</body></html>");
+        defaultHint.setForeground(UIUtil.getContextHelpForeground());
+        defaultHint.setFont(JBUI.Fonts.smallFont());
+
+        JBLabel migrationNote = new JBLabel(
+            "<html><body style='width: 420px'><b>Note:</b> if legacy data exists under "
+                + "<code>{project}/.agentbridge/tool-stats.db</code> or <code>{project}/.agent-work/memory/</code>, "
+                + "it is moved to the new location automatically on first use. "
+                + "Changing the storage root takes effect on the next IDE restart.</body></html>");
+        migrationNote.setForeground(UIUtil.getContextHelpForeground());
+        migrationNote.setFont(JBUI.Fonts.smallFont());
+
+        JBLabel childPagesHint = new JBLabel(
+            "<html><body style='width: 420px'>Configure individual stores below: "
+                + "<b>Tool Statistics</b>, <b>Memory</b>, and <b>Chat History</b>.</body></html>");
+        childPagesHint.setForeground(UIUtil.getContextHelpForeground());
+        childPagesHint.setFont(JBUI.Fonts.smallFont());
+
+        mainPanel = FormBuilder.createFormBuilder()
+            .addComponent(new JBLabel(
+                "<html><body style='width: 420px'>Configure where AgentBridge stores per-project data files "
+                    + "such as tool-call statistics and semantic memory.</body></html>"))
+            .addSeparator(8)
+            .addLabeledComponent("Storage root:", pathRow)
+            .addComponent(defaultHint, 2)
+            .addSeparator(12)
+            .addComponent(migrationNote, 2)
+            .addSeparator(12)
+            .addComponent(childPagesHint, 2)
+            .addComponentFillVertically(new JPanel(), 0)
+            .getPanel();
+        mainPanel.setBorder(JBUI.Borders.empty(8));
+
+        reset();
+        return mainPanel;
+    }
+
+    private static void configureBrowseButton(@NotNull TextFieldWithBrowseButton field) {
+        FileChooserDescriptor descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor();
+        descriptor.setTitle("Select AgentBridge Storage Directory");
+        descriptor.setDescription(
+            "AgentBridge per-project data files such as tool-call statistics and semantic memory will be stored under this directory.");
+        field.addBrowseFolderListener(new TextBrowseFolderListener(descriptor));
+    }
+
+    @Override
+    public boolean isModified() {
+        String fieldText = storageRootField.getText().trim();
+        String currentRoot = settings.getCustomStorageRoot();
+        return !fieldText.equals(currentRoot == null ? "" : currentRoot);
+    }
+
+    @Override
+    public void apply() {
+        String path = storageRootField.getText().trim();
+        settings.setCustomStorageRoot(path.isEmpty() ? null : path);
+    }
+
+    @Override
+    public void reset() {
+        String customRoot = settings.getCustomStorageRoot();
+        storageRootField.setText(customRoot != null ? customRoot : "");
+    }
+
+    @Override
+    public void disposeUIResources() {
+        mainPanel = null;
+        storageRootField = null;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettings.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettings.java
@@ -1,0 +1,151 @@
+package com.github.catatafishen.agentbridge.settings;
+
+import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+/**
+ * Application-level settings for where the AgentBridge plugin stores its
+ * per-project data files (e.g. the tool-call statistics database and semantic
+ * memory files).
+ *
+ * <p>Resolves to {@code ~/.agentbridge/} by default. Users can override the
+ * root via the "Storage" settings page. Per-project data lives under
+ * {@code <root>/projects/<project-name>-<hash>/}, keeping stats scoped to
+ * individual projects while moving them out of the project tree (see issue
+ * #351).</p>
+ */
+@Service(Service.Level.APP)
+@State(name = "AgentBridgeStorageSettings",
+    storages = @Storage("agentbridgeStorage.xml"))
+public final class AgentBridgeStorageSettings
+    implements PersistentStateComponent<AgentBridgeStorageSettings.State> {
+
+    private static final String DEFAULT_DIR_NAME = ".agentbridge";
+    private static final String PROJECTS_DIR_NAME = "projects";
+    private static final String MEMORY_DIR_NAME = "memory";
+
+    private State myState = new State();
+
+    public static AgentBridgeStorageSettings getInstance() {
+        return PlatformApiCompat.getApplicationService(AgentBridgeStorageSettings.class);
+    }
+
+    /**
+     * Returns the user-configured custom root, or {@code null} if the default
+     * should be used.
+     */
+    @Nullable
+    public String getCustomStorageRoot() {
+        String s = myState.customStorageRoot;
+        return (s == null || s.isBlank()) ? null : s.trim();
+    }
+
+    public void setCustomStorageRoot(@Nullable String path) {
+        myState.customStorageRoot = (path == null || path.isBlank()) ? null : path.trim();
+    }
+
+    public boolean isToolStatsEnabled() {
+        return myState.toolStatsEnabled;
+    }
+
+    public void setToolStatsEnabled(boolean enabled) {
+        myState.toolStatsEnabled = enabled;
+    }
+
+    /**
+     * The default storage root: {@code <user.home>/.agentbridge}. This matches
+     * the location already used by the embedding model cache, so all plugin
+     * data lives in one user-visible directory.
+     */
+    @NotNull
+    public static Path getDefaultStorageRoot() {
+        return Paths.get(System.getProperty("user.home"), DEFAULT_DIR_NAME);
+    }
+
+    /**
+     * Returns the effective storage root — the user override if set, otherwise
+     * the default.
+     */
+    @NotNull
+    public Path getEffectiveStorageRoot() {
+        String custom = getCustomStorageRoot();
+        return custom != null ? Paths.get(custom) : getDefaultStorageRoot();
+    }
+
+    /**
+     * Returns the per-project data directory under the effective storage root.
+     * The directory is namespaced by project name plus a hash of the project
+     * base path so that projects with identical names do not collide.
+     */
+    @NotNull
+    public Path getProjectStorageDir(@NotNull Project project) {
+        String safeName = sanitize(project.getName());
+        String hashSource = project.getBasePath() != null ? project.getBasePath() : project.getName();
+        String hash = Integer.toHexString(hashSource.hashCode());
+        return getEffectiveStorageRoot().resolve(PROJECTS_DIR_NAME).resolve(safeName + "-" + hash);
+    }
+
+    /**
+     * Returns the semantic memory directory for the given project under the
+     * shared per-project storage directory.
+     */
+    @NotNull
+    public Path getProjectMemoryDir(@NotNull Project project) {
+        return getProjectStorageDir(project).resolve(MEMORY_DIR_NAME);
+    }
+
+    private static String sanitize(@NotNull String name) {
+        StringBuilder sb = new StringBuilder(name.length());
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (Character.isLetterOrDigit(c) || c == '-' || c == '_' || c == '.') {
+                sb.append(c);
+            } else {
+                sb.append('_');
+            }
+        }
+        String out = sb.toString().toLowerCase(Locale.ROOT);
+        return out.isEmpty() ? "unnamed" : out;
+    }
+
+    @Override
+    public @NotNull State getState() {
+        return myState;
+    }
+
+    @Override
+    public void loadState(@NotNull State state) {
+        myState = state;
+    }
+
+    public static class State {
+        private String customStorageRoot = null;
+        private boolean toolStatsEnabled = true;
+
+        public String getCustomStorageRoot() {
+            return customStorageRoot;
+        }
+
+        public void setCustomStorageRoot(String customStorageRoot) {
+            this.customStorageRoot = customStorageRoot;
+        }
+
+        public boolean isToolStatsEnabled() {
+            return toolStatsEnabled;
+        }
+
+        public void setToolStatsEnabled(boolean toolStatsEnabled) {
+            this.toolStatsEnabled = toolStatsEnabled;
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ChatHistoryConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ChatHistoryConfigurable.java
@@ -173,8 +173,8 @@ public final class ChatHistoryConfigurable implements Configurable {
 
         JPanel panel = FormBuilder.createFormBuilder()
             .addComponent(new JBLabel(
-                "<html>Conversation files stored in this project's "
-                    + "<code>.agent-work</code> directory.</html>"))
+                "<html><body style='width: 420px'>Conversation files stored in this project's "
+                    + "<code>.agent-work</code> directory.</body></html>"))
             .addComponent(summaryLabel)
             .addComponent(injectHistoryCheckbox)
             .addComponent(limitsPanel)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolStatsConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolStatsConfigurable.java
@@ -1,0 +1,84 @@
+package com.github.catatafishen.agentbridge.settings;
+
+import com.intellij.openapi.options.Configurable;
+import com.intellij.ui.components.JBCheckBox;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.util.ui.FormBuilder;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+/**
+ * Settings page controlling the tool-call statistics database. Lives under
+ * the Storage parent page; the underlying file location is governed by the
+ * shared storage root configured there.
+ */
+public final class ToolStatsConfigurable implements Configurable {
+
+    public static final String ID = "com.github.catatafishen.agentbridge.storage.toolStats";
+
+    private JBCheckBox toolStatsEnabledCb;
+    private AgentBridgeStorageSettings settings;
+    private JPanel mainPanel;
+
+    @Override
+    public @Nls(capitalization = Nls.Capitalization.Title) String getDisplayName() {
+        return "Tool Statistics";
+    }
+
+    @Override
+    public @NotNull JComponent createComponent() {
+        settings = AgentBridgeStorageSettings.getInstance();
+
+        toolStatsEnabledCb = new JBCheckBox("Record tool call statistics");
+
+        JBLabel toolStatsHint = new JBLabel(
+            "<html><body style='width: 420px'>When enabled, every MCP tool call is logged to a per-project SQLite "
+                + "database and surfaced in the Tool Statistics and Session Stats panels. "
+                + "Disable to skip recording entirely (no data is collected).</body></html>");
+        toolStatsHint.setForeground(UIUtil.getContextHelpForeground());
+        toolStatsHint.setFont(JBUI.Fonts.smallFont());
+
+        JBLabel locationHint = new JBLabel(
+            "<html><body style='width: 420px'>The database file is stored under the storage root configured "
+                + "on the parent <b>Storage</b> page.</body></html>");
+        locationHint.setForeground(UIUtil.getContextHelpForeground());
+        locationHint.setFont(JBUI.Fonts.smallFont());
+
+        mainPanel = FormBuilder.createFormBuilder()
+            .addComponent(toolStatsEnabledCb)
+            .addComponent(toolStatsHint, 2)
+            .addSeparator(12)
+            .addComponent(locationHint, 2)
+            .addComponentFillVertically(new JPanel(), 0)
+            .getPanel();
+        mainPanel.setBorder(JBUI.Borders.empty(8));
+
+        reset();
+        return mainPanel;
+    }
+
+    @Override
+    public boolean isModified() {
+        return toolStatsEnabledCb.isSelected() != settings.isToolStatsEnabled();
+    }
+
+    @Override
+    public void apply() {
+        settings.setToolStatsEnabled(toolStatsEnabledCb.isSelected());
+    }
+
+    @Override
+    public void reset() {
+        toolStatsEnabledCb.setSelected(settings.isToolStatsEnabled());
+    }
+
+    @Override
+    public void disposeUIResources() {
+        mainPanel = null;
+        toolStatsEnabledCb = null;
+    }
+}

--- a/plugin-core/src/main/resources/META-INF/plugin.xml
+++ b/plugin-core/src/main/resources/META-INF/plugin.xml
@@ -176,9 +176,9 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and Ope
       id="com.github.catatafishen.agentbridge.chatInput"
       displayName="UI/UX"/>
 
-    <!-- ── Chat History ── -->
+    <!-- ── Chat History (under Storage) ── -->
     <projectConfigurable
-      parentId="com.github.catatafishen.agentbridge.settings"
+      parentId="com.github.catatafishen.agentbridge.storage"
       instance="com.github.catatafishen.agentbridge.settings.ChatHistoryConfigurable"
       id="com.github.catatafishen.agentbridge.chatHistory"
       displayName="Chat History"/>
@@ -251,6 +251,19 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and Ope
       id="com.github.catatafishen.agentbridge.clientAgents.codex"
       displayName="Codex"/>
 
+    <!-- ── Storage (file locations + child stores: tool stats, memory, chat history) ── -->
+    <projectConfigurable
+      parentId="com.github.catatafishen.agentbridge.settings"
+      instance="com.github.catatafishen.agentbridge.settings.AgentBridgeStorageConfigurable"
+      id="com.github.catatafishen.agentbridge.storage"
+      displayName="Storage"/>
+
+    <projectConfigurable
+      parentId="com.github.catatafishen.agentbridge.storage"
+      instance="com.github.catatafishen.agentbridge.settings.ToolStatsConfigurable"
+      id="com.github.catatafishen.agentbridge.storage.toolStats"
+      displayName="Tool Statistics"/>
+
     <!-- ── Project Files ── -->
     <projectConfigurable
       parentId="com.github.catatafishen.agentbridge.settings"
@@ -265,9 +278,9 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and Ope
       id="com.github.catatafishen.agentbridge.scratchTypes"
       displayName="Scratch File Types"/>
 
-    <!-- ── Memory (semantic memory / MemPalace) ── -->
+    <!-- ── Memory (semantic memory / MemPalace, under Storage) ── -->
     <projectConfigurable
-      parentId="com.github.catatafishen.agentbridge.settings"
+      parentId="com.github.catatafishen.agentbridge.storage"
       instance="com.github.catatafishen.agentbridge.memory.MemorySettingsConfigurable"
       id="com.github.catatafishen.agentbridge.memory"
       displayName="Memory"/>

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/MemoryServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/MemoryServiceTest.java
@@ -1,0 +1,53 @@
+package com.github.catatafishen.agentbridge.memory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MemoryServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void migrateLegacyMemoryDirMovesProjectAgentWorkMemoryIntoStorageRoot() throws IOException {
+        Path projectBase = tempDir.resolve("project");
+        Path legacyMemoryDir = projectBase.resolve(".agent-work").resolve("memory");
+        Files.createDirectories(legacyMemoryDir);
+        Files.writeString(legacyMemoryDir.resolve("identity.txt"), "identity", StandardCharsets.UTF_8);
+
+        Path newMemoryDir = tempDir.resolve("storage").resolve("projects").resolve("demo-123").resolve("memory");
+        MemoryService.migrateLegacyMemoryDir(projectBase.toString(), newMemoryDir);
+
+        assertFalse(Files.exists(legacyMemoryDir), "Legacy memory directory should be moved");
+        assertEquals("identity",
+            Files.readString(newMemoryDir.resolve("identity.txt"), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void migrateLegacyMemoryDirLeavesExistingNewLocationUntouched() throws IOException {
+        Path projectBase = tempDir.resolve("project");
+        Path legacyMemoryDir = projectBase.resolve(".agent-work").resolve("memory");
+        Files.createDirectories(legacyMemoryDir);
+        Files.writeString(legacyMemoryDir.resolve("identity.txt"), "legacy", StandardCharsets.UTF_8);
+
+        Path newMemoryDir = tempDir.resolve("storage").resolve("projects").resolve("demo-123").resolve("memory");
+        Files.createDirectories(newMemoryDir);
+        Files.writeString(newMemoryDir.resolve("identity.txt"), "new", StandardCharsets.UTF_8);
+
+        MemoryService.migrateLegacyMemoryDir(projectBase.toString(), newMemoryDir);
+
+        assertTrue(Files.exists(legacyMemoryDir.resolve("identity.txt")),
+            "Legacy directory should remain when the new location already exists");
+        assertEquals("new",
+            Files.readString(newMemoryDir.resolve("identity.txt"), StandardCharsets.UTF_8));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/layers/IdentityLayerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/layers/IdentityLayerTest.java
@@ -13,7 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for L0 ({@link IdentityLayer}).
- * Uses a {@code @TempDir} to simulate the project base path and identity file.
+ * Uses a {@code @TempDir} to simulate the resolved memory directory and
+ * identity file.
  */
 class IdentityLayerTest {
 
@@ -102,8 +103,7 @@ class IdentityLayerTest {
     }
 
     private void writeIdentityFile(String content) throws IOException {
-        Path identityDir = tempDir.resolve(".agent-work").resolve("memory");
-        Files.createDirectories(identityDir);
-        Files.writeString(identityDir.resolve("identity.txt"), content, StandardCharsets.UTF_8);
+        Files.createDirectories(tempDir);
+        Files.writeString(tempDir.resolve("identity.txt"), content, StandardCharsets.UTF_8);
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceMigrationTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceMigrationTest.java
@@ -1,0 +1,92 @@
+package com.github.catatafishen.agentbridge.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link ToolCallStatisticsService#migrateLegacyDb(String, Path)} —
+ * exercises the one-shot migration that moves
+ * {@code {project}/.agentbridge/tool-stats.db} to the new user-configurable
+ * storage location (issue #351).
+ */
+class ToolCallStatisticsServiceMigrationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void movesLegacyDbToNewLocationWhenNewMissing() throws IOException {
+        Path projectRoot = tempDir.resolve("project");
+        Path legacyDir = projectRoot.resolve(".agentbridge");
+        Files.createDirectories(legacyDir);
+        Path legacyDb = legacyDir.resolve("tool-stats.db");
+        byte[] payload = "fake-sqlite-bytes".getBytes();
+        Files.write(legacyDb, payload);
+
+        Path newDb = tempDir.resolve("new-loc").resolve("tool-stats.db");
+
+        ToolCallStatisticsService.migrateLegacyDb(projectRoot.toString(), newDb);
+
+        assertFalse(Files.exists(legacyDb), "legacy DB should be moved");
+        assertTrue(Files.exists(newDb), "new DB should exist");
+        assertArrayEquals(payload, Files.readAllBytes(newDb), "payload preserved");
+        assertFalse(Files.exists(legacyDir), "empty legacy dir should be cleaned up");
+    }
+
+    @Test
+    void doesNothingWhenNewDbAlreadyExists() throws IOException {
+        Path projectRoot = tempDir.resolve("project");
+        Path legacyDir = projectRoot.resolve(".agentbridge");
+        Files.createDirectories(legacyDir);
+        Path legacyDb = legacyDir.resolve("tool-stats.db");
+        Files.write(legacyDb, "legacy".getBytes());
+
+        Path newDb = tempDir.resolve("new-loc").resolve("tool-stats.db");
+        Files.createDirectories(newDb.getParent());
+        Files.write(newDb, "existing".getBytes());
+
+        ToolCallStatisticsService.migrateLegacyDb(projectRoot.toString(), newDb);
+
+        // Both files remain — migration did not touch them
+        assertTrue(Files.exists(legacyDb));
+        assertArrayEquals("legacy".getBytes(), Files.readAllBytes(legacyDb));
+        assertArrayEquals("existing".getBytes(), Files.readAllBytes(newDb));
+    }
+
+    @Test
+    void noOpWhenLegacyDbMissing() {
+        Path projectRoot = tempDir.resolve("project");
+        Path newDb = tempDir.resolve("new-loc").resolve("tool-stats.db");
+
+        // Should not throw, should not create anything
+        ToolCallStatisticsService.migrateLegacyDb(projectRoot.toString(), newDb);
+
+        assertFalse(Files.exists(newDb));
+    }
+
+    @Test
+    void migratesSidecarFilesAlongWithDb() throws IOException {
+        Path projectRoot = tempDir.resolve("project");
+        Path legacyDir = projectRoot.resolve(".agentbridge");
+        Files.createDirectories(legacyDir);
+        Files.write(legacyDir.resolve("tool-stats.db"), "db".getBytes());
+        Files.write(legacyDir.resolve("tool-stats.db-journal"), "j".getBytes());
+        Files.write(legacyDir.resolve("tool-stats.db-wal"), "w".getBytes());
+
+        Path newDb = tempDir.resolve("new-loc").resolve("tool-stats.db");
+
+        ToolCallStatisticsService.migrateLegacyDb(projectRoot.toString(), newDb);
+
+        assertTrue(Files.exists(newDb));
+        assertTrue(Files.exists(Path.of(newDb + "-journal")));
+        assertTrue(Files.exists(Path.of(newDb + "-wal")));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettingsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettingsTest.java
@@ -1,0 +1,92 @@
+package com.github.catatafishen.agentbridge.settings;
+
+import com.intellij.openapi.project.Project;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AgentBridgeStorageSettings} path-resolution helpers.
+ * The state lifecycle is covered by IntelliJ's built-in PersistentStateComponent
+ * machinery — tested here only via direct State manipulation.
+ */
+class AgentBridgeStorageSettingsTest {
+
+    @Test
+    void defaultStorageRootIsUserHomeDotAgentbridge() {
+        Path expected = Paths.get(System.getProperty("user.home"), ".agentbridge");
+        assertEquals(expected, AgentBridgeStorageSettings.getDefaultStorageRoot());
+    }
+
+    @Test
+    void effectiveRootUsesCustomWhenSet() {
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        settings.setCustomStorageRoot("/tmp/custom-ab");
+        assertEquals(Paths.get("/tmp/custom-ab"), settings.getEffectiveStorageRoot());
+    }
+
+    @Test
+    void effectiveRootFallsBackToDefaultWhenBlank() {
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        settings.setCustomStorageRoot("   ");
+        assertEquals(AgentBridgeStorageSettings.getDefaultStorageRoot(),
+            settings.getEffectiveStorageRoot());
+    }
+
+    @Test
+    void projectStorageDirIsNamespacedAndSanitized() {
+        Project project = Mockito.mock(Project.class);
+        Mockito.when(project.getName()).thenReturn("My Cool Project!");
+        Mockito.when(project.getBasePath()).thenReturn("/home/user/projects/cool");
+
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        settings.setCustomStorageRoot("/data/ab");
+
+        Path dir = settings.getProjectStorageDir(project);
+        // sanitized: spaces and ! become '_', lower-cased
+        assertTrue(dir.toString().contains("/projects/my_cool_project_-"),
+            "Expected sanitized project name in path: " + dir);
+        assertTrue(dir.startsWith(Paths.get("/data/ab/projects/")), "Path was: " + dir);
+    }
+
+    @Test
+    void projectStorageDirDifferentForProjectsWithSameName() {
+        Project p1 = Mockito.mock(Project.class);
+        Mockito.when(p1.getName()).thenReturn("demo");
+        Mockito.when(p1.getBasePath()).thenReturn("/home/a/demo");
+
+        Project p2 = Mockito.mock(Project.class);
+        Mockito.when(p2.getName()).thenReturn("demo");
+        Mockito.when(p2.getBasePath()).thenReturn("/home/b/demo");
+
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        assertNotEquals(settings.getProjectStorageDir(p1),
+            settings.getProjectStorageDir(p2),
+            "Projects with the same name but different base paths must get distinct directories");
+    }
+
+    @Test
+    void projectMemoryDirLivesUnderProjectStorageDir() {
+        Project project = Mockito.mock(Project.class);
+        Mockito.when(project.getName()).thenReturn("demo");
+        Mockito.when(project.getBasePath()).thenReturn("/home/user/demo");
+
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        settings.setCustomStorageRoot("/data/ab");
+
+        assertEquals(settings.getProjectStorageDir(project).resolve("memory"),
+            settings.getProjectMemoryDir(project));
+    }
+
+    @Test
+    void toolStatsEnabledDefaultsTrue() {
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        assertTrue(settings.isToolStatsEnabled());
+    }
+}


### PR DESCRIPTION
Closes #351

## What changed

Moves AgentBridge plugin storage out of the project working tree and makes the location user-configurable.

### Default location

`~/.agentbridge/projects/<sanitized-project-name>-<basePath-hash>/tool-stats.db`

- Per-project isolation is preserved (subdir per project, hashed basePath prevents collisions when two projects share a name).
- No more stray `.agentbridge/` directory polluting every project root.
- Aligns with the existing `~/.agentbridge/models/` directory used for embedding models.

### User configuration

New settings page: **Settings → Tools → AgentBridge → Storage**

- **Storage root** field with browse + reset-to-default buttons.
- **Record tool call statistics** checkbox — full opt-out from stats collection.
- Changes take effect after IDE restart (documented in the UI).

### Migration

On first launch after upgrade, an existing `{project}/.agentbridge/tool-stats.db` (and its `-journal`/`-wal`/`-shm` sidecars) is automatically moved to the new location. The empty legacy directory is cleaned up. Migration is best-effort — if it fails, a fresh DB is created at the new location and a warning is logged.

### Opt-out semantics

When disabled, `ToolCallStatisticsService.initialize()` returns early and never opens a connection. `recordCall()` already handles a null connection gracefully (warns once, drops silently), so no other code paths needed changes.

## Tests

- `AgentBridgeStorageSettingsTest` — 6 tests covering default path, custom-root override, blank-fallback, project name sanitization, hash-based collision isolation, default opt-in.
- `ToolCallStatisticsServiceMigrationTest` — 4 tests covering happy-path migration, no-op when new file already exists, no-op when legacy missing, sidecar files move alongside the main DB.
- All existing `ToolCallStatistics*` tests still pass (103/103).

## Review request

@MessiasLima since you reported the issue, would you mind giving this a quick look? Happy to adjust if the default location or settings UX doesn't match what you had in mind.

---

<sub>Authored by an AI agent on behalf of @catatafishen.</sub>