### PR TITLE
fix: attach SLSA provenance bundle as release asset for Scorecard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,9 +175,17 @@ jobs:
 
       - name: Generate provenance attestation
         if: steps.version.outputs.skip != 'true'
+        id: attest
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
         with:
           subject-path: '${{ steps.artifacts.outputs.dir }}/*.zip'
+
+      - name: Stage provenance bundle for release upload
+        if: steps.version.outputs.skip != 'true'
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+          ARTIFACTS_DIR: ${{ steps.artifacts.outputs.dir }}
+        run: cp "$BUNDLE_PATH" "$ARTIFACTS_DIR/provenance.intoto.jsonl"
 
       - name: Install cosign
         if: steps.version.outputs.skip != 'true'
@@ -214,4 +222,5 @@ jobs:
             --title "Release $TAG" \
             --notes-file build/release-notes.md \
             "$ARTIFACTS_DIR"/*.zip \
-            "$ARTIFACTS_DIR"/*.sigstore.json
+            "$ARTIFACTS_DIR"/*.sigstore.json \
+            "$ARTIFACTS_DIR"/provenance.intoto.jsonl


### PR DESCRIPTION
## Problem

OpenSSF Scorecard's *Signed-Releases* check reports `does not have provenance` for all recent releases, even though:
- Releases are already signed with cosign/sigstore ✅
- `actions/attest-build-provenance` already stores attestations in GitHub's Attestation API ✅

**Root cause:** The Scorecard version being used for this repo's scans checks for provenance **as a release asset file** (e.g. `.intoto.jsonl`). The GitHub Attestations API entries exist but aren't visible to this Scorecard version.

Verified via API:
```
GET /repos/catatafishen/agentbridge/attestations/sha256:11aeb52781e53691b76ee93d16571839ed92a19c44efb1fe5ef51b8cbc76ae2d
→ HTTP 200 — 2 attestation bundles found (github + user)
```

## Fix

1. Add `id: attest` to the existing `attest-build-provenance` step to capture its `bundle-path` output.
2. Copy the bundle to `release-artifacts/provenance.intoto.jsonl` before the release is created.
3. Upload `provenance.intoto.jsonl` alongside the `.zip` and `.sigstore.json` files.

This makes provenance discoverable by both file-checking (older Scorecard) and API-checking (newer Scorecard) versions, and should raise the *Signed-Releases* score from 8 → 10.