### PR TITLE
refactor(settings): group Tool Stats, Memory, Chat History under Storage

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemorySettingsConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemorySettingsConfigurable.java
@@ -59,10 +59,10 @@ public final class MemorySettingsConfigurable implements Configurable {
         gbc.gridy = 0;
         gbc.gridwidth = 2;
         JLabel desc = new JLabel(
-            "<html>Semantic memory powered by concepts from " +
+            "<html><body style='width: 420px'>Semantic memory powered by concepts from " +
                 "<a href=\"https://github.com/milla-jovovich/mempalace\">MemPalace</a>. " +
                 "Stores decisions, preferences, and milestones from conversations " +
-                "for cross-session recall.</html>");
+                "for cross-session recall.</body></html>");
         panel.add(desc, gbc);
 
         // ── Enabled ──
@@ -135,8 +135,8 @@ public final class MemorySettingsConfigurable implements Configurable {
 
         gbc.gridx = 1;
         JLabel backfillHint = new JLabel(
-            "<html><i>⚠ Can be slow if you have many sessions. " +
-                "Runs in the background.</i></html>");
+            "<html><body style='width: 280px'><i>⚠ Can be slow if you have many sessions. " +
+                "Runs in the background.</i></body></html>");
         backfillHint.setForeground(UIManager.getColor("Component.warningFocusColor"));
         panel.add(backfillHint, gbc);
 
