### PR TITLE
feat(release): publish plugin ZIPs to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      packages: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
@@ -224,3 +225,17 @@ jobs:
             "$ARTIFACTS_DIR"/*.zip \
             "$ARTIFACTS_DIR"/*.sigstore.json \
             "$ARTIFACTS_DIR"/provenance.intoto.jsonl
+
+      - name: Publish plugin ZIPs to GitHub Packages
+        if: steps.version.outputs.skip != 'true'
+        env:
+          PLUGIN_VERSION: ${{ steps.version.outputs.version }}
+          CHANGELOG_FILE: build/changelog.html
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Publish to GitHub Packages (Maven layout) so users have a real
+          # package-registry distribution channel in addition to the GitHub
+          # release ZIP and the JetBrains Marketplace listing. Also gives
+          # OpenSSF Scorecard's "Packaging" check something to detect.
+          gradle :plugin-core:publish :plugin-experimental:publish --no-daemon --quiet

--- a/plugin-core/build.gradle.kts
+++ b/plugin-core/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     kotlin("jvm") version "2.3.20"
     id("org.jetbrains.intellij.platform") version "2.14.0"
     jacoco
+    `maven-publish`
 }
 
 sourceSets {
@@ -587,5 +588,44 @@ tasks.register("printFuzzClasspath") {
     dependsOn("testClasses")
     doLast {
         println(sourceSets.test.get().runtimeClasspath.asPath)
+    }
+}
+
+// Publish the built plugin ZIP to GitHub Packages so users (and tooling like
+// OpenSSF Scorecard) can discover and consume the plugin via a real package
+// registry, in addition to the GitHub Release and the JetBrains Marketplace.
+// Uses configure<PublishingExtension> because the IntelliJ Platform extension
+// also exposes a `publishing { ... }` DSL that would otherwise be selected.
+configure<PublishingExtension> {
+    publications {
+        create<MavenPublication>("pluginZip") {
+            groupId = "com.github.catatafishen"
+            artifactId = "ide-agent-for-copilot"
+            version = project.version.toString()
+            artifact(tasks.named("buildPlugin")) {
+                extension = "zip"
+            }
+            pom {
+                name.set("IDE Agent for Copilot")
+                description.set("IntelliJ plugin integrating GitHub Copilot via ACP/MCP.")
+                url.set("https://github.com/catatafishen/agentbridge")
+                licenses {
+                    license {
+                        name.set("MIT")
+                        url.set("https://github.com/catatafishen/agentbridge/blob/master/LICENSE")
+                    }
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/catatafishen/agentbridge")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR") ?: ""
+                password = System.getenv("GITHUB_TOKEN") ?: ""
+            }
+        }
     }
 }

--- a/plugin-experimental/build.gradle.kts
+++ b/plugin-experimental/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version "2.3.20"
     id("org.jetbrains.intellij.platform") version "2.14.0"
     jacoco
+    `maven-publish`
 }
 
 repositories {
@@ -189,5 +190,42 @@ tasks.named<JacocoReport>("jacocoTestReport") {
     reports {
         xml.required.set(true)
         html.required.set(true)
+    }
+}
+
+// Publish the experimental plugin ZIP to GitHub Packages alongside plugin-core.
+// See plugin-core/build.gradle.kts for the rationale (Scorecard packaging detection,
+// real package-registry distribution channel for users).
+configure<PublishingExtension> {
+    publications {
+        create<MavenPublication>("pluginZip") {
+            groupId = "com.github.catatafishen"
+            artifactId = "ide-agent-for-copilot-experimental"
+            version = project.version.toString()
+            artifact(tasks.named("buildPlugin")) {
+                extension = "zip"
+            }
+            pom {
+                name.set("IDE Agent for Copilot (Experimental)")
+                description.set("Experimental variant of the IntelliJ plugin integrating GitHub Copilot via ACP/MCP.")
+                url.set("https://github.com/catatafishen/agentbridge")
+                licenses {
+                    license {
+                        name.set("MIT")
+                        url.set("https://github.com/catatafishen/agentbridge/blob/master/LICENSE")
+                    }
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/catatafishen/agentbridge")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR") ?: ""
+                password = System.getenv("GITHUB_TOKEN") ?: ""
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes the OpenSSF Scorecard "Packaging" check, currently scoring 0.

## Why

Scorecard's [Packaging probe](https://github.com/ossf/scorecard/blob/main/checks/fileparser/github_workflow.go) only recognises a workflow as "publishes a package" when it pattern-matches one of a fixed list of publishing flows — `npm publish`, `gradle.*publish`, `docker/build-push-action`, `pypa/gh-action-pypi-publish`, etc. Our release workflow uses `gh release create` directly, which is not on that list, so the check stays at 0 even though we ship signed artifacts with provenance to GitHub Releases and the JetBrains Marketplace.

## What this PR does

Adds a real Maven-style package-registry distribution channel:

- Applies the `maven-publish` Gradle plugin in `plugin-core` and `plugin-experimental` and configures a `MavenPublication` that ships the existing `buildPlugin` ZIP to **GitHub Packages**.
  - Coordinates: `com.github.catatafishen:ide-agent-for-copilot:<version>` and `...-experimental:<version>`.
  - Uses `configure<PublishingExtension>` because the IntelliJ Platform Gradle plugin shadows the bare `publishing { ... }` DSL with its own marketplace-publishing extension.
- Extends the release job with `packages: write` and a new "Publish plugin ZIPs to GitHub Packages" step that runs `gradle :plugin-core:publish :plugin-experimental:publish` after the GitHub release is created.
  - The pattern (`actions/setup-java` + `gradle.*publish`) is exactly what Scorecard's `IsPackagingWorkflow` looks for, so the Packaging check should start scoring above 0 once this runs at least once on master.

## User-visible impact

Users gain a third install channel (Maven coordinates from GitHub Packages) on top of:
- the GitHub Release ZIP (signed, with provenance)
- the JetBrains Marketplace listing

Existing release artifacts, signing, attestation, and marketplace publishing are unchanged.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>