### PR TITLE
fix(apply_action): prevent EDT freeze from ambiguous class-import quick-fix

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/EdtUtil.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/EdtUtil.java
@@ -171,23 +171,48 @@ public final class EdtUtil {
     }
 
     /**
-     * Build a human-readable description of all visible modal dialogs.
+     * Build a human-readable description of any UI that is currently blocking the EDT
+     * — modal dialogs and active JBPopups (e.g. class-import choosers).
+     * <p>
+     * Popup detection uses the platform {@link com.intellij.openapi.ui.popup.JBPopupFactory}
+     * rather than scanning {@code Window.getWindows()}, so it covers heavyweight and
+     * lightweight popups consistently and avoids false positives from notifications
+     * or transient UI.
      *
-     * @return e.g. {@code " Modal dialog blocking: 'Settings', 'Confirm'"} or empty string if none
+     * @return e.g. {@code " Modal dialog blocking: 'Settings'"} or
+     * {@code " Popup blocking the EDT (e.g. an import-class chooser opened by a quick-fix)."}
+     * or empty string if nothing is blocking
      */
     public static String describeModalBlocker() {
         StringBuilder sb = new StringBuilder();
+        appendVisibleModalDialogs(sb);
+        if (isJbPopupActive()) {
+            sb.append(sb.isEmpty() ? " " : "; ");
+            sb.append("Popup blocking the EDT (e.g. an import-class chooser opened by a quick-fix). ")
+                .append("Such popups cannot be answered non-interactively — apply the change with edit_text instead.");
+        }
+        return sb.toString();
+    }
+
+    private static void appendVisibleModalDialogs(StringBuilder sb) {
         for (Window window : Window.getWindows()) {
             if (window instanceof Dialog dialog && dialog.isModal() && dialog.isVisible()) {
-                if (sb.isEmpty()) {
-                    sb.append(" Modal dialog blocking: ");
-                } else {
-                    sb.append(", ");
-                }
+                sb.append(sb.isEmpty() ? " Modal dialog blocking: " : ", ");
                 String title = dialog.getTitle();
                 sb.append("'").append(title != null && !title.isEmpty() ? title : "(untitled)").append("'");
             }
         }
-        return sb.toString();
+    }
+
+    /**
+     * Returns true if a JBPopup is currently active. Defensive: returns false on any
+     * exception so the modal-poll loop never crashes due to a diagnostic helper.
+     */
+    private static boolean isJbPopupActive() {
+        try {
+            return com.intellij.openapi.ui.popup.JBPopupFactory.getInstance().isPopupActive();
+        } catch (Exception | LinkageError ignored) {
+            return false;
+        }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/java/RefactoringJavaSupport.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/java/RefactoringJavaSupport.java
@@ -39,6 +39,30 @@ public class RefactoringJavaSupport {
     }
 
     /**
+     * Returns the fully-qualified names of all classes whose short (simple) name matches
+     * {@code simpleName}, searched against the project's resolve scope of {@code psiFile}
+     * (or full project scope if {@code psiFile} is {@code null}).
+     * <p>
+     * Used by {@code ApplyActionTool} to pre-flight ambiguous {@code Import class 'X'}
+     * quick-fixes — when more than one candidate exists, the IDE shows a class-chooser
+     * popup that cannot be answered non-interactively and would block the EDT.
+     * <p>
+     * Must be invoked inside a {@code ReadAction}.
+     */
+    public static java.util.List<String> findClassFqnsByShortName(@NotNull Project project,
+                                                                  @NotNull String simpleName,
+                                                                  @Nullable PsiFile psiFile) {
+        GlobalSearchScope scope = psiFile != null ? psiFile.getResolveScope() : GlobalSearchScope.allScope(project);
+        PsiClass[] classes = PsiShortNamesCache.getInstance(project).getClassesByName(simpleName, scope);
+        java.util.List<String> fqns = new java.util.ArrayList<>(classes.length);
+        for (PsiClass psiClass : classes) {
+            String fqn = psiClass.getQualifiedName();
+            fqns.add(fqn != null ? fqn : psiClass.getName());
+        }
+        return fqns;
+    }
+
+    /**
      * Builds a human-readable type hierarchy string for the given symbol.
      *
      * @param project    current project

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionTool.java
@@ -7,6 +7,7 @@ import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
 import com.github.catatafishen.agentbridge.ui.renderers.GitDiffRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.undo.UndoManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
@@ -16,6 +17,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
@@ -24,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -38,6 +41,8 @@ public final class ApplyActionTool extends QualityTool {
     private static final String PARAM_DRY_RUN = "dry_run";
     private static final String LINE_LABEL = " line ";
     private static final String ACTION_PREFIX = "Action '";
+    private static final String IMPORT_CLASS_PREFIX = "Import class '";
+    private static final int AMBIGUOUS_IMPORT_FQNS_TO_LIST = 5;
 
     public ApplyActionTool(Project project) {
         super(project);
@@ -154,6 +159,9 @@ public final class ApplyActionTool extends QualityTool {
         PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
         if (psiFile == null) return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_CANNOT_PARSE + pathStr;
 
+        String ambiguousImportError = checkAmbiguousImport(actionName, psiFile);
+        if (ambiguousImportError != null) return ambiguousImportError;
+
         Editor editor = getOrOpenEditor(vf);
         if (editor == null) {
             return "Error: Could not open editor for " + pathStr + ". Ensure the file is open in the IDE.";
@@ -263,6 +271,77 @@ public final class ApplyActionTool extends QualityTool {
         }
         return (applied ? "Applied" : "Applied with option") + " action: " + actionName
             + "\n  File: " + pathStr + LINE_LABEL + line + "\n\n" + diff;
+    }
+
+    /**
+     * Pre-flight check for ambiguous {@code Import class 'X'} quick-fixes.
+     * <p>
+     * When more than one class with the same simple name exists in the resolve scope,
+     * the IDE shows a class-chooser {@link com.intellij.openapi.ui.popup.JBPopup} that
+     * cannot be answered non-interactively. Invoking the action would block the EDT.
+     * <p>
+     * Returns an actionable error string when ambiguity is detected, otherwise {@code null}.
+     * Best-effort: only matches the English action name. Returns {@code null} on any failure
+     * (no Java module, PSI lookup error, etc.) so non-import actions are never blocked.
+     */
+    @Nullable
+    private String checkAmbiguousImport(String actionName, PsiFile psiFile) {
+        String simpleName = parseImportSimpleName(actionName);
+        if (simpleName == null) return null;
+        if (!PlatformApiCompat.isPluginInstalled("com.intellij.modules.java")) return null;
+        try {
+            List<String> candidates = ApplicationManager.getApplication().runReadAction(
+                (Computable<List<String>>) () -> com.github.catatafishen.agentbridge.psi.java.RefactoringJavaSupport
+                    .findClassFqnsByShortName(project, simpleName, psiFile)
+            );
+            if (candidates.size() > 1) {
+                return formatAmbiguousImportError(simpleName, candidates);
+            }
+        } catch (Exception | LinkageError e) {
+            LOG.debug("Ambiguous-import precheck skipped for '" + actionName + "'", e);
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the simple class name from an action name like {@code Import class 'Cell'}.
+     * Returns {@code null} if the action name doesn't match the expected pattern.
+     * <p>
+     * <b>Localization caveat:</b> this only matches the English action name. In a localized
+     * IDE this returns {@code null} and the precheck is a no-op — falling through to the
+     * normal action invocation path. The {@code describeModalBlocker()} popup-detection
+     * still surfaces the issue if the popup actually opens.
+     */
+    @Nullable
+    static String parseImportSimpleName(String actionName) {
+        if (actionName == null || !actionName.startsWith(IMPORT_CLASS_PREFIX)) return null;
+        int end = actionName.indexOf('\'', IMPORT_CLASS_PREFIX.length());
+        if (end <= IMPORT_CLASS_PREFIX.length()) return null;
+        return actionName.substring(IMPORT_CLASS_PREFIX.length(), end);
+    }
+
+    /**
+     * Formats the error message for an ambiguous import. Lists up to
+     * {@value #AMBIGUOUS_IMPORT_FQNS_TO_LIST} candidate FQNs and indicates how many more exist.
+     */
+    static String formatAmbiguousImportError(String simpleName, List<String> candidates) {
+        List<String> sorted = new ArrayList<>(candidates);
+        Collections.sort(sorted);
+        int show = Math.min(sorted.size(), AMBIGUOUS_IMPORT_FQNS_TO_LIST);
+        StringBuilder sb = new StringBuilder();
+        sb.append("Error: Import for '").append(simpleName).append("' is ambiguous (")
+            .append(sorted.size()).append(" candidates: ");
+        for (int i = 0; i < show; i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(sorted.get(i));
+        }
+        if (sorted.size() > show) {
+            sb.append(", … (").append(sorted.size() - show).append(" more)");
+        }
+        sb.append("). Invoking this quick-fix would open a class-chooser popup that cannot be ")
+            .append("answered non-interactively (and would freeze the EDT). ")
+            .append("Add the import line directly with edit_text using the fully-qualified name you want.");
+        return sb.toString();
     }
 
     private void undoLastAction(VirtualFile vf) {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionToolStaticMethodsTest.java
@@ -4,7 +4,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link ApplyActionTool#formatApplyResult}.
@@ -61,6 +66,89 @@ class ApplyActionToolStaticMethodsTest {
             assertTrue(result.contains("Selected option for"), result);
             assertTrue(result.contains("action: Import class"), result);
             assertTrue(result.contains("(no file changes)"), result);
+        }
+    }
+
+    @Nested
+    @DisplayName("parseImportSimpleName")
+    class ParseImportSimpleName {
+
+        @Test
+        @DisplayName("returns simple class name for English action name")
+        void englishActionName() {
+            assertEquals("Cell", ApplyActionTool.parseImportSimpleName("Import class 'Cell'"));
+            assertEquals("ArrayList", ApplyActionTool.parseImportSimpleName("Import class 'ArrayList'"));
+        }
+
+        @Test
+        @DisplayName("returns null for non-import action names")
+        void notAnImportAction() {
+            assertNull(ApplyActionTool.parseImportSimpleName("Optimize imports"));
+            assertNull(ApplyActionTool.parseImportSimpleName("Rename 'foo' to 'bar'"));
+            assertNull(ApplyActionTool.parseImportSimpleName(""));
+        }
+
+        @Test
+        @DisplayName("returns null for null input")
+        void nullInput() {
+            assertNull(ApplyActionTool.parseImportSimpleName(null));
+        }
+
+        @Test
+        @DisplayName("returns null for malformed action name (no closing quote)")
+        void noClosingQuote() {
+            assertNull(ApplyActionTool.parseImportSimpleName("Import class 'Cell"));
+        }
+
+        @Test
+        @DisplayName("returns null for empty class name")
+        void emptyClassName() {
+            assertNull(ApplyActionTool.parseImportSimpleName("Import class ''"));
+        }
+    }
+
+    @Nested
+    @DisplayName("formatAmbiguousImportError")
+    class FormatAmbiguousImportError {
+
+        @Test
+        @DisplayName("lists all candidates when count is small, sorted alphabetically")
+        void smallList() {
+            String result = ApplyActionTool.formatAmbiguousImportError(
+                "Cell", List.of("z.Cell", "a.Cell", "m.Cell")
+            );
+
+            assertTrue(result.startsWith("Error: Import for 'Cell' is ambiguous (3 candidates: "), result);
+            // Sorted alphabetically
+            int aIdx = result.indexOf("a.Cell");
+            int mIdx = result.indexOf("m.Cell");
+            int zIdx = result.indexOf("z.Cell");
+            assertTrue(aIdx > 0 && aIdx < mIdx && mIdx < zIdx, "Candidates should be sorted: " + result);
+            assertTrue(result.contains("edit_text"), result);
+            assertFalse(result.contains("more)"), "No 'more' suffix when all listed: " + result);
+        }
+
+        @Test
+        @DisplayName("truncates with 'N more' when exceeding the display cap")
+        void truncatesLongList() {
+            List<String> many = List.of(
+                "p1.Cell", "p2.Cell", "p3.Cell", "p4.Cell", "p5.Cell", "p6.Cell", "p7.Cell"
+            );
+
+            String result = ApplyActionTool.formatAmbiguousImportError("Cell", many);
+
+            assertTrue(result.contains("(7 candidates: "), result);
+            assertTrue(result.contains("p1.Cell"), result);
+            assertTrue(result.contains("p5.Cell"), result);
+            assertTrue(result.contains("… (2 more)"), result);
+        }
+
+        @Test
+        @DisplayName("error message points the user to edit_text")
+        void mentionsEditText() {
+            String result = ApplyActionTool.formatAmbiguousImportError("X", List.of("a.X", "b.X"));
+            assertTrue(result.contains("edit_text"), result);
+            assertTrue(result.contains("freeze") || result.contains("non-interactively"), result);
         }
     }
 }


### PR DESCRIPTION
## Summary

Prevents the IDE-freeze pattern documented in `.agent-work/freeze-investigation-2026-04-30.md`:

`apply_action` invoking the Kotlin/Java "Import class 'X'" quick-fix opens a `JBPopup` class chooser when multiple classes match the simple name (`Cell`, `Action`, `Group`, …). The popup waits for user selection, blocks the EDT indefinitely, and the existing 30-second caller timeout doesn't help because the queued EDT runnable still waits for the popup. Subsequent tool calls pile up → full IDE freeze, requiring a process kill.

## Changes

**Pre-flight ambiguous imports in `ApplyActionTool`** – when the action name is `Import class '<name>'` and >1 candidate exists in the file's resolve scope, refuse with an actionable error pointing the agent at `edit_text`. The PSI lookup lives in `RefactoringJavaSupport.findClassFqnsByShortName` (Java-only helper) so Java PSI types are not loaded in non-Java IDEs. Gated by `PlatformApiCompat.isPluginInstalled("com.intellij.modules.java")`.

**Popup-aware `EdtUtil.describeModalBlocker()`** – also reports active JBPopups via `JBPopupFactory.getInstance().isPopupActive()`. Future popup-blocking actions now surface "Popup blocking the EDT — popups can't be answered non-interactively; use edit_text instead" rather than a silent timeout.

**Tests** – pure-static helpers `parseImportSimpleName` (5 tests) and `formatAmbiguousImportError` (3 tests).

## Deferred (per rubber-duck design review)

- **Cancel-on-timeout** – fire-and-forget `invokeLater` from a stuck EDT can't recover the popup wait (the cleanup runnable can't run until the popup is gone).
- **Proactive popup interception** – proper fix needs a popup listener registered before action invocation, applied across all popup-capable tools (`get_action_options`, `apply_quickfix`, …). Significant scope; tracked in the investigation doc.

## Stacked on #361

Base is `fix/settings-layout-overflow` so this diff is clean. After #361 merges, GitHub will automatically retarget to `master`.

## Test plan

- `./gradlew :plugin-core:test --tests ApplyActionToolStaticMethodsTest --tests EdtUtilTest` → all green
- `build_project plugin-core` → 0 errors, 0 warnings

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>