@@ -177,8 +177,8 @@ public final class MemorySettingsConfigurable implements Configurable {
                 .listSessions(project.getBasePath()).size();
             if (sessionCount > 0) {
                 backfillStatusLabel.setText(
-                    "<html><b>" + sessionCount + " past sessions</b> available to mine. " +
-                        "Click below to populate memory from your conversation history.</html>");
+                    "<html><body style='width: 420px'><b>" + sessionCount + " past sessions</b> available to mine. " +
+                        "Click below to populate memory from your conversation history.</body></html>");
             } else {
                 backfillStatusLabel.setText("No past sessions found.");
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -66,22 +66,19 @@ public final class ToolCallStatisticsService implements Disposable {
         this.project = null;
     }
 
-    /**
-     * Initialize the SQLite database and subscribe to tool call events.
-     * Called lazily on first access via {@code getInstance()}.
-     *
-     * @throws RuntimeException if initialization fails (JDBC driver not found,
-     *                          database cannot be created, or subscription fails).
-     *                          The caller sets {@code initAttempted = true} regardless of
-     *                          success/failure to prevent retry loops — the service stays
-     *                          inert (connection == null) until the IDE is restarted.
-     */
     public void initialize() {
         if (project == null || project.getBasePath() == null) {
             throw new IllegalStateException(
                 "Cannot initialize ToolCallStatisticsService: project has no base path");
         }
         AgentBridgeStorageSettings storageSettings = AgentBridgeStorageSettings.getInstance();
+        // Compute the target path before the enabled check so migration runs unconditionally.
+        // Even when stats collection is disabled, the legacy {project}/.agentbridge/tool-stats.db
+        // must be moved out of the project tree so it no longer pollutes VCS views.
+        Path dbDir = storageSettings.getProjectStorageDir(project);
+        Path dbPath = dbDir.resolve(DB_FILENAME);
+        migrateLegacyDb(project.getBasePath(), dbPath);
+
         if (!storageSettings.isToolStatsEnabled()) {
             LOG.info("ToolCallStatisticsService: tool call statistics collection is disabled in settings — skipping init");
             return;
@@ -92,10 +89,7 @@ public final class ToolCallStatisticsService implements Disposable {
             throw new IllegalStateException("SQLite JDBC driver not found on classpath", e);
         }
         try {
-            Path dbDir = storageSettings.getProjectStorageDir(project);
             Files.createDirectories(dbDir);
-            Path dbPath = dbDir.resolve(DB_FILENAME);
-            migrateLegacyDb(project.getBasePath(), dbPath);
             initializeWithConnection(DriverManager.getConnection("jdbc:sqlite:" + dbPath));
             subscribeToToolCallEvents();
             LOG.info("ToolCallStatisticsService initialized at " + dbPath);
@@ -829,7 +823,9 @@ public final class ToolCallStatisticsService implements Disposable {
                     service.initAttempted = true;
                     try {
                         service.initialize();
-                        triggerBackfillIfNeeded(service, project);
+                        if (service.connection != null) {
+                            triggerBackfillIfNeeded(service, project);
+                        }
                     } catch (RuntimeException e) {
                         LOG.error("ToolCallStatisticsService initialization failed — "
                             + "tool call recording will be disabled until restart", e);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -2,6 +2,7 @@ package com.github.catatafishen.agentbridge.services;
 
 import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
 import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
+import com.github.catatafishen.agentbridge.settings.AgentBridgeStorageSettings;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
@@ -29,8 +30,12 @@ import java.util.Set;
 
 /**
  * Project-level service that records every MCP tool call in a SQLite database
- * ({@code {project}/.agentbridge/tool-stats.db}) and provides query methods for
- * the Tool Statistics UI panel.
+ * and provides query methods for the Tool Statistics UI panel.
+ *
+ * <p>The database location is resolved via {@link AgentBridgeStorageSettings},
+ * which defaults to {@code ~/.agentbridge/projects/<project>-<hash>/tool-stats.db}
+ * but can be overridden by the user. Stats collection can also be disabled
+ * entirely via the same settings page (see issue #351).</p>
  *
  * <p>Subscribes to {@link PsiBridgeService#TOOL_CALL_TOPIC} on the project
  * message bus. Records are appended on the calling thread (MCP handler threads)
@@ -72,25 +77,73 @@ public final class ToolCallStatisticsService implements Disposable {
      *                          inert (connection == null) until the IDE is restarted.
      */
     public void initialize() {
+        AgentBridgeStorageSettings storageSettings = AgentBridgeStorageSettings.getInstance();
+        if (!storageSettings.isToolStatsEnabled()) {
+            LOG.info("ToolCallStatisticsService: tool call statistics collection is disabled in settings — skipping init");
+            return;
+        }
         try {
             Class.forName("org.sqlite.JDBC");
         } catch (ClassNotFoundException e) {
             throw new IllegalStateException("SQLite JDBC driver not found on classpath", e);
         }
-        String basePath = project.getBasePath();
-        if (basePath == null) {
+        if (project.getBasePath() == null) {
             throw new IllegalStateException(
                 "Cannot initialize ToolCallStatisticsService: project has no base path");
         }
         try {
-            Path dbDir = Path.of(basePath, ".agentbridge");
+            Path dbDir = storageSettings.getProjectStorageDir(project);
             Files.createDirectories(dbDir);
             Path dbPath = dbDir.resolve(DB_FILENAME);
+            migrateLegacyDb(project.getBasePath(), dbPath);
             initializeWithConnection(DriverManager.getConnection("jdbc:sqlite:" + dbPath));
             subscribeToToolCallEvents();
             LOG.info("ToolCallStatisticsService initialized at " + dbPath);
         } catch (SQLException | IOException e) {
             throw new IllegalStateException("Failed to initialize ToolCallStatisticsService", e);
+        }
+    }
+
+    /**
+     * If a legacy {@code {project}/.agentbridge/tool-stats.db} exists and the
+     * new location does not, move the file to the new location. Best-effort —
+     * failures are logged but never fatal so the service can still proceed
+     * with a fresh database.
+     *
+     * <p>Also attempts to delete the now-empty legacy directory so the project
+     * tree is left clean.</p>
+     */
+    static void migrateLegacyDb(@NotNull String projectBasePath, @NotNull Path newDbPath) {
+        Path legacyDir = Path.of(projectBasePath, ".agentbridge");
+        Path legacyDb = legacyDir.resolve(DB_FILENAME);
+        if (!Files.exists(legacyDb) || Files.exists(newDbPath)) {
+            return;
+        }
+        try {
+            Files.createDirectories(newDbPath.getParent());
+            Files.move(legacyDb, newDbPath);
+            LOG.info("Migrated tool-stats.db from " + legacyDb + " to " + newDbPath);
+            // SQLite may also have left -journal/-wal/-shm sidecar files alongside the DB.
+            for (String suffix : new String[]{"-journal", "-wal", "-shm"}) {
+                Path sidecar = legacyDir.resolve(DB_FILENAME + suffix);
+                if (Files.exists(sidecar)) {
+                    try {
+                        Files.move(sidecar, Path.of(newDbPath + suffix));
+                    } catch (IOException ignored) {
+                        // Sidecar files are recreated by SQLite as needed; safe to leave behind.
+                    }
+                }
+            }
+            try (var entries = Files.list(legacyDir)) {
+                if (entries.findAny().isEmpty()) {
+                    Files.delete(legacyDir);
+                }
+            } catch (IOException ignored) {
+                // Leaving the empty .agentbridge directory behind is harmless.
+            }
+        } catch (IOException e) {
+            LOG.warn("Failed to migrate legacy tool-stats.db from " + legacyDb
+                + " — a fresh database will be created at " + newDbPath, e);
         }
     }
 
@@ -282,9 +335,10 @@ public final class ToolCallStatisticsService implements Disposable {
         if (project == null) return false;
         closeConnectionQuietly();
         try {
-            String basePath = project.getBasePath();
-            if (basePath == null) return false;
-            Path dbPath = Path.of(basePath, ".agentbridge", DB_FILENAME);
+            if (project.getBasePath() == null) return false;
+            Path dbPath = AgentBridgeStorageSettings.getInstance()
+                .getProjectStorageDir(project)
+                .resolve(DB_FILENAME);
             initializeWithConnection(DriverManager.getConnection("jdbc:sqlite:" + dbPath));
             LOG.info("Reconnected to ToolCallStatisticsService database after file move");
             return true;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -77,6 +77,10 @@ public final class ToolCallStatisticsService implements Disposable {
      *                          inert (connection == null) until the IDE is restarted.
      */
     public void initialize() {
+        if (project == null || project.getBasePath() == null) {
+            throw new IllegalStateException(
+                "Cannot initialize ToolCallStatisticsService: project has no base path");
+        }
         AgentBridgeStorageSettings storageSettings = AgentBridgeStorageSettings.getInstance();
         if (!storageSettings.isToolStatsEnabled()) {
             LOG.info("ToolCallStatisticsService: tool call statistics collection is disabled in settings — skipping init");
@@ -86,10 +90,6 @@ public final class ToolCallStatisticsService implements Disposable {
             Class.forName("org.sqlite.JDBC");
         } catch (ClassNotFoundException e) {
             throw new IllegalStateException("SQLite JDBC driver not found on classpath", e);
-        }
-        if (project.getBasePath() == null) {
-            throw new IllegalStateException(
-                "Cannot initialize ToolCallStatisticsService: project has no base path");
         }
         try {
             Path dbDir = storageSettings.getProjectStorageDir(project);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageConfigurable.java
@@ -1,0 +1,126 @@
+package com.github.catatafishen.agentbridge.settings;
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.ui.components.JBCheckBox;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.util.ui.FormBuilder;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+/**
+ * Settings page for AgentBridge plugin storage location and tool stats opt-out.
+ * Addresses issue #351 — moves {@code tool-stats.db} out of the project tree
+ * and into a user-configurable location.
+ */
+public final class AgentBridgeStorageConfigurable implements Configurable {
+
+    public static final String ID = "com.github.catatafishen.agentbridge.storage";
+
+    private TextFieldWithBrowseButton storageRootField;
+    private JBCheckBox toolStatsEnabledCb;
+    private AgentBridgeStorageSettings settings;
+    private JPanel mainPanel;
+
+    @Override
+    public @Nls(capitalization = Nls.Capitalization.Title) String getDisplayName() {
+        return "Storage";
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    @Override
+    public @NotNull JComponent createComponent() {
+        settings = AgentBridgeStorageSettings.getInstance();
+
+        storageRootField = new TextFieldWithBrowseButton();
+        storageRootField.addBrowseFolderListener(
+            "Select AgentBridge Storage Directory",
+            "All AgentBridge data (per-project tool-stats DB, embedding model cache, future plugin data) will be stored under this directory.",
+            null,
+            FileChooserDescriptorFactory.createSingleFolderDescriptor());
+        storageRootField.getTextField().setColumns(40);
+
+        JButton resetDefaultBtn = new JButton("Reset to default");
+        resetDefaultBtn.addActionListener(e -> storageRootField.setText(""));
+
+        JPanel pathRow = new JPanel();
+        pathRow.setLayout(new BoxLayout(pathRow, BoxLayout.X_AXIS));
+        pathRow.add(storageRootField);
+        pathRow.add(Box.createHorizontalStrut(6));
+        pathRow.add(resetDefaultBtn);
+
+        JBLabel defaultHint = new JBLabel(
+            "<html>Default: <code>" + AgentBridgeStorageSettings.getDefaultStorageRoot()
+                + "</code><br/>Per-project data lives under <code>&lt;root&gt;/projects/&lt;project-name&gt;-&lt;hash&gt;/</code>.</html>");
+        defaultHint.setForeground(UIUtil.getContextHelpForeground());
+        defaultHint.setFont(JBUI.Fonts.smallFont());
+
+        toolStatsEnabledCb = new JBCheckBox("Record tool call statistics");
+
+        JBLabel toolStatsHint = new JBLabel(
+            "<html>When enabled, every MCP tool call is logged to a per-project SQLite database "
+                + "and surfaced in the Tool Statistics and Session Stats panels. "
+                + "Disable to skip recording entirely (no data is collected).</html>");
+        toolStatsHint.setForeground(UIUtil.getContextHelpForeground());
+        toolStatsHint.setFont(JBUI.Fonts.smallFont());
+
+        JBLabel migrationNote = new JBLabel(
+            "<html><b>Note:</b> if a legacy <code>{project}/.agentbridge/tool-stats.db</code> "
+                + "exists, it is moved to the new location automatically on first launch. "
+                + "Changing the storage root takes effect on the next IDE restart.</html>");
+        migrationNote.setForeground(UIUtil.getContextHelpForeground());
+        migrationNote.setFont(JBUI.Fonts.smallFont());
+
+        mainPanel = FormBuilder.createFormBuilder()
+            .addComponent(new JBLabel(
+                "<html>Configure where AgentBridge stores per-project data files such as tool-call statistics.</html>"))
+            .addSeparator(8)
+            .addLabeledComponent("Storage root:", pathRow)
+            .addComponent(defaultHint, 2)
+            .addSeparator(12)
+            .addComponent(toolStatsEnabledCb)
+            .addComponent(toolStatsHint, 2)
+            .addSeparator(12)
+            .addComponent(migrationNote, 2)
+            .addComponentFillVertically(new JPanel(), 0)
+            .getPanel();
+        mainPanel.setBorder(JBUI.Borders.empty(8));
+
+        reset();
+        return mainPanel;
+    }
+
+    @Override
+    public boolean isModified() {
+        if (toolStatsEnabledCb.isSelected() != settings.isToolStatsEnabled()) return true;
+        String fieldText = storageRootField.getText().trim();
+        String currentRoot = settings.getCustomStorageRoot();
+        return !fieldText.equals(currentRoot == null ? "" : currentRoot);
+    }
+
+    @Override
+    public void apply() {
+        settings.setToolStatsEnabled(toolStatsEnabledCb.isSelected());
+        String path = storageRootField.getText().trim();
+        settings.setCustomStorageRoot(path.isEmpty() ? null : path);
+    }
+
+    @Override
+    public void reset() {
+        toolStatsEnabledCb.setSelected(settings.isToolStatsEnabled());
+        String customRoot = settings.getCustomStorageRoot();
+        storageRootField.setText(customRoot != null ? customRoot : "");
+    }
+
+    @Override
+    public void disposeUIResources() {
+        mainPanel = null;
+        storageRootField = null;
+        toolStatsEnabledCb = null;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageConfigurable.java
@@ -1,7 +1,9 @@
 package com.github.catatafishen.agentbridge.settings;
 
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.ui.TextBrowseFolderListener;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
@@ -32,17 +34,12 @@ public final class AgentBridgeStorageConfigurable implements Configurable {
         return "Storage";
     }
 
-    @SuppressWarnings("UnstableApiUsage")
     @Override
     public @NotNull JComponent createComponent() {
         settings = AgentBridgeStorageSettings.getInstance();
 
         storageRootField = new TextFieldWithBrowseButton();
-        storageRootField.addBrowseFolderListener(
-            "Select AgentBridge Storage Directory",
-            "All AgentBridge data (per-project tool-stats DB, embedding model cache, future plugin data) will be stored under this directory.",
-            null,
-            FileChooserDescriptorFactory.createSingleFolderDescriptor());
+        configureBrowseButton(storageRootField);
         storageRootField.getTextField().setColumns(40);
 
         JButton resetDefaultBtn = new JButton("Reset to default");
@@ -93,6 +90,13 @@ public final class AgentBridgeStorageConfigurable implements Configurable {
 
         reset();
         return mainPanel;
+    }
+
+    private static void configureBrowseButton(@NotNull TextFieldWithBrowseButton field) {
+        FileChooserDescriptor descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor();
+        descriptor.setTitle("Select AgentBridge Storage Directory");
+        descriptor.setDescription("AgentBridge per-project data files (tool-call statistics) will be stored under this directory.");
+        field.addBrowseFolderListener(new TextBrowseFolderListener(descriptor));
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageConfigurable.java
@@ -5,7 +5,6 @@ import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.ui.TextBrowseFolderListener;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
-import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
@@ -16,16 +15,18 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 
 /**
- * Settings page for AgentBridge plugin storage location and tool stats opt-out.
- * Addresses issue #351 — moves {@code tool-stats.db} out of the project tree
- * and into a user-configurable location.
+ * Root settings page for AgentBridge storage. Holds the shared storage root
+ * directory; child pages (Tool Statistics, Memory, Chat History) configure
+ * specific stores below it.
+ *
+ * <p>Addresses issue #351 — moves {@code tool-stats.db} out of the project
+ * tree and into a user-configurable location.</p>
  */
 public final class AgentBridgeStorageConfigurable implements Configurable {
 
     public static final String ID = "com.github.catatafishen.agentbridge.storage";
 
     private TextFieldWithBrowseButton storageRootField;
-    private JBCheckBox toolStatsEnabledCb;
     private AgentBridgeStorageSettings settings;
     private JPanel mainPanel;
 
@@ -40,7 +41,6 @@ public final class AgentBridgeStorageConfigurable implements Configurable {
 
         storageRootField = new TextFieldWithBrowseButton();
         configureBrowseButton(storageRootField);
-        storageRootField.getTextField().setColumns(40);
 
         JButton resetDefaultBtn = new JButton("Reset to default");
         resetDefaultBtn.addActionListener(e -> storageRootField.setText(""));
@@ -52,38 +52,35 @@ public final class AgentBridgeStorageConfigurable implements Configurable {
         pathRow.add(resetDefaultBtn);
 
         JBLabel defaultHint = new JBLabel(
-            "<html>Default: <code>" + AgentBridgeStorageSettings.getDefaultStorageRoot()
-                + "</code><br/>Per-project data lives under <code>&lt;root&gt;/projects/&lt;project-name&gt;-&lt;hash&gt;/</code>.</html>");
+            "<html><body style='width: 420px'>Default: <code>" + AgentBridgeStorageSettings.getDefaultStorageRoot()
+                + "</code><br/>Per-project data lives under <code>&lt;root&gt;/projects/&lt;project-name&gt;-&lt;hash&gt;/</code>.</body></html>");
         defaultHint.setForeground(UIUtil.getContextHelpForeground());
         defaultHint.setFont(JBUI.Fonts.smallFont());
 
-        toolStatsEnabledCb = new JBCheckBox("Record tool call statistics");
-
-        JBLabel toolStatsHint = new JBLabel(
-            "<html>When enabled, every MCP tool call is logged to a per-project SQLite database "
-                + "and surfaced in the Tool Statistics and Session Stats panels. "
-                + "Disable to skip recording entirely (no data is collected).</html>");
-        toolStatsHint.setForeground(UIUtil.getContextHelpForeground());
-        toolStatsHint.setFont(JBUI.Fonts.smallFont());
-
         JBLabel migrationNote = new JBLabel(
-            "<html><b>Note:</b> if a legacy <code>{project}/.agentbridge/tool-stats.db</code> "
+            "<html><body style='width: 420px'><b>Note:</b> if a legacy <code>{project}/.agentbridge/tool-stats.db</code> "
                 + "exists, it is moved to the new location automatically on first launch. "
-                + "Changing the storage root takes effect on the next IDE restart.</html>");
+                + "Changing the storage root takes effect on the next IDE restart.</body></html>");
         migrationNote.setForeground(UIUtil.getContextHelpForeground());
         migrationNote.setFont(JBUI.Fonts.smallFont());
 
+        JBLabel childPagesHint = new JBLabel(
+            "<html><body style='width: 420px'>Configure individual stores below: "
+                + "<b>Tool Statistics</b>, <b>Memory</b>, and <b>Chat History</b>.</body></html>");
+        childPagesHint.setForeground(UIUtil.getContextHelpForeground());
+        childPagesHint.setFont(JBUI.Fonts.smallFont());
+
         mainPanel = FormBuilder.createFormBuilder()
             .addComponent(new JBLabel(
-                "<html>Configure where AgentBridge stores per-project data files such as tool-call statistics.</html>"))
+                "<html><body style='width: 420px'>Configure where AgentBridge stores per-project data files "
+                    + "such as tool-call statistics.</body></html>"))
             .addSeparator(8)
             .addLabeledComponent("Storage root:", pathRow)
             .addComponent(defaultHint, 2)
             .addSeparator(12)
-            .addComponent(toolStatsEnabledCb)
-            .addComponent(toolStatsHint, 2)
-            .addSeparator(12)
             .addComponent(migrationNote, 2)
+            .addSeparator(12)
+            .addComponent(childPagesHint, 2)
             .addComponentFillVertically(new JPanel(), 0)
             .getPanel();
         mainPanel.setBorder(JBUI.Borders.empty(8));
@@ -101,7 +98,6 @@ public final class AgentBridgeStorageConfigurable implements Configurable {
 
     @Override
     public boolean isModified() {
-        if (toolStatsEnabledCb.isSelected() != settings.isToolStatsEnabled()) return true;
         String fieldText = storageRootField.getText().trim();
         String currentRoot = settings.getCustomStorageRoot();
         return !fieldText.equals(currentRoot == null ? "" : currentRoot);
@@ -109,14 +105,12 @@ public final class AgentBridgeStorageConfigurable implements Configurable {
 
     @Override
     public void apply() {
-        settings.setToolStatsEnabled(toolStatsEnabledCb.isSelected());
         String path = storageRootField.getText().trim();
         settings.setCustomStorageRoot(path.isEmpty() ? null : path);
     }
 
     @Override
     public void reset() {
-        toolStatsEnabledCb.setSelected(settings.isToolStatsEnabled());
         String customRoot = settings.getCustomStorageRoot();
         storageRootField.setText(customRoot != null ? customRoot : "");
     }
@@ -125,6 +119,5 @@ public final class AgentBridgeStorageConfigurable implements Configurable {
     public void disposeUIResources() {
         mainPanel = null;
         storageRootField = null;
-        toolStatsEnabledCb = null;
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettings.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettings.java
@@ -1,0 +1,140 @@
+package com.github.catatafishen.agentbridge.settings;
+
+import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+/**
+ * Application-level settings for where the AgentBridge plugin stores its
+ * persistent data files (tool-stats DB, embedding model cache, future plugin
+ * data).
+ *
+ * <p>Resolves to {@code ~/.agentbridge/} by default. Users can override the
+ * root via the "Storage" settings page. Per-project data lives under
+ * {@code <root>/projects/<project-name>-<hash>/}, keeping stats scoped to
+ * individual projects while moving them out of the project tree (see issue
+ * #351).</p>
+ */
+@Service(Service.Level.APP)
+@State(name = "AgentBridgeStorageSettings",
+       storages = @Storage("agentbridgeStorage.xml"))
+public final class AgentBridgeStorageSettings
+        implements PersistentStateComponent<AgentBridgeStorageSettings.State> {
+
+    private static final String DEFAULT_DIR_NAME = ".agentbridge";
+
+    private State myState = new State();
+
+    public static AgentBridgeStorageSettings getInstance() {
+        return PlatformApiCompat.getApplicationService(AgentBridgeStorageSettings.class);
+    }
+
+    /**
+     * Returns the user-configured custom root, or {@code null} if the default
+     * should be used.
+     */
+    @Nullable
+    public String getCustomStorageRoot() {
+        String s = myState.customStorageRoot;
+        return (s == null || s.isBlank()) ? null : s.trim();
+    }
+
+    public void setCustomStorageRoot(@Nullable String path) {
+        myState.customStorageRoot = (path == null || path.isBlank()) ? null : path.trim();
+    }
+
+    public boolean isToolStatsEnabled() {
+        return myState.toolStatsEnabled;
+    }
+
+    public void setToolStatsEnabled(boolean enabled) {
+        myState.toolStatsEnabled = enabled;
+    }
+
+    /**
+     * The default storage root: {@code <user.home>/.agentbridge}. This matches
+     * the location already used by the embedding model cache, so all plugin
+     * data lives in one user-visible directory.
+     */
+    @NotNull
+    public static Path getDefaultStorageRoot() {
+        return Paths.get(System.getProperty("user.home"), DEFAULT_DIR_NAME);
+    }
+
+    /**
+     * Returns the effective storage root — the user override if set, otherwise
+     * the default.
+     */
+    @NotNull
+    public Path getEffectiveStorageRoot() {
+        String custom = getCustomStorageRoot();
+        return custom != null ? Paths.get(custom) : getDefaultStorageRoot();
+    }
+
+    /**
+     * Returns the per-project data directory under the effective storage root.
+     * The directory is namespaced by project name plus a hash of the project
+     * base path so that projects with identical names do not collide.
+     */
+    @NotNull
+    public Path getProjectStorageDir(@NotNull Project project) {
+        String safeName = sanitize(project.getName());
+        String hashSource = project.getBasePath() != null ? project.getBasePath() : project.getName();
+        String hash = Integer.toHexString(hashSource.hashCode());
+        return getEffectiveStorageRoot().resolve("projects").resolve(safeName + "-" + hash);
+    }
+
+    private static String sanitize(@NotNull String name) {
+        StringBuilder sb = new StringBuilder(name.length());
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (Character.isLetterOrDigit(c) || c == '-' || c == '_' || c == '.') {
+                sb.append(c);
+            } else {
+                sb.append('_');
+            }
+        }
+        String out = sb.toString().toLowerCase(Locale.ROOT);
+        return out.isEmpty() ? "unnamed" : out;
+    }
+
+    @Override
+    public @NotNull State getState() {
+        return myState;
+    }
+
+    @Override
+    public void loadState(@NotNull State state) {
+        myState = state;
+    }
+
+    public static class State {
+        private String customStorageRoot = null;
+        private boolean toolStatsEnabled = true;
+
+        public String getCustomStorageRoot() {
+            return customStorageRoot;
+        }
+
+        public void setCustomStorageRoot(String customStorageRoot) {
+            this.customStorageRoot = customStorageRoot;
+        }
+
+        public boolean isToolStatsEnabled() {
+            return toolStatsEnabled;
+        }
+
+        public void setToolStatsEnabled(boolean toolStatsEnabled) {
+            this.toolStatsEnabled = toolStatsEnabled;
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettings.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettings.java
@@ -15,8 +15,7 @@ import java.util.Locale;
 
 /**
  * Application-level settings for where the AgentBridge plugin stores its
- * persistent data files (tool-stats DB, embedding model cache, future plugin
- * data).
+ * per-project data files (e.g. the tool-call statistics database).
  *
  * <p>Resolves to {@code ~/.agentbridge/} by default. Users can override the
  * root via the "Storage" settings page. Per-project data lives under
@@ -26,9 +25,9 @@ import java.util.Locale;
  */
 @Service(Service.Level.APP)
 @State(name = "AgentBridgeStorageSettings",
-       storages = @Storage("agentbridgeStorage.xml"))
+    storages = @Storage("agentbridgeStorage.xml"))
 public final class AgentBridgeStorageSettings
-        implements PersistentStateComponent<AgentBridgeStorageSettings.State> {
+    implements PersistentStateComponent<AgentBridgeStorageSettings.State> {
 
     private static final String DEFAULT_DIR_NAME = ".agentbridge";
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ChatHistoryConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ChatHistoryConfigurable.java
@@ -173,8 +173,8 @@ public final class ChatHistoryConfigurable implements Configurable {
 
         JPanel panel = FormBuilder.createFormBuilder()
             .addComponent(new JBLabel(
-                "<html>Conversation files stored in this project's "
-                    + "<code>.agent-work</code> directory.</html>"))
+                "<html><body style='width: 420px'>Conversation files stored in this project's "
+                    + "<code>.agent-work</code> directory.</body></html>"))
             .addComponent(summaryLabel)
             .addComponent(injectHistoryCheckbox)
             .addComponent(limitsPanel)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolStatsConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolStatsConfigurable.java
@@ -1,0 +1,84 @@
+package com.github.catatafishen.agentbridge.settings;
+
+import com.intellij.openapi.options.Configurable;
+import com.intellij.ui.components.JBCheckBox;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.util.ui.FormBuilder;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+/**
+ * Settings page controlling the tool-call statistics database. Lives under
+ * the Storage parent page; the underlying file location is governed by the
+ * shared storage root configured there.
+ */
+public final class ToolStatsConfigurable implements Configurable {
+
+    public static final String ID = "com.github.catatafishen.agentbridge.storage.toolStats";
+
+    private JBCheckBox toolStatsEnabledCb;
+    private AgentBridgeStorageSettings settings;
+    private JPanel mainPanel;
+
+    @Override
+    public @Nls(capitalization = Nls.Capitalization.Title) String getDisplayName() {
+        return "Tool Statistics";
+    }
+
+    @Override
+    public @NotNull JComponent createComponent() {
+        settings = AgentBridgeStorageSettings.getInstance();
+
+        toolStatsEnabledCb = new JBCheckBox("Record tool call statistics");
+
+        JBLabel toolStatsHint = new JBLabel(
+            "<html><body style='width: 420px'>When enabled, every MCP tool call is logged to a per-project SQLite "
+                + "database and surfaced in the Tool Statistics and Session Stats panels. "
+                + "Disable to skip recording entirely (no data is collected).</body></html>");
+        toolStatsHint.setForeground(UIUtil.getContextHelpForeground());
+        toolStatsHint.setFont(JBUI.Fonts.smallFont());
+
+        JBLabel locationHint = new JBLabel(
+            "<html><body style='width: 420px'>The database file is stored under the storage root configured "
+                + "on the parent <b>Storage</b> page.</body></html>");
+        locationHint.setForeground(UIUtil.getContextHelpForeground());
+        locationHint.setFont(JBUI.Fonts.smallFont());
+
+        mainPanel = FormBuilder.createFormBuilder()
+            .addComponent(toolStatsEnabledCb)
+            .addComponent(toolStatsHint, 2)
+            .addSeparator(12)
+            .addComponent(locationHint, 2)
+            .addComponentFillVertically(new JPanel(), 0)
+            .getPanel();
+        mainPanel.setBorder(JBUI.Borders.empty(8));
+
+        reset();
+        return mainPanel;
+    }
+
+    @Override
+    public boolean isModified() {
+        return toolStatsEnabledCb.isSelected() != settings.isToolStatsEnabled();
+    }
+
+    @Override
+    public void apply() {
+        settings.setToolStatsEnabled(toolStatsEnabledCb.isSelected());
+    }
+
+    @Override
+    public void reset() {
+        toolStatsEnabledCb.setSelected(settings.isToolStatsEnabled());
+    }
+
+    @Override
+    public void disposeUIResources() {
+        mainPanel = null;
+        toolStatsEnabledCb = null;
+    }
+}

--- a/plugin-core/src/main/resources/META-INF/plugin.xml
+++ b/plugin-core/src/main/resources/META-INF/plugin.xml
@@ -251,6 +251,13 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and Ope
       id="com.github.catatafishen.agentbridge.clientAgents.codex"
       displayName="Codex"/>
 
+    <!-- ── Storage (file locations + tool stats opt-out) ── -->
+    <projectConfigurable
+      parentId="com.github.catatafishen.agentbridge.settings"
+      instance="com.github.catatafishen.agentbridge.settings.AgentBridgeStorageConfigurable"
+      id="com.github.catatafishen.agentbridge.storage"
+      displayName="Storage"/>
+
     <!-- ── Project Files ── -->
     <projectConfigurable
       parentId="com.github.catatafishen.agentbridge.settings"

--- a/plugin-core/src/main/resources/META-INF/plugin.xml
+++ b/plugin-core/src/main/resources/META-INF/plugin.xml
@@ -176,9 +176,9 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and Ope
       id="com.github.catatafishen.agentbridge.chatInput"
       displayName="UI/UX"/>
 
-    <!-- ── Chat History ── -->
+    <!-- ── Chat History (under Storage) ── -->
     <projectConfigurable
-      parentId="com.github.catatafishen.agentbridge.settings"
+      parentId="com.github.catatafishen.agentbridge.storage"
       instance="com.github.catatafishen.agentbridge.settings.ChatHistoryConfigurable"
       id="com.github.catatafishen.agentbridge.chatHistory"
       displayName="Chat History"/>
@@ -251,12 +251,18 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and Ope
       id="com.github.catatafishen.agentbridge.clientAgents.codex"
       displayName="Codex"/>
 
-    <!-- ── Storage (file locations + tool stats opt-out) ── -->
+    <!-- ── Storage (file locations + child stores: tool stats, memory, chat history) ── -->
     <projectConfigurable
       parentId="com.github.catatafishen.agentbridge.settings"
       instance="com.github.catatafishen.agentbridge.settings.AgentBridgeStorageConfigurable"
       id="com.github.catatafishen.agentbridge.storage"
       displayName="Storage"/>
+
+    <projectConfigurable
+      parentId="com.github.catatafishen.agentbridge.storage"
+      instance="com.github.catatafishen.agentbridge.settings.ToolStatsConfigurable"
+      id="com.github.catatafishen.agentbridge.storage.toolStats"
+      displayName="Tool Statistics"/>
 
     <!-- ── Project Files ── -->
     <projectConfigurable
@@ -272,9 +278,9 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and Ope
       id="com.github.catatafishen.agentbridge.scratchTypes"
       displayName="Scratch File Types"/>
 
-    <!-- ── Memory (semantic memory / MemPalace) ── -->
+    <!-- ── Memory (semantic memory / MemPalace, under Storage) ── -->
     <projectConfigurable
-      parentId="com.github.catatafishen.agentbridge.settings"
+      parentId="com.github.catatafishen.agentbridge.storage"
       instance="com.github.catatafishen.agentbridge.memory.MemorySettingsConfigurable"
       id="com.github.catatafishen.agentbridge.memory"
       displayName="Memory"/>

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceMigrationTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceMigrationTest.java
@@ -1,0 +1,92 @@
+package com.github.catatafishen.agentbridge.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link ToolCallStatisticsService#migrateLegacyDb(String, Path)} —
+ * exercises the one-shot migration that moves
+ * {@code {project}/.agentbridge/tool-stats.db} to the new user-configurable
+ * storage location (issue #351).
+ */
+class ToolCallStatisticsServiceMigrationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void movesLegacyDbToNewLocationWhenNewMissing() throws IOException {
+        Path projectRoot = tempDir.resolve("project");
+        Path legacyDir = projectRoot.resolve(".agentbridge");
+        Files.createDirectories(legacyDir);
+        Path legacyDb = legacyDir.resolve("tool-stats.db");
+        byte[] payload = "fake-sqlite-bytes".getBytes();
+        Files.write(legacyDb, payload);
+
+        Path newDb = tempDir.resolve("new-loc").resolve("tool-stats.db");
+
+        ToolCallStatisticsService.migrateLegacyDb(projectRoot.toString(), newDb);
+
+        assertFalse(Files.exists(legacyDb), "legacy DB should be moved");
+        assertTrue(Files.exists(newDb), "new DB should exist");
+        assertArrayEquals(payload, Files.readAllBytes(newDb), "payload preserved");
+        assertFalse(Files.exists(legacyDir), "empty legacy dir should be cleaned up");
+    }
+
+    @Test
+    void doesNothingWhenNewDbAlreadyExists() throws IOException {
+        Path projectRoot = tempDir.resolve("project");
+        Path legacyDir = projectRoot.resolve(".agentbridge");
+        Files.createDirectories(legacyDir);
+        Path legacyDb = legacyDir.resolve("tool-stats.db");
+        Files.write(legacyDb, "legacy".getBytes());
+
+        Path newDb = tempDir.resolve("new-loc").resolve("tool-stats.db");
+        Files.createDirectories(newDb.getParent());
+        Files.write(newDb, "existing".getBytes());
+
+        ToolCallStatisticsService.migrateLegacyDb(projectRoot.toString(), newDb);
+
+        // Both files remain — migration did not touch them
+        assertTrue(Files.exists(legacyDb));
+        assertArrayEquals("legacy".getBytes(), Files.readAllBytes(legacyDb));
+        assertArrayEquals("existing".getBytes(), Files.readAllBytes(newDb));
+    }
+
+    @Test
+    void noOpWhenLegacyDbMissing() {
+        Path projectRoot = tempDir.resolve("project");
+        Path newDb = tempDir.resolve("new-loc").resolve("tool-stats.db");
+
+        // Should not throw, should not create anything
+        ToolCallStatisticsService.migrateLegacyDb(projectRoot.toString(), newDb);
+
+        assertFalse(Files.exists(newDb));
+    }
+
+    @Test
+    void migratesSidecarFilesAlongWithDb() throws IOException {
+        Path projectRoot = tempDir.resolve("project");
+        Path legacyDir = projectRoot.resolve(".agentbridge");
+        Files.createDirectories(legacyDir);
+        Files.write(legacyDir.resolve("tool-stats.db"), "db".getBytes());
+        Files.write(legacyDir.resolve("tool-stats.db-journal"), "j".getBytes());
+        Files.write(legacyDir.resolve("tool-stats.db-wal"), "w".getBytes());
+
+        Path newDb = tempDir.resolve("new-loc").resolve("tool-stats.db");
+
+        ToolCallStatisticsService.migrateLegacyDb(projectRoot.toString(), newDb);
+
+        assertTrue(Files.exists(newDb));
+        assertTrue(Files.exists(Path.of(newDb + "-journal")));
+        assertTrue(Files.exists(Path.of(newDb + "-wal")));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettingsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettingsTest.java
@@ -1,0 +1,79 @@
+package com.github.catatafishen.agentbridge.settings;
+
+import com.intellij.openapi.project.Project;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AgentBridgeStorageSettings} path-resolution helpers.
+ * The state lifecycle is covered by IntelliJ's built-in PersistentStateComponent
+ * machinery — tested here only via direct State manipulation.
+ */
+class AgentBridgeStorageSettingsTest {
+
+    @Test
+    void defaultStorageRootIsUserHomeDotAgentbridge() {
+        Path expected = Paths.get(System.getProperty("user.home"), ".agentbridge");
+        assertEquals(expected, AgentBridgeStorageSettings.getDefaultStorageRoot());
+    }
+
+    @Test
+    void effectiveRootUsesCustomWhenSet() {
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        settings.setCustomStorageRoot("/tmp/custom-ab");
+        assertEquals(Paths.get("/tmp/custom-ab"), settings.getEffectiveStorageRoot());
+    }
+
+    @Test
+    void effectiveRootFallsBackToDefaultWhenBlank() {
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        settings.setCustomStorageRoot("   ");
+        assertEquals(AgentBridgeStorageSettings.getDefaultStorageRoot(),
+            settings.getEffectiveStorageRoot());
+    }
+
+    @Test
+    void projectStorageDirIsNamespacedAndSanitized() {
+        Project project = Mockito.mock(Project.class);
+        Mockito.when(project.getName()).thenReturn("My Cool Project!");
+        Mockito.when(project.getBasePath()).thenReturn("/home/user/projects/cool");
+
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        settings.setCustomStorageRoot("/data/ab");
+
+        Path dir = settings.getProjectStorageDir(project);
+        // sanitized: spaces and ! become '_', lower-cased
+        assertTrue(dir.toString().contains("/projects/my_cool_project_-"),
+            "Expected sanitized project name in path: " + dir);
+        assertTrue(dir.startsWith(Paths.get("/data/ab/projects/")), "Path was: " + dir);
+    }
+
+    @Test
+    void projectStorageDirDifferentForProjectsWithSameName() {
+        Project p1 = Mockito.mock(Project.class);
+        Mockito.when(p1.getName()).thenReturn("demo");
+        Mockito.when(p1.getBasePath()).thenReturn("/home/a/demo");
+
+        Project p2 = Mockito.mock(Project.class);
+        Mockito.when(p2.getName()).thenReturn("demo");
+        Mockito.when(p2.getBasePath()).thenReturn("/home/b/demo");
+
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        assertNotEquals(settings.getProjectStorageDir(p1),
+            settings.getProjectStorageDir(p2),
+            "Projects with the same name but different base paths must get distinct directories");
+    }
+
+    @Test
+    void toolStatsEnabledDefaultsTrue() {
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        assertTrue(settings.isToolStatsEnabled());
+    }
+}


### PR DESCRIPTION
Builds on #355.

## Settings hierarchy change

Restructures the AgentBridge settings tree so the shared storage root lives on the **Storage** parent page, with three child pages configuring each store below it:

```
AgentBridge
├── UI/UX
├── MCP / Agents / …
└── Storage              ← storage root + migration note
    ├── Tool Statistics  ← new page, record-tool-calls toggle
    ├── Memory           ← moved from root
    └── Chat History     ← moved from root
```

The "Record tool call statistics" toggle moved from the Storage page into the new Tool Statistics page. `AgentBridgeStorageSettings` is unchanged — only the UI is reorganised.

## Layout fix

Several settings panels rendered too wide and forced the IntelliJ Settings dialog into horizontal scroll. This:
- Adds `<body style='width: 420px'>` width hints to the HTML descriptions on Storage, Tool Stats, Memory, and Chat History pages so they wrap with the dialog
- Removes the `setColumns(40)` on the storage path text field that was setting a wide preferred size

Build green, migration test still passes.