### PR TITLE
fix(apply_action): cancel quick-fix popups during invocation to prevent EDT freeze

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/EdtUtil.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/EdtUtil.java
@@ -171,23 +171,48 @@ public final class EdtUtil {
     }
 
     /**
-     * Build a human-readable description of all visible modal dialogs.
+     * Build a human-readable description of any UI that is currently blocking the EDT
+     * — modal dialogs and active JBPopups (e.g. class-import choosers).
+     * <p>
+     * Popup detection uses the platform {@link com.intellij.openapi.ui.popup.JBPopupFactory}
+     * rather than scanning {@code Window.getWindows()}, so it covers heavyweight and
+     * lightweight popups consistently and avoids false positives from notifications
+     * or transient UI.
      *
-     * @return e.g. {@code " Modal dialog blocking: 'Settings', 'Confirm'"} or empty string if none
+     * @return e.g. {@code " Modal dialog blocking: 'Settings'"} or
+     * {@code " Popup blocking the EDT (e.g. an import-class chooser opened by a quick-fix)."}
+     * or empty string if nothing is blocking
      */
     public static String describeModalBlocker() {
         StringBuilder sb = new StringBuilder();
+        appendVisibleModalDialogs(sb);
+        if (isJbPopupActive()) {
+            sb.append(sb.isEmpty() ? " " : "; ");
+            sb.append("Popup blocking the EDT (e.g. an import-class chooser opened by a quick-fix). ")
+                .append("Such popups cannot be answered non-interactively — apply the change with edit_text instead.");
+        }
+        return sb.toString();
+    }
+
+    private static void appendVisibleModalDialogs(StringBuilder sb) {
         for (Window window : Window.getWindows()) {
             if (window instanceof Dialog dialog && dialog.isModal() && dialog.isVisible()) {
-                if (sb.isEmpty()) {
-                    sb.append(" Modal dialog blocking: ");
-                } else {
-                    sb.append(", ");
-                }
+                sb.append(sb.isEmpty() ? " Modal dialog blocking: " : ", ");
                 String title = dialog.getTitle();
                 sb.append("'").append(title != null && !title.isEmpty() ? title : "(untitled)").append("'");
             }
         }
-        return sb.toString();
+    }
+
+    /**
+     * Returns true if a JBPopup is currently active. Defensive: returns false on any
+     * exception so the modal-poll loop never crashes due to a diagnostic helper.
+     */
+    private static boolean isJbPopupActive() {
+        try {
+            return com.intellij.openapi.ui.popup.JBPopupFactory.getInstance().isPopupActive();
+        } catch (Exception | LinkageError ignored) {
+            return false;
+        }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/java/RefactoringJavaSupport.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/java/RefactoringJavaSupport.java
@@ -39,6 +39,30 @@ public class RefactoringJavaSupport {
     }
 
     /**
+     * Returns the fully-qualified names of all classes whose short (simple) name matches
+     * {@code simpleName}, searched against the project's resolve scope of {@code psiFile}
+     * (or full project scope if {@code psiFile} is {@code null}).
+     * <p>
+     * Used by {@code ApplyActionTool} to pre-flight ambiguous {@code Import class 'X'}
+     * quick-fixes — when more than one candidate exists, the IDE shows a class-chooser
+     * popup that cannot be answered non-interactively and would block the EDT.
+     * <p>
+     * Must be invoked inside a {@code ReadAction}.
+     */
+    public static java.util.List<String> findClassFqnsByShortName(@NotNull Project project,
+                                                                  @NotNull String simpleName,
+                                                                  @Nullable PsiFile psiFile) {
+        GlobalSearchScope scope = psiFile != null ? psiFile.getResolveScope() : GlobalSearchScope.allScope(project);
+        PsiClass[] classes = PsiShortNamesCache.getInstance(project).getClassesByName(simpleName, scope);
+        java.util.List<String> fqns = new java.util.ArrayList<>(classes.length);
+        for (PsiClass psiClass : classes) {
+            String fqn = psiClass.getQualifiedName();
+            fqns.add(fqn != null ? fqn : psiClass.getName());
+        }
+        return fqns;
+    }
+
+    /**
      * Builds a human-readable type hierarchy string for the given symbol.
      *
      * @param project    current project

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionTool.java
@@ -7,6 +7,7 @@ import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
 import com.github.catatafishen.agentbridge.ui.renderers.GitDiffRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.undo.UndoManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
@@ -16,6 +17,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
@@ -24,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -38,6 +41,8 @@ public final class ApplyActionTool extends QualityTool {
     private static final String PARAM_DRY_RUN = "dry_run";
     private static final String LINE_LABEL = " line ";
     private static final String ACTION_PREFIX = "Action '";
+    private static final String IMPORT_CLASS_PREFIX = "Import class '";
+    private static final int AMBIGUOUS_IMPORT_FQNS_TO_LIST = 5;
 
     public ApplyActionTool(Project project) {
         super(project);
@@ -154,6 +159,9 @@ public final class ApplyActionTool extends QualityTool {
         PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
         if (psiFile == null) return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_CANNOT_PARSE + pathStr;
 
+        String ambiguousImportError = checkAmbiguousImport(actionName, psiFile);
+        if (ambiguousImportError != null) return ambiguousImportError;
+
         Editor editor = getOrOpenEditor(vf);
         if (editor == null) {
             return "Error: Could not open editor for " + pathStr + ". Ensure the file is open in the IDE.";
@@ -263,6 +271,77 @@ public final class ApplyActionTool extends QualityTool {
         }
         return (applied ? "Applied" : "Applied with option") + " action: " + actionName
             + "\n  File: " + pathStr + LINE_LABEL + line + "\n\n" + diff;
+    }
+
+    /**
+     * Pre-flight check for ambiguous {@code Import class 'X'} quick-fixes.
+     * <p>
+     * When more than one class with the same simple name exists in the resolve scope,
+     * the IDE shows a class-chooser {@link com.intellij.openapi.ui.popup.JBPopup} that
+     * cannot be answered non-interactively. Invoking the action would block the EDT.
+     * <p>
+     * Returns an actionable error string when ambiguity is detected, otherwise {@code null}.
+     * Best-effort: only matches the English action name. Returns {@code null} on any failure
+     * (no Java module, PSI lookup error, etc.) so non-import actions are never blocked.
+     */
+    @Nullable
+    private String checkAmbiguousImport(String actionName, PsiFile psiFile) {
+        String simpleName = parseImportSimpleName(actionName);
+        if (simpleName == null) return null;
+        if (!PlatformApiCompat.isPluginInstalled("com.intellij.modules.java")) return null;
+        try {
+            List<String> candidates = ApplicationManager.getApplication().runReadAction(
+                (Computable<List<String>>) () -> com.github.catatafishen.agentbridge.psi.java.RefactoringJavaSupport
+                    .findClassFqnsByShortName(project, simpleName, psiFile)
+            );
+            if (candidates.size() > 1) {
+                return formatAmbiguousImportError(simpleName, candidates);
+            }
+        } catch (Exception | LinkageError e) {
+            LOG.debug("Ambiguous-import precheck skipped for '" + actionName + "'", e);
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the simple class name from an action name like {@code Import class 'Cell'}.
+     * Returns {@code null} if the action name doesn't match the expected pattern.
+     * <p>
+     * <b>Localization caveat:</b> this only matches the English action name. In a localized
+     * IDE this returns {@code null} and the precheck is a no-op — falling through to the
+     * normal action invocation path. The {@code describeModalBlocker()} popup-detection
+     * still surfaces the issue if the popup actually opens.
+     */
+    @Nullable
+    static String parseImportSimpleName(String actionName) {
+        if (actionName == null || !actionName.startsWith(IMPORT_CLASS_PREFIX)) return null;
+        int end = actionName.indexOf('\'', IMPORT_CLASS_PREFIX.length());
+        if (end <= IMPORT_CLASS_PREFIX.length()) return null;
+        return actionName.substring(IMPORT_CLASS_PREFIX.length(), end);
+    }
+
+    /**
+     * Formats the error message for an ambiguous import. Lists up to
+     * {@value #AMBIGUOUS_IMPORT_FQNS_TO_LIST} candidate FQNs and indicates how many more exist.
+     */
+    static String formatAmbiguousImportError(String simpleName, List<String> candidates) {
+        List<String> sorted = new ArrayList<>(candidates);
+        Collections.sort(sorted);
+        int show = Math.min(sorted.size(), AMBIGUOUS_IMPORT_FQNS_TO_LIST);
+        StringBuilder sb = new StringBuilder();
+        sb.append("Error: Import for '").append(simpleName).append("' is ambiguous (")
+            .append(sorted.size()).append(" candidates: ");
+        for (int i = 0; i < show; i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(sorted.get(i));
+        }
+        if (sorted.size() > show) {
+            sb.append(", … (").append(sorted.size() - show).append(" more)");
+        }
+        sb.append("). Invoking this quick-fix would open a class-chooser popup that cannot be ")
+            .append("answered non-interactively (and would freeze the EDT). ")
+            .append("Add the import line directly with edit_text using the fully-qualified name you want.");
+        return sb.toString();
     }
 
     private void undoLastAction(VirtualFile vf) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionTool.java
@@ -221,7 +221,13 @@ public final class ApplyActionTool extends QualityTool {
 
     private String applyAsDryRun(String actionName, String pathStr, String before,
                                  ActionContext ctx, VirtualFile vf) {
-        invokeRespectingWriteAction(actionName, ctx);
+        PopupInterceptor.Result popupResult = PopupInterceptor.runDetectingPopups(
+            ctx.editor().getComponent(),
+            () -> invokeRespectingWriteAction(actionName, ctx)
+        );
+        if (popupResult.popupWasOpened()) {
+            return PopupInterceptor.formatPopupBlockedError(actionName, popupResult);
+        }
         PsiDocumentManager.getInstance(project).commitDocument(ctx.doc());
         String after = ctx.doc().getText();
         String diff = DiffUtils.unifiedDiff(before, after, pathStr);
@@ -237,10 +243,17 @@ public final class ApplyActionTool extends QualityTool {
                                  String before, ActionContext ctx) {
         VirtualFile vf = FileDocumentManager.getInstance().getFile(ctx.doc());
         FileTool.notifyBeforeEdit(project, vf, ctx.doc());
+        PopupInterceptor.Result popupResult;
         try {
-            invokeRespectingWriteAction(actionName, ctx);
+            popupResult = PopupInterceptor.runDetectingPopups(
+                ctx.editor().getComponent(),
+                () -> invokeRespectingWriteAction(actionName, ctx)
+            );
         } finally {
             FileTool.notifyEditComplete();
+        }
+        if (popupResult.popupWasOpened()) {
+            return PopupInterceptor.formatPopupBlockedError(actionName, popupResult);
         }
         PsiDocumentManager.getInstance(project).commitDocument(ctx.doc());
         FileDocumentManager.getInstance().saveDocument(ctx.doc());

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyQuickfixTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyQuickfixTool.java
@@ -218,12 +218,21 @@ public final class ApplyQuickfixTool extends QualityTool {
 
         var fix = fixes[Math.min(fixIndex, fixes.length - 1)];
 
-        com.intellij.openapi.command.CommandProcessor.getInstance().executeCommand(
-            project,
-            () -> fix.applyFix(project, targetProblem),
-            "Apply Quick Fix: " + fix.getName(),
-            null
+        // Wrap in PopupInterceptor so a quick-fix that opens a JBPopup chooser (e.g. a
+        // class-import disambiguation) cannot freeze the EDT — see PopupInterceptor and
+        // .agent-work/freeze-investigation-2026-04-30.md.
+        // No editor available here → null owner falls back to a global frame scan.
+        PopupInterceptor.Result popupResult = PopupInterceptor.runDetectingPopups(null,
+            () -> com.intellij.openapi.command.CommandProcessor.getInstance().executeCommand(
+                project,
+                () -> fix.applyFix(project, targetProblem),
+                "Apply Quick Fix: " + fix.getName(),
+                null
+            )
         );
+        if (popupResult.popupWasOpened()) {
+            return PopupInterceptor.formatPopupBlockedError("apply_quickfix:" + fix.getName(), popupResult);
+        }
 
         PsiDocumentManager.getInstance(project).commitAllDocuments();
         FileDocumentManager.getInstance().saveAllDocuments();

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetActionOptionsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetActionOptionsTool.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Runs an intention action and intercepts any dialog it opens, returning the dialog options
@@ -145,14 +146,27 @@ public final class GetActionOptionsTool extends QualityTool {
         // Capture document text before running the action
         String before = doc.getText();
 
-        // Run the action and intercept any dialog it opens
-        DialogInterceptor.DialogInfo dialogInfo = DialogInterceptor.runAndCapture(
-            () -> invokeRespectingWriteAction(actionName, action, editor, psiFile)
+        // Run the action and intercept any dialog OR popup it opens.
+        // - DialogInterceptor handles modal Dialogs (radio/checkbox forms with OK button).
+        // - PopupInterceptor handles JBPopup choosers (e.g. "select which Cell to import"),
+        //   which would otherwise pump a nested event loop and freeze the EDT.
+        // See .agent-work/freeze-investigation-2026-04-30.md.
+        AtomicReference<DialogInterceptor.DialogInfo> dialogRef = new AtomicReference<>();
+        PopupInterceptor.Result popupResult = PopupInterceptor.runDetectingPopups(
+            editor.getComponent(),
+            () -> dialogRef.set(DialogInterceptor.runAndCapture(
+                () -> invokeRespectingWriteAction(actionName, action, editor, psiFile)
+            ))
         );
 
         PsiDocumentManager.getInstance(project).commitAllDocuments();
         String after = doc.getText();
 
+        if (popupResult.popupWasOpened()) {
+            return PopupInterceptor.formatPopupBlockedError(actionName, popupResult);
+        }
+
+        DialogInterceptor.DialogInfo dialogInfo = dialogRef.get();
         if (dialogInfo != null) {
             // A dialog was intercepted — no changes were committed (dialog was cancelled)
             return formatDialogOptions(actionName, pathStr, targetLine, dialogInfo);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupInterceptor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupInterceptor.java
@@ -1,0 +1,288 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.ui.popup.JBPopup;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.AWTEventListener;
+import java.awt.event.WindowEvent;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Detects and cancels {@link JBPopup quick-fix / chooser popups} that an
+ * {@link com.intellij.codeInsight.intention.IntentionAction} opens during {@code invoke()}.
+ *
+ * <p><b>Why this exists — DO NOT REMOVE without reading
+ * {@code .agent-work/freeze-investigation-2026-04-30.md}.</b>
+ *
+ * <p>When an {@code IntentionAction} like {@code "Import class 'Cell'"} cannot decide what to do
+ * non-interactively (e.g. multiple {@code Cell} classes are importable), it opens a heavyweight
+ * {@link JBPopup} class chooser and pumps a <em>nested AWT event loop</em> on the EDT until the
+ * user picks an option. From outside that nested loop, the EDT looks frozen — every other tool
+ * call queued via {@code invokeLater} starves, and the entire IDE becomes unresponsive.
+ * {@link com.github.catatafishen.agentbridge.psi.EdtUtil#describeModalBlocker EdtUtil} can
+ * <em>diagnose</em> that situation after the fact (after the 1.5 s modal-poll timeout), but the
+ * EDT is still stuck inside the popup loop because nothing has cancelled the popup.
+ *
+ * <p>This interceptor closes that gap. It installs a global AWT {@code WINDOW_OPENED} listener,
+ * runs the action, and — when a new popup window appears <em>inside</em> the nested loop —
+ * looks up the corresponding {@link JBPopup} via {@link JBPopupFactory#getChildPopups} and calls
+ * {@link JBPopup#cancel()} on the EDT. {@code cancel()} disposes the popup synchronously, which
+ * exits the nested event loop, and the original {@code action.invoke()} call returns to the
+ * caller. The caller can then report a structured "popup blocked" error to the agent so it can
+ * choose a different strategy ({@code edit_text}, ambiguous-import pre-flight, etc.).
+ *
+ * <p>The detection is <em>scoped</em> to a chosen owner component (typically the editor's
+ * root pane). We snapshot the popups visible under that owner before invoking the action and
+ * cancel only popups that were not present in the snapshot. This avoids cancelling unrelated
+ * popups that happen to be open in the IDE at the same time (e.g. a tool-window quick search).
+ *
+ * <p>This handles the heavyweight-popup freeze case only. Lightweight popups (overlaid on
+ * {@link javax.swing.JLayeredPane} without a nested event loop) cannot freeze the EDT and are
+ * intentionally out of scope.
+ *
+ * <p>All methods must be called from the EDT.
+ *
+ * @see DialogInterceptor for the analogous pattern targeting modal {@link java.awt.Dialog}s.
+ */
+final class PopupInterceptor {
+
+    private static final Logger LOG = Logger.getInstance(PopupInterceptor.class);
+
+    /**
+     * Snapshot returned to the caller after invocation.
+     */
+    record Result(boolean popupWasOpened, @NotNull List<String> popupTitles, boolean cancelled) {
+
+        @NotNull
+        String describe() {
+            if (popupTitles.isEmpty()) {
+                return "(unidentified popup)";
+            }
+            return String.join(", ", popupTitles.stream().map(t -> "'" + t + "'").toList());
+        }
+    }
+
+    private PopupInterceptor() {
+    }
+
+    /**
+     * Runs {@code action}, cancelling any new {@link JBPopup} that opens under {@code owner}'s
+     * window during invocation. Returns a {@link Result} describing what was caught (if anything).
+     *
+     * @param owner  optional component used to scope popup detection. Pass the editor component
+     *               or root pane. {@code null} falls back to a global scan across all frames.
+     * @param action the EDT-bound action whose popup-opening side-effect should be intercepted.
+     */
+    @NotNull
+    static Result runDetectingPopups(@Nullable Component owner, @NotNull Runnable action) {
+        // Snapshot the popups already open under this owner so we cancel ONLY new ones.
+        Set<JBPopup> baseline = collectActivePopups(owner);
+        AtomicReference<List<JBPopup>> capturedRef = new AtomicReference<>(List.of());
+
+        AWTEventListener listener = event -> onWindowEvent(event, owner, baseline, capturedRef);
+
+        Toolkit.getDefaultToolkit().addAWTEventListener(listener, AWTEvent.WINDOW_EVENT_MASK);
+        try {
+            action.run();
+        } finally {
+            Toolkit.getDefaultToolkit().removeAWTEventListener(listener);
+        }
+
+        List<JBPopup> captured = capturedRef.get();
+        if (captured.isEmpty()) {
+            return new Result(false, List.of(), false);
+        }
+
+        List<String> titles = new ArrayList<>(captured.size());
+        boolean allCancelled = cancelAndCollectTitles(captured, titles);
+        return new Result(true, List.copyOf(titles), allCancelled);
+    }
+
+    private static void onWindowEvent(@NotNull AWTEvent event, @Nullable Component owner,
+                                      @NotNull Set<JBPopup> baseline,
+                                      @NotNull AtomicReference<List<JBPopup>> capturedRef) {
+        if (!(event instanceof WindowEvent we) || we.getID() != WindowEvent.WINDOW_OPENED) {
+            return;
+        }
+        if (!capturedRef.get().isEmpty()) {
+            return; // already captured one set; ignore further window-opens
+        }
+        try {
+            List<JBPopup> newPopups = diffNewPopups(owner, baseline);
+            if (newPopups.isEmpty()) {
+                return;
+            }
+            capturedRef.set(newPopups);
+            // cancel() must run on the EDT inside the popup's nested event loop so the loop
+            // exits and action.invoke() returns. The AWT listener fires on the EDT, so we
+            // call cancel() right here — the very same EDT cycle the popup opened in.
+            for (JBPopup popup : newPopups) {
+                tryCancel(popup);
+            }
+        } catch (Exception | LinkageError t) {
+            // Defensive: never let a diagnostic listener crash the EDT.
+            LOG.warn("PopupInterceptor: failed while inspecting opened window", t);
+        }
+    }
+
+    private static boolean cancelAndCollectTitles(@NotNull List<JBPopup> popups,
+                                                  @NotNull List<String> titlesOut) {
+        boolean allCancelled = true;
+        for (JBPopup popup : popups) {
+            titlesOut.add(extractPopupTitle(popup));
+            // Defensive second cancel pass for the unusual case where the listener saw the
+            // window AFTER action.run() returned (the new window event was queued but not yet
+            // dispatched while the action was still on the stack).
+            if (!tryCancel(popup) || !popup.isDisposed()) {
+                allCancelled = false;
+            }
+        }
+        return allCancelled;
+    }
+
+    private static boolean tryCancel(@NotNull JBPopup popup) {
+        try {
+            if (!popup.isDisposed()) {
+                popup.cancel();
+            }
+            return true;
+        } catch (Exception | LinkageError t) {
+            LOG.warn("PopupInterceptor: failed to cancel popup", t);
+            return false;
+        }
+    }
+
+    // ── Pure helpers (unit-testable) ──────────────────────────
+
+    /**
+     * Returns the popups visible <em>now</em> that were not in {@code baseline}. Pure function
+     * over the live UI state — exposed at package-private level so the listener path and tests
+     * use the same logic.
+     */
+    @NotNull
+    static List<JBPopup> diffNewPopups(@Nullable Component owner, @NotNull Set<JBPopup> baseline) {
+        List<JBPopup> result = new ArrayList<>();
+        for (JBPopup popup : collectActivePopups(owner)) {
+            if (!baseline.contains(popup)) {
+                result.add(popup);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Collects active {@link JBPopup}s anchored under {@code owner}'s window. When {@code owner}
+     * is {@code null} (no editor available), falls back to scanning every {@link Frame}.
+     */
+    @NotNull
+    static Set<JBPopup> collectActivePopups(@Nullable Component owner) {
+        Set<JBPopup> result = new HashSet<>();
+        try {
+            JBPopupFactory factory = JBPopupFactory.getInstance();
+            if (factory == null) {
+                return result;
+            }
+            if (owner != null) {
+                JComponent root = findRootJComponent(owner);
+                if (root != null) {
+                    result.addAll(factory.getChildPopups(root));
+                    return result;
+                }
+            }
+            for (Frame frame : Frame.getFrames()) {
+                if (frame instanceof javax.swing.RootPaneContainer rpc) {
+                    JRootPane rootPane = rpc.getRootPane();
+                    if (rootPane != null) {
+                        result.addAll(factory.getChildPopups(rootPane));
+                    }
+                }
+            }
+        } catch (Exception | LinkageError t) {
+            LOG.warn("PopupInterceptor: failed to enumerate active popups", t);
+        }
+        return result;
+    }
+
+    @Nullable
+    private static JComponent findRootJComponent(@NotNull Component component) {
+        Window window = component instanceof Window w ? w
+            : javax.swing.SwingUtilities.getWindowAncestor(component);
+        if (window instanceof javax.swing.RootPaneContainer rpc) {
+            return rpc.getRootPane();
+        }
+        return component instanceof JComponent jc ? jc : null;
+    }
+
+    /**
+     * Best-effort title for a popup. JBPopup has no public title accessor, so we look for a
+     * window title (heavyweight popups carry the title there) and fall back to the first visible
+     * label inside the popup content. Returns {@code "(untitled popup)"} if nothing is found.
+     */
+    @NotNull
+    static String extractPopupTitle(@NotNull JBPopup popup) {
+        try {
+            JComponent content = popup.getContent();
+            Window w = javax.swing.SwingUtilities.getWindowAncestor(content);
+            if (w instanceof java.awt.Frame f && notBlank(f.getTitle())) {
+                return f.getTitle();
+            }
+            if (w instanceof java.awt.Dialog d && notBlank(d.getTitle())) {
+                return d.getTitle();
+            }
+            String label = firstVisibleLabel(content);
+            if (label != null) return label;
+        } catch (Exception | LinkageError t) {
+            LOG.debug("PopupInterceptor: failed to extract popup title", t);
+        }
+        return "(untitled popup)";
+    }
+
+    @Nullable
+    static String firstVisibleLabel(@NotNull Container container) {
+        for (Component comp : container.getComponents()) {
+            if (comp instanceof JLabel lbl && comp.isVisible() && notBlank(lbl.getText())) {
+                return lbl.getText();
+            }
+            if (comp instanceof Container c) {
+                String nested = firstVisibleLabel(c);
+                if (nested != null) return nested;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Formats the agent-facing error returned when a popup was intercepted. Pure function.
+     */
+    @NotNull
+    static String formatPopupBlockedError(@NotNull String actionName, @NotNull Result result) {
+        Objects.requireNonNull(result);
+        String desc = result.describe();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Error: action '").append(actionName).append("' opened a popup chooser (")
+            .append(desc).append(") that cannot be answered non-interactively.");
+        if (result.cancelled()) {
+            sb.append(" The popup was cancelled to prevent freezing the IDE.");
+        } else {
+            sb.append(" Attempted to cancel the popup but it may still be visible.");
+        }
+        sb.append(" Use edit_text to make the change directly, or call get_action_options first")
+            .append(" to inspect dialog-style choices (note: popup choosers are not the same as")
+            .append(" dialog options and cannot be selected via the 'option' parameter).");
+        return sb.toString();
+    }
+
+    private static boolean notBlank(@Nullable String s) {
+        return s != null && !s.isBlank();
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionToolStaticMethodsTest.java
@@ -4,7 +4,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link ApplyActionTool#formatApplyResult}.
@@ -61,6 +66,89 @@ class ApplyActionToolStaticMethodsTest {
             assertTrue(result.contains("Selected option for"), result);
             assertTrue(result.contains("action: Import class"), result);
             assertTrue(result.contains("(no file changes)"), result);
+        }
+    }
+
+    @Nested
+    @DisplayName("parseImportSimpleName")
+    class ParseImportSimpleName {
+
+        @Test
+        @DisplayName("returns simple class name for English action name")
+        void englishActionName() {
+            assertEquals("Cell", ApplyActionTool.parseImportSimpleName("Import class 'Cell'"));
+            assertEquals("ArrayList", ApplyActionTool.parseImportSimpleName("Import class 'ArrayList'"));
+        }
+
+        @Test
+        @DisplayName("returns null for non-import action names")
+        void notAnImportAction() {
+            assertNull(ApplyActionTool.parseImportSimpleName("Optimize imports"));
+            assertNull(ApplyActionTool.parseImportSimpleName("Rename 'foo' to 'bar'"));
+            assertNull(ApplyActionTool.parseImportSimpleName(""));
+        }
+
+        @Test
+        @DisplayName("returns null for null input")
+        void nullInput() {
+            assertNull(ApplyActionTool.parseImportSimpleName(null));
+        }
+
+        @Test
+        @DisplayName("returns null for malformed action name (no closing quote)")
+        void noClosingQuote() {
+            assertNull(ApplyActionTool.parseImportSimpleName("Import class 'Cell"));
+        }
+
+        @Test
+        @DisplayName("returns null for empty class name")
+        void emptyClassName() {
+            assertNull(ApplyActionTool.parseImportSimpleName("Import class ''"));
+        }
+    }
+
+    @Nested
+    @DisplayName("formatAmbiguousImportError")
+    class FormatAmbiguousImportError {
+
+        @Test
+        @DisplayName("lists all candidates when count is small, sorted alphabetically")
+        void smallList() {
+            String result = ApplyActionTool.formatAmbiguousImportError(
+                "Cell", List.of("z.Cell", "a.Cell", "m.Cell")
+            );
+
+            assertTrue(result.startsWith("Error: Import for 'Cell' is ambiguous (3 candidates: "), result);
+            // Sorted alphabetically
+            int aIdx = result.indexOf("a.Cell");
+            int mIdx = result.indexOf("m.Cell");
+            int zIdx = result.indexOf("z.Cell");
+            assertTrue(aIdx > 0 && aIdx < mIdx && mIdx < zIdx, "Candidates should be sorted: " + result);
+            assertTrue(result.contains("edit_text"), result);
+            assertFalse(result.contains("more)"), "No 'more' suffix when all listed: " + result);
+        }
+
+        @Test
+        @DisplayName("truncates with 'N more' when exceeding the display cap")
+        void truncatesLongList() {
+            List<String> many = List.of(
+                "p1.Cell", "p2.Cell", "p3.Cell", "p4.Cell", "p5.Cell", "p6.Cell", "p7.Cell"
+            );
+
+            String result = ApplyActionTool.formatAmbiguousImportError("Cell", many);
+
+            assertTrue(result.contains("(7 candidates: "), result);
+            assertTrue(result.contains("p1.Cell"), result);
+            assertTrue(result.contains("p5.Cell"), result);
+            assertTrue(result.contains("… (2 more)"), result);
+        }
+
+        @Test
+        @DisplayName("error message points the user to edit_text")
+        void mentionsEditText() {
+            String result = ApplyActionTool.formatAmbiguousImportError("X", List.of("a.X", "b.X"));
+            assertTrue(result.contains("edit_text"), result);
+            assertTrue(result.contains("freeze") || result.contains("non-interactively"), result);
         }
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupInterceptorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupInterceptorTest.java
@@ -1,0 +1,199 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the pure helpers in {@link PopupInterceptor}: {@code Result},
+ * {@code firstVisibleLabel}, and {@code formatPopupBlockedError}.
+ *
+ * <p>The AWT-listener mechanics ({@code runDetectingPopups}, popup cancellation, and
+ * window-open detection) require a live IDE platform and are not unit-testable in
+ * headless mode; they are exercised by integration testing.</p>
+ */
+class PopupInterceptorTest {
+
+    @BeforeAll
+    static void setHeadless() {
+        System.setProperty("java.awt.headless", "true");
+    }
+
+    // ── Result ───────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Result")
+    class ResultTest {
+
+        @Test
+        @DisplayName("describe with empty titles → unidentified marker")
+        void describeEmpty() {
+            var r = new PopupInterceptor.Result(true, List.of(), true);
+            assertEquals("(unidentified popup)", r.describe());
+        }
+
+        @Test
+        @DisplayName("describe with one title → quoted title")
+        void describeOne() {
+            var r = new PopupInterceptor.Result(true, List.of("Choose Class"), true);
+            assertEquals("'Choose Class'", r.describe());
+        }
+
+        @Test
+        @DisplayName("describe with multiple titles → comma-joined quoted")
+        void describeMany() {
+            var r = new PopupInterceptor.Result(true, List.of("A", "B", "C"), false);
+            assertEquals("'A', 'B', 'C'", r.describe());
+        }
+
+        @Test
+        @DisplayName("popupTitles is exposed as immutable List")
+        void titlesAccessor() {
+            List<String> titles = List.of("X");
+            var r = new PopupInterceptor.Result(true, titles, true);
+            assertEquals(titles, r.popupTitles());
+            assertTrue(r.popupWasOpened());
+            assertTrue(r.cancelled());
+        }
+    }
+
+    // ── firstVisibleLabel ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("firstVisibleLabel")
+    class FirstVisibleLabelTest {
+
+        @Test
+        @DisplayName("returns text of first visible non-blank JLabel")
+        void findsFirstLabel() {
+            JPanel root = new JPanel();
+            root.add(new JLabel("Choose class:"));
+            root.add(new JLabel("ignored second"));
+            assertEquals("Choose class:", PopupInterceptor.firstVisibleLabel(root));
+        }
+
+        @Test
+        @DisplayName("descends into nested containers")
+        void recursesIntoChildren() {
+            JPanel root = new JPanel();
+            JPanel inner = new JPanel();
+            inner.add(new JLabel("nested"));
+            root.add(inner);
+            assertEquals("nested", PopupInterceptor.firstVisibleLabel(root));
+        }
+
+        @Test
+        @DisplayName("skips blank labels")
+        void skipsBlank() {
+            JPanel root = new JPanel();
+            root.add(new JLabel(""));
+            root.add(new JLabel("   "));
+            root.add(new JLabel("found"));
+            assertEquals("found", PopupInterceptor.firstVisibleLabel(root));
+        }
+
+        @Test
+        @DisplayName("skips invisible labels")
+        void skipsInvisible() {
+            JPanel root = new JPanel();
+            JLabel hidden = new JLabel("hidden");
+            hidden.setVisible(false);
+            root.add(hidden);
+            root.add(new JLabel("visible"));
+            assertEquals("visible", PopupInterceptor.firstVisibleLabel(root));
+        }
+
+        @Test
+        @DisplayName("empty container → null")
+        void emptyContainer() {
+            assertNull(PopupInterceptor.firstVisibleLabel(new JPanel()));
+        }
+    }
+
+    // ── formatPopupBlockedError ──────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("formatPopupBlockedError")
+    class FormatErrorTest {
+
+        @Test
+        @DisplayName("starts with 'Error:' so MCP detects isError=true")
+        void startsWithErrorPrefix() {
+            var r = new PopupInterceptor.Result(true, List.of("X"), true);
+            String msg = PopupInterceptor.formatPopupBlockedError("Import class 'Cell'", r);
+            assertTrue(msg.startsWith("Error: "), "expected 'Error: ' prefix, got: " + msg);
+        }
+
+        @Test
+        @DisplayName("includes the action name and popup description")
+        void includesActionAndDescription() {
+            var r = new PopupInterceptor.Result(true, List.of("Choose Class"), true);
+            String msg = PopupInterceptor.formatPopupBlockedError("Import class 'Cell'", r);
+            assertTrue(msg.contains("Import class 'Cell'"), msg);
+            assertTrue(msg.contains("'Choose Class'"), msg);
+        }
+
+        @Test
+        @DisplayName("when cancelled → confirms the popup was cancelled")
+        void cancelledMessage() {
+            var r = new PopupInterceptor.Result(true, List.of("X"), true);
+            String msg = PopupInterceptor.formatPopupBlockedError("act", r);
+            assertTrue(msg.contains("cancelled"), msg);
+            assertFalse(msg.contains("may still be visible"), msg);
+        }
+
+        @Test
+        @DisplayName("when not cancelled → warns that the popup may still be visible")
+        void notCancelledMessage() {
+            var r = new PopupInterceptor.Result(true, List.of("X"), false);
+            String msg = PopupInterceptor.formatPopupBlockedError("act", r);
+            assertTrue(msg.contains("may still be visible"), msg);
+        }
+
+        @Test
+        @DisplayName("guides the agent to edit_text instead")
+        void guidesToEditText() {
+            var r = new PopupInterceptor.Result(true, List.of("X"), true);
+            String msg = PopupInterceptor.formatPopupBlockedError("act", r);
+            assertTrue(msg.contains("edit_text"), msg);
+        }
+
+        @Test
+        @DisplayName("clarifies that popup choosers are NOT 'option' parameter selections")
+        void clarifiesOptionDistinction() {
+            var r = new PopupInterceptor.Result(true, List.of("X"), true);
+            String msg = PopupInterceptor.formatPopupBlockedError("act", r);
+            // We do NOT want the message to (mis)direct the agent to use the 'option' param,
+            // since 'option' currently only handles dialog-radio selection, not popup choosers.
+            assertTrue(msg.contains("not the same as") || msg.contains("cannot be selected via the 'option'"),
+                "Expected message to clarify that popup choosers are not option-selectable. Got: " + msg);
+        }
+    }
+
+    // ── Result construction sanity ────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Result has sensible defaults")
+    class ResultDefaultsTest {
+
+        @Test
+        @DisplayName("no popup → popupWasOpened=false, no titles, not cancelled")
+        void noPopup() {
+            var r = new PopupInterceptor.Result(false, List.of(), false);
+            assertFalse(r.popupWasOpened());
+            assertNotNull(r.popupTitles());
+            assertTrue(r.popupTitles().isEmpty());
+        }
+    }
+}


### PR DESCRIPTION
Stacked on top of #362.

## Problem

When `apply_action` triggered a quick-fix that opened a `JBPopup` chooser (e.g. **"Import class 'Cell'"** with multiple ambiguous candidates), the popup opened its own nested AWT event loop and waited for a user selection that never came — freezing the EDT permanently. The 30s caller timeout returned to the HTTP handler but did **not** free the EDT, so subsequent tool calls piled up behind it and the IDE became fully unresponsive (the user had to kill the process).

PR #362 already mitigates this with detection in \`describeModalBlocker\` and a Java-pre-flight \`checkAmbiguousImport\` for English action names, but a non-English IDE or any other popup-using quick-fix would still freeze.

## Solution

\`PopupInterceptor\` mirrors the existing \`DialogInterceptor\` pattern:
1. Register \`Toolkit.addAWTEventListener(WINDOW_OPENED)\` **before** invoking the action
2. Snapshot existing popups under the owner's window
3. On each new window, detect popups via \`JBPopupFactory.getChildPopups(...)\` and diff against the baseline
4. Cancel any **new** popup synchronously on the EDT (this exits the popup's nested event loop)
5. Return an actionable error to the agent explaining popup choosers are NOT \`option\`-selectable and pointing to \`edit_text\`

## Wired into

- \`ApplyActionTool\` (both \`applyNormally\` and \`applyAsDryRun\` paths)
- \`GetActionOptionsTool\` (stacked with existing \`DialogInterceptor\`)
- \`ApplyQuickfixTool\` (no editor at call site → null owner falls back to global Frame scan; baseline diff still ensures only **new** popups are cancelled)

## Documentation as code

Top-level Javadoc on \`PopupInterceptor\` explicitly references \`.agent-work/freeze-investigation-2026-04-30.md\` so the class is not removed by accident, and explains the AWT-WINDOW_OPENED-inside-nested-event-loop mechanism.

## Tests

16 new unit tests in \`PopupInterceptorTest\` covering pure helpers:
- \`Result.describe()\` — empty / single / multiple titles
- \`formatPopupBlockedError\` — error prefix, action name inclusion, cancellation status, \`edit_text\` guidance, option-vs-popup clarification
- \`firstVisibleLabel\` — recursion, blank skip, invisibility skip

The AWT-listener and popup-cancellation mechanics require a live IDE platform and are exercised by integration testing.

## Stack

- #361 — \`fix/settings-layout-overflow\`
- #362 — \`fix/edt-freeze-on-popup-quickfix\` (depends on #361)
- **this PR** — depends on #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)