### PR TITLE
feat: interactive popup handling for apply_action / apply_quickfix

### DIFF
--- a/docs/INTERACTIVE-POPUP-HANDLING.md
+++ b/docs/INTERACTIVE-POPUP-HANDLING.md
@@ -1,0 +1,280 @@
+# Interactive Popup Handling
+
+**Status:** implemented on `feat/interactive-popup-handling` after `fix/edt-freeze-on-popup-quickfix` and `fix/popup-interception-in-apply-action` landed in `master`.
+
+## Why this feature exists
+
+Some IntelliJ intentions and quick-fixes do not complete synchronously. Instead they open a heavyweight `JBPopup` chooser on the EDT and wait for a user selection. A concrete case was `apply_action("Import class 'Cell'")`, which opened the ambiguous-import popup and froze the IDE until the process was killed.
+
+PR #363 fixed the immediate freeze by cancelling such popups and returning a structured error. This feature adds the second half: the agent can now inspect the popup choices and explicitly continue the action through a follow-up MCP tool call.
+
+## The core constraint
+
+**We cannot keep the popup open between MCP tool calls.**
+
+`JBPopup` drives a nested AWT event loop on the EDT. If we left it open while waiting for the agent's next tool call:
+
+- other MCP calls would pile up behind EDT timeouts,
+- unrelated IDE work would stall,
+- we would reintroduce the original freeze under a different name.
+
+That constraint drives the whole design.
+
+## High-level design
+
+The implementation uses **snapshot + cancel + replay**.
+
+1. `apply_action` / `apply_quickfix` run under `PopupInterceptor`.
+2. If no popup opens, they behave normally.
+3. If a popup opens, the interceptor snapshots its content, cancels it immediately, and the tool returns a success message with a `popup_id` and the choice list.
+4. The agent calls `popup_respond` with `action="select"` or `action="cancel"`.
+5. For `select`, the original tool is re-run with a `PopupHandler.SelectByValue` that drives the popup to the chosen item.
+
+This means the original action runs **twice** in popup cases: once to discover the popup, once to complete it.
+
+## User-visible tool flow
+
+### Initial tool call
+
+Example:
+
+```text
+apply_action(file=..., line=..., action_name="Import class 'Cell'")
+```
+
+If a popup opens, the tool returns success text describing:
+
+- the popup title,
+- a generated `popup_id`,
+- the available choices,
+- how to call `popup_respond`.
+
+### Follow-up tool call
+
+```text
+popup_respond(popup_id="...", action="select", value_id="...")
+```
+
+or
+
+```text
+popup_respond(popup_id="...", action="cancel")
+```
+
+## Blocking model while a popup is pending
+
+While a popup is pending, **every other tool call is blocked** except `popup_respond`.
+
+This is intentional:
+
+- the popup originated from a live IDE action and still owns the next meaningful step,
+- allowing unrelated tools would let the agent mutate state between snapshot and replay,
+- even read-only IDE work is not useful enough to justify the extra complexity and race surface.
+
+Auto-cancel rules:
+
+- pending popup expires after **5 minutes**, or
+- after **5 unrelated tool calls from the same MCP session**.
+
+Calls from a different MCP session are blocked too, but they do **not** consume the owning session's auto-cancel budget.
+
+## Main components
+
+| File | Responsibility |
+| --- | --- |
+| `PopupHandler.java` | Sealed strategy passed into popup-aware tool execution. Variants: `Cancel`, `Snapshot`, `SelectByValue`. |
+| `PopupInterceptor.java` | Detects newly opened `JBPopup`s, snapshots or cancels them, or schedules replay selection. |
+| `PopupContentExtractor.java` | Converts a live popup into a `PopupSnapshot`. Prefers `ListPopupStep`, falls back to raw `JList`/`JTree`. |
+| `PopupChoice.java` | One popup row with stable `valueId`, display text, and metadata like `hasSubstep`. |
+| `PopupSnapshot.java` | Title + popup kind + immutable choice list + `contentDigest()` for loop detection. |
+| `ContextFingerprint.java` | Captures action identity + file path + document modification stamp for replay validation. |
+| `PendingPopupService.java` | App-level single-slot store for the currently pending popup. Holds ownership, timeout, and replay metadata. |
+| `PopupGateLogic.java` | Pure decision function used by `McpProtocolHandler` to allow, block, or auto-cancel pending-popup state. |
+| `PopupRespondTool.java` | New MCP tool that resolves the pending popup by selecting a captured choice or cancelling it. |
+| `Replayable.java` | Bridge interface implemented by replay-capable tools (`ApplyActionTool`, `ApplyQuickfixTool`). |
+| `McpCallContext.java` | Thread-local carrying the current MCP session key from protocol layer into tool execution. |
+| `QualityToolFactory.java` | Registers `popup_respond` and wires replayable tools into it. |
+
+## Why the design looks the way it does
+
+### 1. Explicit handler object instead of hidden global mode
+
+`PopupHandler` is threaded explicitly through popup-aware tool paths. We did **not** use a thread-local for the handler mode because the popup listener fires on the EDT in a different stack from the caller. Capturing the handler in the listener closure is simpler and easier to reason about.
+
+The only thread-local involved here is `McpCallContext`, and it carries session ownership information, not popup behavior.
+
+### 2. `ListPopupStep` is the source of truth
+
+The preferred popup representation comes from `ListPopupImpl` + `ListPopupStep`, not from Swing row scraping.
+
+Why:
+
+- list renderers are presentation, not identity,
+- rows can include disabled values or separators,
+- replay needs to select the *same semantic value*, not just the same visual row.
+
+Fallback extraction from `JList` / `JTree` exists only so we can still describe less structured popups instead of failing silently.
+
+### 3. Stable `valueId` instead of raw index
+
+Choices are identified by `PopupChoice.valueId()`, derived from popup text plus index. Raw indices alone are too fragile if the popup reorders slightly on replay.
+
+Replay first tries to find the matching `valueId`; it only falls back to `fallbackIndex` when the row text still matches.
+
+### 4. Single-slot pending store
+
+`PendingPopupService` intentionally stores **at most one** pending popup.
+
+Reasons:
+
+- the IDE effectively has one meaningful pending chooser at a time for this workflow,
+- the gating model blocks all other tool calls anyway,
+- one-slot state keeps the agent contract simple and reduces failure modes.
+
+### 5. Replay validation via document modification stamp
+
+`ContextFingerprint` prevents replaying a stale popup into a changed file.
+
+If the file changed after the snapshot was captured, `popup_respond` rejects the replay and tells the agent to re-run the original tool. This is safer than trying to guess whether the change was compatible.
+
+### 6. Different suspend behavior in `ApplyActionTool` vs `ApplyQuickfixTool`
+
+This asymmetry is intentional.
+
+- `ApplyActionTool` tries harder to recover if the document changed before the popup opened. It attempts an undo-and-recheck path before deciding whether it can safely suspend.
+- `ApplyQuickfixTool` is stricter: if the document modification stamp changed before suspension, it refuses to suspend and falls back to the PR #363 error path.
+
+The simpler quick-fix path is deliberate: popup-before-mutation is common enough there that safety matters more than squeezing out a few extra suspendable cases.
+
+### 7. Pure gate logic
+
+`PopupGateLogic.evaluate(...)` is pure by design. It does not mutate service state; it only returns one of:
+
+- allow,
+- allow-with-auto-cancel note,
+- block.
+
+That separation makes the gating contract testable without bringing up an IntelliJ application.
+
+## Actual control flow in code
+
+### Snapshot path
+
+1. Tool enters popup-aware execution (`ApplyActionTool` or `ApplyQuickfixTool`).
+2. Tool calls `PopupInterceptor.runDetectingPopups(..., new PopupHandler.Snapshot(...), ...)`.
+3. Interceptor detects newly opened popup(s) relative to a baseline.
+4. `PopupContentExtractor` builds a `PopupSnapshot`.
+5. Interceptor cancels the popup.
+6. Tool validates the action is still suspendable.
+7. Tool registers a `PendingPopupService.Pending` record.
+8. Tool returns a success message instructing the agent to call `popup_respond`.
+
+### Replay path
+
+1. Agent calls `popup_respond`.
+2. Tool validates `popup_id`, action, and selected choice.
+3. Tool validates the current `ContextFingerprint` against the captured one.
+4. Tool takes the pending slot.
+5. Tool re-runs the original action through `Replayable.replay(...)` using `PopupHandler.SelectByValue`.
+6. `PopupInterceptor` waits for the popup to reopen and schedules `ListPopupImpl.selectAndExecuteValue(...)` on the EDT.
+7. If replay succeeds, normal tool output is returned.
+
+## Safety rules and invariants
+
+These are load-bearing and should not be removed casually.
+
+### Popup must always be dismissed before returning
+
+This is the core freeze-prevention invariant. Any future change that tries to hold a popup open across tool calls must first solve the nested-EDT-loop problem.
+
+### Pending popup blocks all unrelated tools
+
+Without this, the agent could modify files between snapshot and replay and invalidate the captured context in harder-to-debug ways.
+
+### `ContextFingerprint.documentModStamp` is not optional
+
+It is the key guard against stale replay into a mutated document.
+
+### Cross-session ownership matters
+
+The session ownership branch in `PopupGateLogic` prevents one MCP session from accidentally consuming another session's auto-cancel budget.
+
+### `PopupSnapshot.contentDigest()` is for loop detection
+
+If replay opens the *same* chooser again, we fail fast instead of endlessly letting the agent retry.
+
+## Current limitations
+
+These are intentional v1 boundaries, not accidental gaps.
+
+### Chained popups are not supported
+
+If a choice has `hasSubstep=true`, `popup_respond` rejects it. We do not yet support recursively snapshotting and replaying popup trees.
+
+### Only popup-capable tools are replayable
+
+Right now the replay contract is implemented for:
+
+- `apply_action`
+- `apply_quickfix`
+
+Other tools would need explicit `Replayable` support and their own suspend-safety analysis.
+
+### Looping popups fail closed
+
+If replay opens the same popup again, we return an error and tell the agent to fall back to a manual path such as `edit_text`.
+
+### Non-list popups are best-effort only
+
+When the popup is not a `ListPopupImpl`, extraction falls back to visible Swing content. That is useful for diagnostics, but less reliable than the structured `ListPopupStep` path.
+
+### No persistent multi-step transaction across IDE restarts
+
+Pending popup state is in-memory only. If the IDE restarts or the tool session disappears, the popup is gone and the agent must restart from the original tool call.
+
+## Testing strategy
+
+The feature is mostly covered by pure unit tests around the logic that *can* be isolated:
+
+- `PopupChoiceTest`
+- `PopupSnapshotTest`
+- `ContextFingerprintTest`
+- `PopupGateLogicTest`
+- updated `PopupInterceptorTest`
+
+These validate stable IDs, digest behavior, mismatch reporting, and the gate rules.
+
+What is **not** fully unit-tested:
+
+- end-to-end replay against a live `ListPopupImpl`,
+- real IDE popup opening behavior,
+- service behavior that depends on a live IntelliJ application instance.
+
+Those parts are validated by integration/manual testing.
+
+## Future work
+
+Likely follow-ups if this area needs to grow:
+
+1. support chained popup flows (`hasSubstep=true`),
+2. add broader replay support to more tools beyond quality actions,
+3. add dedicated integration tests around live `ListPopupImpl` behavior,
+4. improve extraction for more popup types if we encounter them in practice,
+5. consider richer agent messaging for replay failures (for example, explicit retry hints by failure type).
+
+## Debugging tips for future maintainers
+
+If popup handling appears broken, check these in order:
+
+1. **Was the popup actually a `JBPopup`?** If not, this subsystem may not apply.
+2. **Was it a `ListPopupImpl`?** If not, extraction is fallback-only.
+3. **Did the document modification stamp change before replay?** That will intentionally block resume.
+4. **Did the same popup reopen?** Loop detection may be doing its job.
+5. **Was another MCP session involved?** Cross-session blocking is expected.
+6. **Did the pending popup age out or consume its 5-call budget?** Then `popup_respond` will no longer find it.
+
+## Related documents
+
+- `.agent-work/freeze-investigation-2026-04-30.md` - original freeze investigation and root cause
+- `.agent-work/popup-interaction-design-2026-04-30.md` - deeper implementation rationale captured during development
+- `docs/ACP-TOOL-INTERCEPTION.md` - broader context on tool execution limitations in the Copilot CLI / ACP stack

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
@@ -1436,4 +1436,22 @@ public final class PlatformApiCompat {
         com.intellij.ui.tabs.JBTabs tabs = com.intellij.ui.tabs.JBTabsFactory.createTabs(project, parentDisposable);
         return new JBTabsPanel(tabs);
     }
+
+    /**
+     * Returns the {@link com.intellij.openapi.ui.popup.ListPopupStep} backing a
+     * {@link com.intellij.ui.popup.list.ListPopupImpl}.
+     *
+     * <p><b>Why extracted:</b> the IDE editor daemon flags
+     * {@code ListPopupImpl.getListStep()} with a spurious "Incompatible types. Found
+     * ListPopupStep&lt;Object&gt;, required ListPopupStep&lt;Object&gt;" error because the
+     * SDK generic signatures differ between the development IDE and the target SDK.
+     * Gradle compiles cleanly. Wrapping the call in a raw-typed bridge keeps the
+     * false-positive confined to this single method.</p>
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static @Nullable com.intellij.openapi.ui.popup.ListPopupStep<Object> getListStep(
+        @NotNull com.intellij.ui.popup.list.ListPopupImpl popup) {
+        com.intellij.openapi.ui.popup.ListPopupStep raw = popup.getListStep();
+        return (com.intellij.openapi.ui.popup.ListPopupStep<Object>) raw;
+    }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionTool.java
@@ -4,6 +4,7 @@ import com.github.catatafishen.agentbridge.psi.EdtUtil;
 import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
 import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
+import com.github.catatafishen.agentbridge.services.McpCallContext;
 import com.github.catatafishen.agentbridge.ui.renderers.GitDiffRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.codeInsight.intention.IntentionAction;
@@ -30,8 +31,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
-public final class ApplyActionTool extends QualityTool {
+public final class ApplyActionTool extends QualityTool implements Replayable {
 
     private static final Logger LOG = Logger.getInstance(ApplyActionTool.class);
     private static final String PARAM_COLUMN = "column";
@@ -97,6 +99,32 @@ public final class ApplyActionTool extends QualityTool {
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        return executeWithHandler(args, new PopupHandler.Cancel(), false);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Re-runs the same action pipeline but with a {@link PopupHandler.SelectByValue}
+     * handler — see {@link PopupRespondTool} and
+     * {@code .agent-work/popup-interaction-design-2026-04-30.md}.
+     */
+    @Override
+    public @NotNull String replay(@NotNull JsonObject originalArgs,
+                                  @NotNull PopupHandler.SelectByValue handler) throws Exception {
+        return executeWithHandler(originalArgs, handler, true);
+    }
+
+    /**
+     * Shared dispatch for both {@link #execute} and {@link #replay}. The {@code handler}
+     * controls what happens when an {@link com.intellij.openapi.ui.popup.JBPopup} opens
+     * during the action invocation. {@code isReplay} marks calls coming from
+     * {@link PopupRespondTool} so the snapshot-and-suspend path is skipped (we want to
+     * complete the action this time, not capture choices again).
+     */
+    private @NotNull String executeWithHandler(@NotNull JsonObject args,
+                                               @NotNull PopupHandler handler,
+                                               boolean isReplay) throws Exception {
         if (!args.has("file") || !args.has("line") || !args.has(PARAM_ACTION_NAME)) {
             return "Error: 'file', 'line', and 'action_name' parameters are required";
         }
@@ -111,7 +139,8 @@ public final class ApplyActionTool extends QualityTool {
         CompletableFuture<String> future = new CompletableFuture<>();
         EdtUtil.invokeLater(() -> {
             try {
-                future.complete(invokeAction(pathStr, targetLine, actionName, symbol, targetCol, option, dryRun));
+                future.complete(invokeAction(pathStr, targetLine, actionName, symbol, targetCol,
+                    option, dryRun, args, handler, isReplay));
             } catch (AssertionError e) {
                 // Some actions (e.g. SafeDeleteFix) trigger interactive dialogs via assertions
                 // that fail headlessly. Catch AssertionError separately for a clear message.
@@ -129,7 +158,8 @@ public final class ApplyActionTool extends QualityTool {
         String result = future.get(30, TimeUnit.SECONDS);
         if (result == null) return "Error: action invocation returned no result";
         if (!dryRun && !result.startsWith("Error") && !result.startsWith("No ")
-            && !result.startsWith(ACTION_PREFIX) && !result.startsWith("Preview")) {
+            && !result.startsWith(ACTION_PREFIX) && !result.startsWith("Preview")
+            && !result.startsWith("The action ")) {
             FileTool.followFileIfEnabled(project, pathStr, targetLine, targetLine,
                 FileTool.HIGHLIGHT_EDIT, FileTool.agentLabel(project) + " applied action");
         }
@@ -145,7 +175,9 @@ public final class ApplyActionTool extends QualityTool {
 
     private String invokeAction(String pathStr, int targetLine, String actionName,
                                 @Nullable String symbol, @Nullable Integer targetCol,
-                                @Nullable String option, boolean dryRun) {
+                                @Nullable String option, boolean dryRun,
+                                @NotNull JsonObject originalArgs,
+                                @NotNull PopupHandler handler, boolean isReplay) {
         VirtualFile vf = resolveVirtualFile(pathStr);
         if (vf == null) return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_FILE_NOT_FOUND + pathStr;
 
@@ -159,8 +191,12 @@ public final class ApplyActionTool extends QualityTool {
         PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
         if (psiFile == null) return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_CANNOT_PARSE + pathStr;
 
-        String ambiguousImportError = checkAmbiguousImport(actionName, psiFile);
-        if (ambiguousImportError != null) return ambiguousImportError;
+        // Skip ambiguous-import precheck on replay — the agent already saw the choices and
+        // made a selection; refusing here would leave them stuck.
+        if (!isReplay) {
+            String ambiguousImportError = checkAmbiguousImport(actionName, psiFile);
+            if (ambiguousImportError != null) return ambiguousImportError;
+        }
 
         Editor editor = getOrOpenEditor(vf);
         if (editor == null) {
@@ -184,15 +220,17 @@ public final class ApplyActionTool extends QualityTool {
         }
 
         String before = doc.getText();
+        long beforeModStamp = doc.getModificationStamp();
         ActionContext ctx = new ActionContext(action, editor, psiFile, doc);
 
         if (option != null) {
             return applyWithOption(option, actionName, pathStr, targetLine, before, ctx);
         }
         if (dryRun) {
-            return applyAsDryRun(actionName, pathStr, before, ctx, vf);
+            return applyAsDryRun(actionName, pathStr, before, ctx, vf, handler);
         }
-        return applyNormally(actionName, pathStr, targetLine, before, ctx);
+        return applyNormally(actionName, pathStr, targetLine, before, beforeModStamp, ctx,
+            vf, originalArgs, handler, isReplay);
     }
 
     private String applyWithOption(String option, String actionName, String pathStr, int targetLine,
@@ -220,12 +258,17 @@ public final class ApplyActionTool extends QualityTool {
     }
 
     private String applyAsDryRun(String actionName, String pathStr, String before,
-                                 ActionContext ctx, VirtualFile vf) {
+                                 ActionContext ctx, VirtualFile vf, @NotNull PopupHandler handler) {
+        AtomicReference<PopupSnapshot> snapRef = new AtomicReference<>();
+        PopupHandler effective = wrapHandlerForCapture(handler, snapRef);
         PopupInterceptor.Result popupResult = PopupInterceptor.runDetectingPopups(
             ctx.editor().getComponent(),
+            effective,
             () -> invokeRespectingWriteAction(actionName, ctx)
         );
-        if (popupResult.popupWasOpened()) {
+        if (popupResult.popupWasOpened() && !popupResult.selectionScheduled()) {
+            // Dry-run cannot meaningfully suspend on a popup — preview semantics require a
+            // single deterministic outcome. Fall back to PR #363 behaviour.
             return PopupInterceptor.formatPopupBlockedError(actionName, popupResult);
         }
         PsiDocumentManager.getInstance(project).commitDocument(ctx.doc());
@@ -240,21 +283,47 @@ public final class ApplyActionTool extends QualityTool {
     }
 
     private String applyNormally(String actionName, String pathStr, int targetLine,
-                                 String before, ActionContext ctx) {
-        VirtualFile vf = FileDocumentManager.getInstance().getFile(ctx.doc());
+                                 String before, long beforeModStamp, ActionContext ctx,
+                                 VirtualFile vf, @NotNull JsonObject originalArgs,
+                                 @NotNull PopupHandler handler, boolean isReplay) {
         FileTool.notifyBeforeEdit(project, vf, ctx.doc());
         PopupInterceptor.Result popupResult;
+        AtomicReference<PopupSnapshot> snapRef = new AtomicReference<>();
+        PopupHandler effective = wrapHandlerForCapture(handler, snapRef);
         try {
             popupResult = PopupInterceptor.runDetectingPopups(
                 ctx.editor().getComponent(),
+                effective,
                 () -> invokeRespectingWriteAction(actionName, ctx)
             );
         } finally {
             FileTool.notifyEditComplete();
         }
-        if (popupResult.popupWasOpened()) {
+
+        boolean popupOpened = popupResult.popupWasOpened();
+        boolean isSelectMode = handler instanceof PopupHandler.SelectByValue;
+        boolean isCancelMode = handler instanceof PopupHandler.Cancel;
+        boolean isSnapshotMode = handler instanceof PopupHandler.Snapshot;
+
+        if (popupOpened && (isSnapshotMode || isCancelMode) && !isReplay) {
+            // Default-mode popup: try to capture a snapshot and suspend the call so the agent
+            // can drive the popup via popup_respond. Falls back to PR #363 error when the
+            // snapshot is unusable or rollback fails.
+            String suspended = trySuspendForPopup(actionName, originalArgs, ctx.doc(),
+                beforeModStamp, popupResult, snapRef.get(), vf);
+            if (suspended != null) return suspended;
             return PopupInterceptor.formatPopupBlockedError(actionName, popupResult);
         }
+        if (popupOpened && isSelectMode && !popupResult.selectionScheduled()) {
+            return PopupInterceptor.formatPopupBlockedError(actionName, popupResult);
+        }
+        if (popupOpened && isReplay && isSnapshotMode) {
+            // Chained popup during replay — out of scope for v1; surface a clear error.
+            return "Error: replaying action '" + actionName + "' opened a chained popup ('"
+                + popupResult.describe() + "'). Chained popups are not supported by popup_respond"
+                + " yet — please use edit_text to complete the change manually.";
+        }
+
         PsiDocumentManager.getInstance(project).commitDocument(ctx.doc());
         FileDocumentManager.getInstance().saveDocument(ctx.doc());
         String after = ctx.doc().getText();
@@ -264,6 +333,100 @@ public final class ApplyActionTool extends QualityTool {
                 + "Try get_action_options to inspect what dialog options it shows.";
         }
         return formatApplyResult(actionName, pathStr, targetLine, diff, true);
+    }
+
+    /**
+     * If the caller passed a {@link PopupHandler.Cancel} we upgrade it to {@link PopupHandler.Snapshot}
+     * so we can still capture choices for {@link PendingPopupService} registration. If the caller
+     * already passed Snapshot we chain its sink. SelectByValue is passed through unchanged.
+     */
+    @NotNull
+    private static PopupHandler wrapHandlerForCapture(@NotNull PopupHandler in,
+                                                      @NotNull AtomicReference<PopupSnapshot> sink) {
+        return switch (in) {
+            case PopupHandler.SelectByValue sv -> sv;
+            case PopupHandler.Snapshot snap -> new PopupHandler.Snapshot(s -> {
+                sink.set(s);
+                snap.sink().accept(s);
+            });
+            case PopupHandler.Cancel ignored -> new PopupHandler.Snapshot(sink::set);
+        };
+    }
+
+    /**
+     * Attempts to register a {@link PendingPopupService.Pending} for the just-intercepted popup,
+     * after rolling back any document changes the action made before opening the popup. Returns
+     * the agent-facing success message when registration succeeds, or {@code null} to fall
+     * through to the PR #363 error path.
+     */
+    @Nullable
+    private String trySuspendForPopup(@NotNull String actionName, @NotNull JsonObject originalArgs,
+                                      @NotNull Document doc, long beforeModStamp,
+                                      @NotNull PopupInterceptor.Result popupResult,
+                                      @Nullable PopupSnapshot snapshot, @NotNull VirtualFile vf) {
+        if (snapshot == null || snapshot.isEmpty()) {
+            LOG.info("ApplyActionTool: popup intercepted but snapshot was empty/null — falling back to error");
+            return null;
+        }
+        long afterModStamp = doc.getModificationStamp();
+        if (afterModStamp != beforeModStamp) {
+            // Action mutated the document before opening the popup. Try to undo so the file
+            // is left clean for the agent to either complete via popup_respond or pick a
+            // different strategy. If we can't restore the original mod stamp, refuse to
+            // suspend (PR #363 fallback).
+            undoLastAction(vf);
+            if (doc.getModificationStamp() != beforeModStamp) {
+                LOG.warn("ApplyActionTool: rollback failed (mod stamp " + beforeModStamp + " → "
+                    + doc.getModificationStamp() + "); cannot safely suspend for popup");
+                return null;
+            }
+        }
+
+        ContextFingerprint fp = new ContextFingerprint(
+            project.getName(), vf.getPath(), beforeModStamp, id() + "|" + actionName);
+        PendingPopupService.Pending pending = PendingPopupService.getInstance().register(
+            id(), originalArgs, project, fp, snapshot,
+            McpCallContext.currentOrFallback(), null);
+        if (pending == null) {
+            // Slot already taken — shouldn't happen because the gate blocks tool calls when
+            // pending != null, but guard anyway.
+            return null;
+        }
+        return formatPopupSuspendedMessage(actionName, popupResult.describe(), pending);
+    }
+
+    @NotNull
+    private static String formatPopupSuspendedMessage(@NotNull String actionName,
+                                                      @NotNull String popupTitles,
+                                                      @NotNull PendingPopupService.Pending pending) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("The action '").append(actionName).append("' opened a popup chooser (")
+            .append(popupTitles).append("). The popup is suspended awaiting your selection ")
+            .append("(popup_id=").append(pending.id()).append(").\n\n");
+        sb.append("Choices:\n");
+        var choices = pending.snapshot().choices();
+        for (int i = 0; i < choices.size(); i++) {
+            var c = choices.get(i);
+            sb.append("  ").append(i).append(": ").append(c.text());
+            if (c.secondaryText() != null) sb.append(" — ").append(c.secondaryText());
+            if (!c.selectable()) sb.append("  (not selectable)");
+            if (c.hasSubstep()) sb.append("  (opens submenu — not yet supported in v1)");
+            sb.append('\n');
+        }
+        sb.append("\nTo complete: popup_respond(popup_id=\"").append(pending.id())
+            .append("\", action=\"select\", value_id=\"<one of the value_id strings above>\")\n");
+        sb.append("To cancel:   popup_respond(popup_id=\"").append(pending.id())
+            .append("\", action=\"cancel\")\n\n");
+        sb.append("(value_id strings: ");
+        for (int i = 0; i < choices.size(); i++) {
+            if (i > 0) sb.append(", ");
+            sb.append('"').append(choices.get(i).valueId()).append('"');
+        }
+        sb.append(")\n\n");
+        sb.append("The popup will auto-cancel after ").append(PendingPopupService.MAX_UNRELATED_CALLS)
+            .append(" unrelated tool calls or ").append(PendingPopupService.MAX_AGE.toMinutes())
+            .append(" minutes.");
+        return sb.toString();
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyQuickfixTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyQuickfixTool.java
@@ -3,6 +3,7 @@ package com.github.catatafishen.agentbridge.psi.tools.quality;
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
 import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
+import com.github.catatafishen.agentbridge.services.McpCallContext;
 import com.github.catatafishen.agentbridge.ui.renderers.SimpleStatusRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.application.WriteAction;
@@ -22,11 +23,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Applies an IntelliJ quick-fix at a specific file and line.
  */
-public final class ApplyQuickfixTool extends QualityTool {
+public final class ApplyQuickfixTool extends QualityTool implements Replayable {
 
     private static final Logger LOG = Logger.getInstance(ApplyQuickfixTool.class);
     private static final String PARAM_FIX_INDEX = "fix_index";
@@ -74,6 +76,25 @@ public final class ApplyQuickfixTool extends QualityTool {
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        return executeWithHandler(args, new PopupHandler.Cancel(), false);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Re-runs the same quick-fix pipeline with a {@link PopupHandler.SelectByValue}
+     * handler — see {@link PopupRespondTool} and
+     * {@code .agent-work/popup-interaction-design-2026-04-30.md}.
+     */
+    @Override
+    public @NotNull String replay(@NotNull JsonObject originalArgs,
+                                  @NotNull PopupHandler.SelectByValue handler) throws Exception {
+        return executeWithHandler(originalArgs, handler, true);
+    }
+
+    private @NotNull String executeWithHandler(@NotNull JsonObject args,
+                                               @NotNull PopupHandler handler,
+                                               boolean isReplay) throws Exception {
         if (!args.has("file") || !args.has("line") || !args.has(PARAM_INSPECTION_ID)) {
             return "Error: 'file', 'line', and '" + PARAM_INSPECTION_ID + "' parameters are required";
         }
@@ -139,11 +160,14 @@ public final class ApplyQuickfixTool extends QualityTool {
                 // invoking the lambda, otherwise the ThreadLocal agent-edit marker leaks across
                 // tool calls. Wrap the whole WriteAction.run() in try/finally (matches the
                 // pattern used in ApplyActionTool / SuppressInspectionTool / WriteFileTool).
+                long beforeModStamp = document.getModificationStamp();
                 FileTool.notifyBeforeEdit(project, vf, document);
                 try {
                     WriteAction.run(() -> {
                         try {
-                            resultFuture.complete(applyAndReportFix(lineProblems, fixIndex, pathStr, targetLine));
+                            resultFuture.complete(applyAndReportFix(lineProblems, fixIndex,
+                                pathStr, targetLine, inspectionId, vf, document, beforeModStamp,
+                                args, handler, isReplay));
                         } catch (Exception e) {
                             LOG.warn("Error applying quickfix", e);
                             resultFuture.complete("Error applying quickfix: " + e.getMessage());
@@ -159,7 +183,7 @@ public final class ApplyQuickfixTool extends QualityTool {
         });
 
         String result = resultFuture.get(30, TimeUnit.SECONDS);
-        if (!result.startsWith("Error") && !result.startsWith("No ")) {
+        if (!result.startsWith("Error") && !result.startsWith("No ") && !result.startsWith("The action ")) {
             FileTool.followFileIfEnabled(project, pathStr, targetLine, targetLine,
                 FileTool.HIGHLIGHT_EDIT, FileTool.agentLabel(project) + " applied fix");
         }
@@ -206,7 +230,11 @@ public final class ApplyQuickfixTool extends QualityTool {
 
     @SuppressWarnings("unchecked") // QuickFix generic — safe at runtime
     private String applyAndReportFix(List<com.intellij.codeInspection.ProblemDescriptor> lineProblems,
-                                     int fixIndex, String pathStr, int targetLine) {
+                                     int fixIndex, String pathStr, int targetLine,
+                                     String inspectionId, VirtualFile vf, Document document,
+                                     long beforeModStamp,
+                                     @NotNull JsonObject originalArgs,
+                                     @NotNull PopupHandler handler, boolean isReplay) {
         com.intellij.codeInspection.ProblemDescriptor targetProblem =
             lineProblems.get(Math.min(fixIndex, lineProblems.size() - 1));
 
@@ -222,7 +250,9 @@ public final class ApplyQuickfixTool extends QualityTool {
         // class-import disambiguation) cannot freeze the EDT — see PopupInterceptor and
         // .agent-work/freeze-investigation-2026-04-30.md.
         // No editor available here → null owner falls back to a global frame scan.
-        PopupInterceptor.Result popupResult = PopupInterceptor.runDetectingPopups(null,
+        AtomicReference<PopupSnapshot> snapRef = new AtomicReference<>();
+        PopupHandler effective = wrapHandlerForCapture(handler, snapRef);
+        PopupInterceptor.Result popupResult = PopupInterceptor.runDetectingPopups(null, effective,
             () -> com.intellij.openapi.command.CommandProcessor.getInstance().executeCommand(
                 project,
                 () -> fix.applyFix(project, targetProblem),
@@ -230,8 +260,23 @@ public final class ApplyQuickfixTool extends QualityTool {
                 null
             )
         );
+
         if (popupResult.popupWasOpened()) {
-            return PopupInterceptor.formatPopupBlockedError("apply_quickfix:" + fix.getName(), popupResult);
+            boolean isSelectMode = handler instanceof PopupHandler.SelectByValue;
+            if (!isReplay && !isSelectMode) {
+                String suspended = trySuspendForPopup(fix.getName(), inspectionId, originalArgs,
+                    document, beforeModStamp, popupResult, snapRef.get(), vf);
+                if (suspended != null) return suspended;
+            } else if (isSelectMode && !popupResult.selectionScheduled()) {
+                return PopupInterceptor.formatPopupBlockedError("apply_quickfix:" + fix.getName(), popupResult);
+            } else if (isReplay) {
+                return "Error: replaying quick-fix '" + fix.getName() + "' opened a chained popup ('"
+                    + popupResult.describe() + "'). Chained popups are not supported by popup_respond"
+                    + " yet — use edit_text to complete the change manually.";
+            }
+            if (!isSelectMode) {
+                return PopupInterceptor.formatPopupBlockedError("apply_quickfix:" + fix.getName(), popupResult);
+            }
         }
 
         PsiDocumentManager.getInstance(project).commitAllDocuments();
@@ -250,6 +295,93 @@ public final class ApplyQuickfixTool extends QualityTool {
                 }
             }
         }
+        return sb.toString();
+    }
+
+    /**
+     * Same wrapping pattern as {@link ApplyActionTool#wrapHandlerForCapture}: upgrade
+     * {@link PopupHandler.Cancel} to {@link PopupHandler.Snapshot} so we can capture choices,
+     * chain {@link PopupHandler.Snapshot} sinks, pass {@link PopupHandler.SelectByValue}
+     * through unchanged.
+     */
+    @NotNull
+    private static PopupHandler wrapHandlerForCapture(@NotNull PopupHandler in,
+                                                      @NotNull AtomicReference<PopupSnapshot> sink) {
+        return switch (in) {
+            case PopupHandler.SelectByValue sv -> sv;
+            case PopupHandler.Snapshot snap -> new PopupHandler.Snapshot(s -> {
+                sink.set(s);
+                snap.sink().accept(s);
+            });
+            case PopupHandler.Cancel ignored -> new PopupHandler.Snapshot(sink::set);
+        };
+    }
+
+    /**
+     * Registers a {@link PendingPopupService.Pending} for the just-intercepted popup so the
+     * agent can drive it via {@code popup_respond}. Returns the suspended-message on success,
+     * or {@code null} to fall through to PR #363's error.
+     */
+    @org.jetbrains.annotations.Nullable
+    private String trySuspendForPopup(@NotNull String fixName, @NotNull String inspectionId,
+                                      @NotNull JsonObject originalArgs,
+                                      @NotNull Document doc, long beforeModStamp,
+                                      @NotNull PopupInterceptor.Result popupResult,
+                                      @org.jetbrains.annotations.Nullable PopupSnapshot snapshot,
+                                      @NotNull VirtualFile vf) {
+        if (snapshot == null || snapshot.isEmpty()) {
+            LOG.info("ApplyQuickfixTool: popup intercepted but snapshot empty — falling back to error");
+            return null;
+        }
+        // Quick-fixes run inside WriteAction with our CommandProcessor group; the IntelliJ
+        // undo manager records the command. We don't attempt rollback here for v1 because
+        // quick-fix popup-then-mutate is rare and cleanly undoing across nested commands is
+        // brittle. If the action mutated the document before the popup, refuse to suspend so
+        // the user is not left with dangling edits.
+        if (doc.getModificationStamp() != beforeModStamp) {
+            LOG.info("ApplyQuickfixTool: quick-fix mutated document before opening popup; refusing to suspend");
+            return null;
+        }
+        ContextFingerprint fp = new ContextFingerprint(
+            project.getName(), vf.getPath(), beforeModStamp, id() + "|" + inspectionId);
+        PendingPopupService.Pending pending = PendingPopupService.getInstance().register(
+            id(), originalArgs, project, fp, snapshot,
+            McpCallContext.currentOrFallback(), null);
+        if (pending == null) return null;
+        return formatPopupSuspendedMessage(fixName, popupResult.describe(), pending);
+    }
+
+    @NotNull
+    private static String formatPopupSuspendedMessage(@NotNull String fixName,
+                                                      @NotNull String popupTitles,
+                                                      @NotNull PendingPopupService.Pending pending) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("The quick-fix '").append(fixName).append("' opened a popup chooser (")
+            .append(popupTitles).append("). The popup is suspended awaiting your selection ")
+            .append("(popup_id=").append(pending.id()).append(").\n\n");
+        sb.append("Choices:\n");
+        var choices = pending.snapshot().choices();
+        for (int i = 0; i < choices.size(); i++) {
+            var c = choices.get(i);
+            sb.append("  ").append(i).append(": ").append(c.text());
+            if (c.secondaryText() != null) sb.append(" — ").append(c.secondaryText());
+            if (!c.selectable()) sb.append("  (not selectable)");
+            if (c.hasSubstep()) sb.append("  (opens submenu — not yet supported in v1)");
+            sb.append('\n');
+        }
+        sb.append("\nTo complete: popup_respond(popup_id=\"").append(pending.id())
+            .append("\", action=\"select\", value_id=\"<one of the value_id strings above>\")\n");
+        sb.append("To cancel:   popup_respond(popup_id=\"").append(pending.id())
+            .append("\", action=\"cancel\")\n\n");
+        sb.append("(value_id strings: ");
+        for (int i = 0; i < choices.size(); i++) {
+            if (i > 0) sb.append(", ");
+            sb.append('"').append(choices.get(i).valueId()).append('"');
+        }
+        sb.append(")\n\n");
+        sb.append("The popup will auto-cancel after ").append(PendingPopupService.MAX_UNRELATED_CALLS)
+            .append(" unrelated tool calls or ").append(PendingPopupService.MAX_AGE.toMinutes())
+            .append(" minutes.");
         return sb.toString();
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ContextFingerprint.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ContextFingerprint.java
@@ -1,0 +1,90 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Identifies the IDE state under which a popup was captured, so the {@code popup_respond}
+ * tool can reject replays that would land on different content than the agent saw.
+ *
+ * <p><b>Why this exists — DO NOT REMOVE without reading
+ * {@code .agent-work/popup-interaction-design-2026-04-30.md}.</b>
+ *
+ * <p>Between the snapshot tool call and the {@code popup_respond} call, the agent could call
+ * other tools (read-only) or the user could edit the file via the IDE. If the document mod
+ * stamp or active file changed, replaying the action could:
+ * <ul>
+ *   <li>Open a different popup (different ambiguity set after edits)</li>
+ *   <li>Apply the wrong fix to the wrong context</li>
+ *   <li>Silently no-op</li>
+ * </ul>
+ *
+ * <p>{@link #matches(ContextFingerprint)} tolerates {@code null} file paths (some actions
+ * aren't file-bound) but requires exact match on document mod stamp when both fingerprints
+ * carry one.
+ *
+ * @param projectName    project the action ran in
+ * @param filePath       absolute path of the file the action targeted, or {@code null}
+ * @param documentModStamp document mod stamp at invocation time, or {@code -1} when N/A
+ * @param actionIdentity {@code action_name | inspection_id} — whatever uniquely names the
+ *                       action, used for loop detection across replays
+ */
+public record ContextFingerprint(
+    @NotNull String projectName,
+    @Nullable String filePath,
+    long documentModStamp,
+    @NotNull String actionIdentity
+) {
+
+    private static final String NOW_PREFIX = "', now '";
+
+    public ContextFingerprint {
+        Objects.requireNonNull(projectName, "projectName");
+        Objects.requireNonNull(actionIdentity, "actionIdentity");
+    }
+
+    /**
+     * Returns true if {@code other} represents the same logical context as this fingerprint.
+     * Project name and action identity must match exactly. File path must match when both are
+     * present. Document mod stamp must match when both are non-negative.
+     */
+    public boolean matches(@NotNull ContextFingerprint other) {
+        if (!projectName.equals(other.projectName)) return false;
+        if (!actionIdentity.equals(other.actionIdentity)) return false;
+        if (filePath != null && other.filePath != null && !filePath.equals(other.filePath)) {
+            return false;
+        }
+        return documentModStamp < 0 || other.documentModStamp < 0
+            || documentModStamp == other.documentModStamp;
+    }
+
+    /**
+     * Human-readable description used in agent-facing error messages when a fingerprint check
+     * fails.
+     */
+    @NotNull
+    public String describeMismatch(@NotNull ContextFingerprint current) {
+        StringBuilder sb = new StringBuilder();
+        if (!projectName.equals(current.projectName)) {
+            sb.append("project changed (was '").append(projectName)
+                .append(NOW_PREFIX).append(current.projectName).append("'); ");
+        }
+        if (!actionIdentity.equals(current.actionIdentity)) {
+            sb.append("action changed (was '").append(actionIdentity)
+                .append(NOW_PREFIX).append(current.actionIdentity).append("'); ");
+        }
+        if (filePath != null && current.filePath != null && !filePath.equals(current.filePath)) {
+            sb.append("file changed (was '").append(filePath)
+                .append(NOW_PREFIX).append(current.filePath).append("'); ");
+        }
+        if (documentModStamp >= 0 && current.documentModStamp >= 0
+            && documentModStamp != current.documentModStamp) {
+            sb.append("document modified since snapshot (mod stamp ")
+                .append(documentModStamp).append(" → ").append(current.documentModStamp)
+                .append("); ");
+        }
+        return sb.isEmpty() ? "fingerprint mismatch" : sb.substring(0, sb.length() - 2);
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PendingPopupService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PendingPopupService.java
@@ -1,0 +1,228 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import com.google.gson.JsonObject;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
+import org.jetbrains.annotations.VisibleForTesting;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Application-level single-slot store for the popup that is currently waiting for an agent
+ * response.
+ *
+ * <p><b>Why this exists — DO NOT REMOVE without reading
+ * {@code .agent-work/popup-interaction-design-2026-04-30.md}.</b>
+ *
+ * <p>Only one popup can be pending at a time, intentionally:
+ * <ul>
+ *   <li>The EDT can only host one heavyweight popup at a time anyway.</li>
+ *   <li>Having a single slot keeps the agent's mental model trivial: "either there is a popup
+ *       or there isn't".</li>
+ *   <li>{@link PopupGateLogic} blocks <em>all</em> other tool calls while a popup is pending,
+ *       so multi-popup support would be dead complexity.</li>
+ * </ul>
+ *
+ * <h2>Auto-expiry</h2>
+ * The pending popup is cleared on:
+ * <ul>
+ *   <li><b>Time</b>: {@link #MAX_AGE} since {@link Pending#createdAt()}, checked lazily on
+ *       {@link #peek()}.</li>
+ *   <li><b>Unrelated calls</b>: {@link #MAX_UNRELATED_CALLS} tool calls from the
+ *       <em>same MCP session</em> that aren't {@code popup_respond} bump the counter via
+ *       {@link #recordUnrelatedCall(String)}; the {@code MAX_UNRELATED_CALLS}-th call clears
+ *       the slot. Foreign-session calls do not burn the budget.</li>
+ *   <li><b>Explicit</b>: {@link #cancelAndClear(String)} from {@code popup_respond}'s
+ *       {@code cancel} action.</li>
+ * </ul>
+ *
+ * <p>All methods are thread-safe (synchronized on the service instance).
+ */
+@Service(Service.Level.APP)
+public final class PendingPopupService {
+
+    private static final Logger LOG = Logger.getInstance(PendingPopupService.class);
+
+    /**
+     * After this many tool calls from the owning session that aren't {@code popup_respond},
+     * the pending popup is auto-cancelled. Public for {@link PopupGateLogic} and tests.
+     */
+    public static final int MAX_UNRELATED_CALLS = 5;
+
+    /**
+     * After this duration since {@link Pending#createdAt()}, the pending popup is auto-cancelled
+     * the next time {@link #peek()} is called. Defensive bound for the case where the agent
+     * hangs without making any tool calls at all.
+     */
+    public static final Duration MAX_AGE = Duration.ofMinutes(5);
+
+    /**
+     * Snapshot + replay state stored in the slot.
+     *
+     * @param id                            generated UUID — agents pass this back as
+     *                                      {@code popup_id} to {@code popup_respond}
+     * @param originalTool                  e.g. {@code "apply_action"}
+     * @param originalArgs                  the JSON object the agent originally sent
+     * @param project                       project the action targets
+     * @param fingerprint                   captured at invocation time, validated on replay
+     * @param snapshot                      what the popup looked like
+     * @param createdAt                     wall-clock time the snapshot was captured
+     * @param owningSessionKey              MCP session that owns this pending; only this session's
+     *                                      calls count toward {@link #MAX_UNRELATED_CALLS}
+     * @param unrelatedCallsSinceCreated    bumped by {@link #recordUnrelatedCall(String)}
+     * @param previousReplayDigest          {@link PopupSnapshot#contentDigest()} of the previous
+     *                                      replay attempt (for loop detection across replays);
+     *                                      {@code null} on first registration
+     */
+    public record Pending(
+        @NotNull String id,
+        @NotNull String originalTool,
+        @NotNull JsonObject originalArgs,
+        @Nullable Project project,
+        @NotNull ContextFingerprint fingerprint,
+        @NotNull PopupSnapshot snapshot,
+        @NotNull Instant createdAt,
+        @NotNull String owningSessionKey,
+        int unrelatedCallsSinceCreated,
+        @Nullable String previousReplayDigest
+    ) {
+    }
+
+    private @Nullable Pending current;
+    private @NotNull java.util.function.Supplier<Instant> clock = Instant::now;
+
+    @NotNull
+    public static PendingPopupService getInstance() {
+        return ApplicationManager.getApplication().getService(PendingPopupService.class);
+    }
+
+    /**
+     * Replaces the clock used by {@link #peek()} to evaluate {@link #MAX_AGE}. Tests only.
+     */
+    @TestOnly
+    public synchronized void setClockForTests(@NotNull java.util.function.Supplier<Instant> clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Atomically claims the pending slot.
+     *
+     * @return the registered {@link Pending}, or {@code null} when the slot was already taken.
+     */
+    @Nullable
+    public synchronized Pending register(@NotNull String originalTool,
+                                         @NotNull JsonObject originalArgs,
+                                         @Nullable Project project,
+                                         @NotNull ContextFingerprint fingerprint,
+                                         @NotNull PopupSnapshot snapshot,
+                                         @NotNull String owningSessionKey,
+                                         @Nullable String previousReplayDigest) {
+        if (current != null) {
+            LOG.warn("PendingPopupService: register rejected — slot already holds id="
+                + current.id);
+            return null;
+        }
+        Pending p = new Pending(
+            UUID.randomUUID().toString(),
+            originalTool,
+            originalArgs,
+            project,
+            fingerprint,
+            snapshot,
+            clock.get(),
+            owningSessionKey,
+            0,
+            previousReplayDigest
+        );
+        current = p;
+        return p;
+    }
+
+    /**
+     * Returns the current pending popup, or {@code null} if none. Lazily clears the slot if the
+     * pending popup is older than {@link #MAX_AGE}.
+     */
+    @Nullable
+    public synchronized Pending peek() {
+        if (current == null) return null;
+        if (Duration.between(current.createdAt, clock.get()).compareTo(MAX_AGE) > 0) {
+            LOG.info("PendingPopupService: auto-cancelling pending '" + current.id
+                + "' (older than " + MAX_AGE + ")");
+            current = null;
+            return null;
+        }
+        return current;
+    }
+
+    /**
+     * Atomically removes and returns the pending popup if its id matches.
+     */
+    @Nullable
+    public synchronized Pending take(@NotNull String popupId) {
+        Pending c = peek();
+        if (c == null || !c.id.equals(popupId)) return null;
+        current = null;
+        return c;
+    }
+
+    /**
+     * Clears the slot. When {@code popupId} is non-null, only clears if the id matches.
+     *
+     * @return true if a pending popup was cleared.
+     */
+    public synchronized boolean cancelAndClear(@Nullable String popupId) {
+        if (current == null) return false;
+        if (popupId != null && !current.id.equals(popupId)) return false;
+        current = null;
+        return true;
+    }
+
+    /**
+     * Records a tool call from {@code callerSessionKey} that is not {@code popup_respond}. Only
+     * calls from the owning session bump the counter. Returns the pending popup if this call
+     * just exhausted the budget and cleared the slot, or {@code null} otherwise.
+     */
+    @Nullable
+    public synchronized Pending recordUnrelatedCall(@NotNull String callerSessionKey) {
+        Pending c = peek();
+        if (c == null) return null;
+        if (!c.owningSessionKey.equals(callerSessionKey)) {
+            return null;
+        }
+        int next = c.unrelatedCallsSinceCreated + 1;
+        if (next >= MAX_UNRELATED_CALLS) {
+            current = null;
+            return c;
+        }
+        current = new Pending(
+            c.id, c.originalTool, c.originalArgs, c.project, c.fingerprint,
+            c.snapshot, c.createdAt, c.owningSessionKey, next, c.previousReplayDigest
+        );
+        return null;
+    }
+
+    /**
+     * Updates the {@code previousReplayDigest} of the current pending after a replay rendered a
+     * new popup. Used by loop detection across consecutive replays.
+     */
+    public synchronized void noteReplayDigest(@NotNull String popupId, @NotNull String digest) {
+        if (current == null || !current.id.equals(popupId)) return;
+        current = new Pending(
+            current.id, current.originalTool, current.originalArgs, current.project,
+            current.fingerprint, current.snapshot, current.createdAt, current.owningSessionKey,
+            current.unrelatedCallsSinceCreated, digest
+        );
+    }
+
+    @VisibleForTesting
+    public synchronized void clearForTests() {
+        current = null;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupChoice.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupChoice.java
@@ -1,0 +1,43 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * One row in a {@link com.intellij.openapi.ui.popup.JBPopup} chooser, captured at snapshot time.
+ *
+ * <p><b>Why this exists — DO NOT REMOVE without reading
+ * {@code .agent-work/popup-interaction-design-2026-04-30.md}.</b>
+ *
+ * <p>{@code valueId} is a stable identifier derived from the platform's
+ * {@link com.intellij.openapi.ui.popup.ListPopupStep#getTextFor} and the row position. It is used
+ * by {@code popup_respond} to drive selection during replay (NOT the raw list index, which can
+ * shift when separators / disabled rows / filtering are involved). Agents may pass either
+ * {@code valueId} or {@code index} when responding; {@code valueId} wins when both are provided.
+ *
+ * @param valueId       stable id; pattern: {@code <text>|<index>}
+ * @param index         display-only row position (0-based)
+ * @param text          primary text from {@code step.getTextFor(value)}
+ * @param secondaryText optional secondary text (subtitle/secondary label) — may be {@code null}
+ * @param selectable    whether the row is selectable (from {@code step.isSelectable(value)})
+ * @param hasSubstep    whether selecting this row opens a further popup
+ *                      (from {@code step.hasSubstep(value)})
+ */
+public record PopupChoice(
+    @NotNull String valueId,
+    int index,
+    @NotNull String text,
+    @Nullable String secondaryText,
+    boolean selectable,
+    boolean hasSubstep
+) {
+
+    /**
+     * Builds the canonical valueId used at both snapshot and replay sides so the same value
+     * round-trips deterministically.
+     */
+    @NotNull
+    public static String buildValueId(@NotNull String text, int index) {
+        return text + "|" + index;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupContentExtractor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupContentExtractor.java
@@ -8,15 +8,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.ListCellRenderer;
-import javax.swing.ListModel;
+import javax.swing.*;
 import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
-import java.awt.Component;
-import java.awt.Container;
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupContentExtractor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupContentExtractor.java
@@ -1,0 +1,254 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.ui.popup.JBPopup;
+import com.intellij.openapi.ui.popup.ListPopupStep;
+import com.intellij.ui.popup.list.ListPopupImpl;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+import javax.swing.ListModel;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreePath;
+import java.awt.Component;
+import java.awt.Container;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Extracts a structural {@link PopupSnapshot} from a live {@link JBPopup}.
+ *
+ * <p><b>Why this exists — DO NOT REMOVE without reading
+ * {@code .agent-work/popup-interaction-design-2026-04-30.md}.</b>
+ *
+ * <p>Strategy (in priority order):
+ * <ol>
+ *   <li><b>{@link ListPopupStep}</b> (preferred): cast popup to {@link ListPopupImpl}, get its
+ *       {@code ListPopupStep<Object>} via {@link ListPopupImpl#getListStep()}, enumerate
+ *       {@link ListPopupStep#getValues()}, format with
+ *       {@link ListPopupStep#getTextFor(Object)}, check
+ *       {@link ListPopupStep#isSelectable(Object)} and {@link ListPopupStep#hasSubstep(Object)}.
+ *       This is structurally accurate and aligns with what the platform exposes for
+ *       programmatic selection later via {@link ListPopupImpl#selectAndExecuteValue(Object)}.</li>
+ *   <li><b>Raw {@link JList} fallback</b>: when the popup is not a {@code ListPopupImpl} (custom
+ *       chooser, wizard step, etc.), walk the popup content for the first visible {@code JList},
+ *       enumerate its {@code ListModel}, render each row with the cell renderer, and pull the
+ *       first visible {@code JLabel}'s text. Marked {@code popupKind="list-fallback"} —
+ *       structural metadata is best-effort.</li>
+ *   <li><b>Tree</b>: when the popup contains a {@code JTree}, flatten the visible nodes with
+ *       indentation up to depth 3.</li>
+ *   <li><b>Unsupported</b>: otherwise, return an empty snapshot — caller falls back to the
+ *       PR #363 cancel-and-error path.</li>
+ * </ol>
+ *
+ * <p>All public methods are EDT-safe (called from the AWT {@code WINDOW_OPENED} listener
+ * which fires on the EDT).
+ */
+public final class PopupContentExtractor {
+
+    private static final Logger LOG = Logger.getInstance(PopupContentExtractor.class);
+    private static final int MAX_CHOICES = 200;
+    private static final int MAX_TREE_DEPTH = 3;
+
+    private PopupContentExtractor() {
+    }
+
+    /**
+     * Extracts a snapshot of {@code popup}. Never throws — returns an unsupported snapshot on
+     * any failure so the listener can still cancel the popup safely.
+     */
+    @NotNull
+    public static PopupSnapshot extract(@NotNull JBPopup popup) {
+        String title = PopupInterceptor.extractPopupTitle(popup);
+        try {
+            if (popup instanceof ListPopupImpl listPopup) {
+                ListPopupStep<Object> step = com.github.catatafishen.agentbridge.psi.PlatformApiCompat.getListStep(listPopup);
+                if (step != null) {
+                    List<PopupChoice> choices = extractFromStep(step);
+                    if (!choices.isEmpty()) {
+                        return new PopupSnapshot(title, choices, PopupSnapshot.KIND_LIST_STEP);
+                    }
+                }
+            }
+            JComponent content = popup.getContent();
+            JList<?> list = findFirstList(content);
+            if (list != null) {
+                List<PopupChoice> choices = extractFromList(list);
+                if (!choices.isEmpty()) {
+                    return new PopupSnapshot(title, choices, PopupSnapshot.KIND_LIST_FALLBACK);
+                }
+            }
+            javax.swing.JTree tree = findFirstTree(content);
+            if (tree != null) {
+                List<PopupChoice> choices = extractFromTree(tree);
+                if (!choices.isEmpty()) {
+                    return new PopupSnapshot(title, choices, PopupSnapshot.KIND_TREE);
+                }
+            }
+        } catch (Exception | LinkageError t) {
+            LOG.warn("PopupContentExtractor: extraction failed for popup '" + title + "'", t);
+        }
+        return new PopupSnapshot(title, List.of(), PopupSnapshot.KIND_UNSUPPORTED);
+    }
+
+    // ── Pure helpers (unit-testable with fakes) ───────────────────────
+
+    /**
+     * Pure logic over a {@link ListPopupStep} — directly testable with a fake step.
+     */
+    @VisibleForTesting
+    @NotNull
+    public static <T> List<PopupChoice> extractFromStep(@NotNull ListPopupStep<T> step) {
+        List<? extends T> values = step.getValues();
+        int limit = Math.min(values.size(), MAX_CHOICES);
+        List<PopupChoice> result = new ArrayList<>(limit);
+        for (int i = 0; i < limit; i++) {
+            T value = values.get(i);
+            String text = safeText(safeCall(() -> step.getTextFor(value)));
+            boolean selectable = Boolean.TRUE.equals(safeCall(() -> step.isSelectable(value)));
+            boolean hasSub = Boolean.TRUE.equals(safeCall(() -> step.hasSubstep(value)));
+            result.add(new PopupChoice(
+                PopupChoice.buildValueId(text, i), i, text, null, selectable, hasSub
+            ));
+        }
+        return result;
+    }
+
+    @NotNull
+    private static List<PopupChoice> extractFromList(@NotNull JList<?> list) {
+        ListModel<?> model = list.getModel();
+        ListCellRenderer<Object> renderer = castRenderer(list);
+        int size = Math.min(model.getSize(), MAX_CHOICES);
+        List<PopupChoice> result = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            Object value = model.getElementAt(i);
+            String text = renderRowText(list, renderer, value, i);
+            // Best-effort: assume selectable, no substep — fallback path lacks this metadata.
+            result.add(new PopupChoice(
+                PopupChoice.buildValueId(text, i), i, text, null, true, false
+            ));
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    @NotNull
+    private static ListCellRenderer<Object> castRenderer(@NotNull JList<?> list) {
+        return (ListCellRenderer<Object>) list.getCellRenderer();
+    }
+
+    @NotNull
+    private static String renderRowText(@NotNull JList<?> list,
+                                        @Nullable ListCellRenderer<Object> renderer,
+                                        @Nullable Object value, int index) {
+        if (renderer == null) {
+            return value != null ? value.toString() : "(null)";
+        }
+        try {
+            Component comp = renderer.getListCellRendererComponent(list, value, index, false, false);
+            if (comp instanceof JLabel lbl && lbl.getText() != null && !lbl.getText().isBlank()) {
+                return lbl.getText();
+            }
+            if (comp instanceof Container c) {
+                String label = PopupInterceptor.firstVisibleLabel(c);
+                if (label != null) return label;
+            }
+        } catch (Exception | LinkageError t) {
+            LOG.debug("renderRowText failed at index " + index, t);
+        }
+        return value != null ? value.toString() : "(null)";
+    }
+
+    @NotNull
+    private static List<PopupChoice> extractFromTree(@NotNull javax.swing.JTree tree) {
+        TreeModel model = tree.getModel();
+        if (model == null || model.getRoot() == null) return List.of();
+        Object root = model.getRoot();
+        List<PopupChoice> result = new ArrayList<>();
+        TreePath rootPath = new TreePath(root);
+        boolean rootVisible = tree.isRootVisible();
+        if (rootVisible) {
+            addTreeNode(model, root, 0, result);
+        }
+        appendChildren(model, root, rootPath, rootVisible ? 1 : 0, tree, result);
+        return result;
+    }
+
+    private static void appendChildren(@NotNull TreeModel model, @NotNull Object parent,
+                                       @NotNull TreePath parentPath, int depth,
+                                       @NotNull javax.swing.JTree tree,
+                                       @NotNull List<PopupChoice> out) {
+        if (depth > MAX_TREE_DEPTH) return;
+        int n = model.getChildCount(parent);
+        for (int i = 0; i < n && out.size() < MAX_CHOICES; i++) {
+            Object child = model.getChild(parent, i);
+            TreePath path = parentPath.pathByAddingChild(child);
+            addTreeNode(model, child, depth, out);
+            if (tree.isExpanded(path)) {
+                appendChildren(model, child, path, depth + 1, tree, out);
+            }
+        }
+    }
+
+    private static void addTreeNode(@NotNull TreeModel model, @NotNull Object node,
+                                    int depth, @NotNull List<PopupChoice> out) {
+        String label = nodeLabel(node);
+        String indented = "  ".repeat(Math.min(depth, MAX_TREE_DEPTH)) + label;
+        boolean leaf = model.isLeaf(node);
+        out.add(new PopupChoice(
+            PopupChoice.buildValueId(indented, out.size()),
+            out.size(), indented, null, leaf, !leaf
+        ));
+    }
+
+    @NotNull
+    private static String nodeLabel(@NotNull Object node) {
+        if (node instanceof javax.swing.tree.DefaultMutableTreeNode dmtn && dmtn.getUserObject() != null) {
+            return dmtn.getUserObject().toString();
+        }
+        return node.toString();
+    }
+
+    @Nullable
+    private static JList<?> findFirstList(@NotNull Container container) {
+        for (Component c : container.getComponents()) {
+            if (c instanceof JList<?> list && list.isVisible()) return list;
+            if (c instanceof Container nested) {
+                JList<?> r = findFirstList(nested);
+                if (r != null) return r;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private static javax.swing.JTree findFirstTree(@NotNull Container container) {
+        for (Component c : container.getComponents()) {
+            if (c instanceof javax.swing.JTree tree && tree.isVisible()) return tree;
+            if (c instanceof Container nested) {
+                javax.swing.JTree r = findFirstTree(nested);
+                if (r != null) return r;
+            }
+        }
+        return null;
+    }
+
+    @NotNull
+    private static String safeText(@Nullable String s) {
+        return (s != null && !s.isBlank()) ? s : "(unnamed)";
+    }
+
+    @Nullable
+    private static <T> T safeCall(@NotNull java.util.function.Supplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (Exception | LinkageError t) {
+            return null;
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupGateLogic.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupGateLogic.java
@@ -1,0 +1,139 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import com.github.catatafishen.agentbridge.psi.tools.quality.PendingPopupService.Pending;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Pure decision function: given the current {@link Pending} (if any) and an incoming tool call,
+ * decide whether the call is allowed, blocked, or should proceed with a "popup auto-cancelled"
+ * note prepended to its result.
+ *
+ * <p><b>Why this exists — DO NOT REMOVE without reading
+ * {@code .agent-work/popup-interaction-design-2026-04-30.md}.</b>
+ *
+ * <p>Extracted from {@link com.github.catatafishen.agentbridge.services.McpProtocolHandler} so
+ * the gate behavior is unit-testable in isolation. The protocol handler calls
+ * {@link #evaluate(Pending, String, String, Instant)} before dispatching to {@code bridge.callTool}
+ * and acts on the returned {@link Decision}.
+ *
+ * <h2>Rules</h2>
+ * <ol>
+ *   <li>{@link #POPUP_RESPOND_TOOL} always passes (it's the tool that resolves the pending).</li>
+ *   <li>If no popup is pending → {@link Allow}.</li>
+ *   <li>If a popup is pending and the time budget has expired → {@link AllowWithCancelNote}
+ *       (the gate is responsible for telling the caller to drop the slot).</li>
+ *   <li>If the call comes from the owning session and would be the
+ *       {@link PendingPopupService#MAX_UNRELATED_CALLS}-th unrelated call →
+ *       {@link AllowWithCancelNote}.</li>
+ *   <li>Otherwise → {@link Block} with an actionable message naming the popup id.</li>
+ * </ol>
+ *
+ * <p>Cross-session calls return {@link Block} (a popup on the EDT affects every session) but do
+ * not bump the owning session's counter — they're a "noisy neighbor" signal, not progress
+ * toward auto-cancel.
+ */
+public final class PopupGateLogic {
+
+    public static final String POPUP_RESPOND_TOOL = "popup_respond";
+
+    private PopupGateLogic() {
+    }
+
+    /**
+     * Result of {@link #evaluate(Pending, String, String, Instant)}.
+     *
+     * <ul>
+     *   <li>{@link Allow} — dispatch the call normally.</li>
+     *   <li>{@link AllowWithCancelNote} — dispatch the call normally, but the caller MUST
+     *       prepend {@link AllowWithCancelNote#note()} to the tool's response and clear the
+     *       pending slot via {@link PendingPopupService#cancelAndClear(String)} before
+     *       dispatching. The cancelled {@link Pending} is included for context.</li>
+     *   <li>{@link Block} — return {@link Block#message()} as the tool's error response and do
+     *       not dispatch.</li>
+     * </ul>
+     */
+    public sealed interface Decision {
+    }
+
+    public record Allow() implements Decision {
+    }
+
+    public record AllowWithCancelNote(@NotNull Pending cancelled, @NotNull String note)
+        implements Decision {
+    }
+
+    public record Block(@NotNull String message) implements Decision {
+    }
+
+    /**
+     * Pure decision. Does NOT mutate {@link PendingPopupService} — the caller is responsible
+     * for {@link PendingPopupService#recordUnrelatedCall(String)} or
+     * {@link PendingPopupService#cancelAndClear(String)} based on the returned {@link Decision}.
+     *
+     * @param pending           current pending popup, or {@code null}
+     * @param toolName          incoming tool name
+     * @param callerSessionKey  MCP session key of the caller
+     * @param now               current instant (injected for testability)
+     */
+    @NotNull
+    public static Decision evaluate(@Nullable Pending pending,
+                                    @NotNull String toolName,
+                                    @NotNull String callerSessionKey,
+                                    @NotNull Instant now) {
+        if (POPUP_RESPOND_TOOL.equals(toolName)) {
+            return new Allow();
+        }
+        if (pending == null) {
+            return new Allow();
+        }
+        Duration age = Duration.between(pending.createdAt(), now);
+        if (age.compareTo(PendingPopupService.MAX_AGE) > 0) {
+            return new AllowWithCancelNote(pending, formatTimeoutNote(pending, age));
+        }
+        boolean owning = pending.owningSessionKey().equals(callerSessionKey);
+        if (owning && pending.unrelatedCallsSinceCreated() + 1 >= PendingPopupService.MAX_UNRELATED_CALLS) {
+            return new AllowWithCancelNote(pending, formatExhaustedNote(pending));
+        }
+        return new Block(formatBlockedMessage(pending, owning));
+    }
+
+    @NotNull
+    static String formatBlockedMessage(@NotNull Pending pending, boolean owningSession) {
+        int remaining = PendingPopupService.MAX_UNRELATED_CALLS
+            - pending.unrelatedCallsSinceCreated() - 1;
+        StringBuilder sb = new StringBuilder();
+        sb.append("Error: a popup is awaiting response (id=").append(pending.id())
+            .append(", originally opened by '").append(pending.originalTool())
+            .append("' for action '").append(pending.fingerprint().actionIdentity())
+            .append("'). Call popup_respond first.");
+        if (owningSession) {
+            sb.append(" Auto-cancels in ").append(Math.max(remaining, 0))
+                .append(" more tool call(s)").append(remaining <= 0 ? " (next call cancels)" : "")
+                .append(".");
+        } else {
+            sb.append(" The popup is owned by a different MCP session; this call is blocked")
+                .append(" because the popup occupies the IDE's EDT.");
+        }
+        return sb.toString();
+    }
+
+    @NotNull
+    static String formatExhaustedNote(@NotNull Pending pending) {
+        return "Note: pending popup '" + pending.snapshot().popupTitle()
+            + "' (id=" + pending.id() + ") was auto-cancelled — "
+            + PendingPopupService.MAX_UNRELATED_CALLS
+            + " unrelated tool calls without response.\n\n";
+    }
+
+    @NotNull
+    static String formatTimeoutNote(@NotNull Pending pending, @NotNull Duration age) {
+        return "Note: pending popup '" + pending.snapshot().popupTitle()
+            + "' (id=" + pending.id() + ") was auto-cancelled — older than "
+            + PendingPopupService.MAX_AGE.toMinutes() + " min (age "
+            + age.toSeconds() + "s).\n\n";
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupHandler.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupHandler.java
@@ -1,0 +1,53 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+/**
+ * Strategy controlling what {@link PopupInterceptor} does when an action opens a
+ * {@link com.intellij.openapi.ui.popup.JBPopup} chooser inside its nested AWT event loop.
+ *
+ * <p><b>Why this exists — DO NOT REMOVE without reading
+ * {@code .agent-work/popup-interaction-design-2026-04-30.md}.</b>
+ *
+ * <p>The handler is passed <em>explicitly</em> down the call chain (NOT via thread-local) because
+ * the AWT {@code WINDOW_OPENED} listener fires on the EDT in a different stack from the MCP
+ * worker thread. The closure captures the handler at registration time so the listener has the
+ * correct strategy regardless of which thread originally triggered the action.
+ *
+ * <p>Variants:
+ * <ul>
+ *   <li>{@link Cancel} — current PR #363 behavior; cancel any new popup, surface an error.</li>
+ *   <li>{@link Snapshot} — extract the popup's choices via {@link PopupContentExtractor}, push
+ *       the snapshot through the sink, then cancel the popup. The caller registers the snapshot
+ *       in {@link PendingPopupService} and tells the agent to call {@code popup_respond}.</li>
+ *   <li>{@link SelectByValue} — used by {@code popup_respond} to drive the popup. On open,
+ *       locate the value with the matching captured id and select it via
+ *       {@link com.intellij.openapi.ui.popup.ListPopupStep#onChosen}.
+ *       Falls back to {@code fallbackIndex} only if the captured text still occupies that row.</li>
+ * </ul>
+ */
+public sealed interface PopupHandler {
+
+    /** Cancel any new popup; reports back via {@link PopupInterceptor.Result#popupWasOpened()}. */
+    record Cancel() implements PopupHandler {
+    }
+
+    /**
+     * Snapshot the popup's choices then cancel. The {@code sink} is invoked on the EDT during
+     * the listener callback, before the popup is cancelled.
+     */
+    record Snapshot(@NotNull Consumer<PopupSnapshot> sink) implements PopupHandler {
+    }
+
+    /**
+     * Select a specific value in the popup. {@code valueId} is the stable id captured by
+     * {@link PopupChoice#valueId()} at snapshot time. {@code fallbackIndex} is used only if
+     * the value can't be located by id but the row at {@code fallbackIndex} still has the
+     * captured text — this covers the common case where the popup is identical on re-open.
+     */
+    record SelectByValue(@NotNull String valueId, int fallbackIndex,
+                         @NotNull String fallbackText) implements PopupHandler {
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupInterceptor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupInterceptor.java
@@ -1,13 +1,25 @@
 package com.github.catatafishen.agentbridge.psi.tools.quality;
 
+import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.ui.popup.ListPopupStep;
+import com.intellij.ui.popup.list.ListPopupImpl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JRootPane;
+import java.awt.AWTEvent;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Frame;
+import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.event.AWTEventListener;
 import java.awt.event.WindowEvent;
 import java.util.ArrayList;
@@ -18,39 +30,47 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Detects and cancels {@link JBPopup quick-fix / chooser popups} that an
- * {@link com.intellij.codeInsight.intention.IntentionAction} opens during {@code invoke()}.
+ * Detects {@link JBPopup} popups opened during an
+ * {@link com.intellij.codeInsight.intention.IntentionAction} invocation and either cancels them
+ * (default), snapshots their structure for later replay, or programmatically selects a captured
+ * value to drive the popup to completion.
  *
  * <p><b>Why this exists — DO NOT REMOVE without reading
- * {@code .agent-work/freeze-investigation-2026-04-30.md}.</b>
+ * {@code .agent-work/freeze-investigation-2026-04-30.md} and
+ * {@code .agent-work/popup-interaction-design-2026-04-30.md}.</b>
  *
- * <p>When an {@code IntentionAction} like {@code "Import class 'Cell'"} cannot decide what to do
+ * <p>When an {@code IntentionAction} like {@code "Import class 'Cell'"} cannot decide
  * non-interactively (e.g. multiple {@code Cell} classes are importable), it opens a heavyweight
- * {@link JBPopup} class chooser and pumps a <em>nested AWT event loop</em> on the EDT until the
- * user picks an option. From outside that nested loop, the EDT looks frozen — every other tool
- * call queued via {@code invokeLater} starves, and the entire IDE becomes unresponsive.
- * {@link com.github.catatafishen.agentbridge.psi.EdtUtil#describeModalBlocker EdtUtil} can
- * <em>diagnose</em> that situation after the fact (after the 1.5 s modal-poll timeout), but the
- * EDT is still stuck inside the popup loop because nothing has cancelled the popup.
+ * {@link JBPopup} chooser and pumps a <em>nested AWT event loop</em> on the EDT until the user
+ * picks. From outside that nested loop, the EDT looks frozen — every other tool call queued via
+ * {@code invokeLater} starves, and the entire IDE becomes unresponsive.
  *
- * <p>This interceptor closes that gap. It installs a global AWT {@code WINDOW_OPENED} listener,
- * runs the action, and — when a new popup window appears <em>inside</em> the nested loop —
- * looks up the corresponding {@link JBPopup} via {@link JBPopupFactory#getChildPopups} and calls
- * {@link JBPopup#cancel()} on the EDT. {@code cancel()} disposes the popup synchronously, which
- * exits the nested event loop, and the original {@code action.invoke()} call returns to the
- * caller. The caller can then report a structured "popup blocked" error to the agent so it can
- * choose a different strategy ({@code edit_text}, ambiguous-import pre-flight, etc.).
+ * <h2>Handler modes</h2>
+ * <ul>
+ *   <li>{@link PopupHandler.Cancel} — the original PR #363 behavior: cancel the popup, return a
+ *       {@code popupWasOpened=true} result. The caller surfaces a structured error to the agent
+ *       and suggests {@code edit_text}.</li>
+ *   <li>{@link PopupHandler.Snapshot} — extract a {@link PopupSnapshot} via
+ *       {@link PopupContentExtractor}, push it through {@link PopupHandler.Snapshot#sink()},
+ *       then cancel. The caller stores the snapshot in {@code PendingPopupService} and tells the
+ *       agent it can call {@code popup_respond}.</li>
+ *   <li>{@link PopupHandler.SelectByValue} — given a {@code valueId} captured by a prior
+ *       Snapshot run, locate the matching value in the popup's {@link ListPopupStep} and invoke
+ *       {@link ListPopupImpl#selectAndExecuteValue(Object)} via
+ *       {@link ApplicationManager#invokeLater(Runnable, ModalityState)} with
+ *       {@link ModalityState#any()} (per the rubber-duck review: dispatching the selection
+ *       inside the {@code WINDOW_OPENED} listener can race popup initialisation).</li>
+ * </ul>
  *
- * <p>The detection is <em>scoped</em> to a chosen owner component (typically the editor's
- * root pane). We snapshot the popups visible under that owner before invoking the action and
- * cancel only popups that were not present in the snapshot. This avoids cancelling unrelated
- * popups that happen to be open in the IDE at the same time (e.g. a tool-window quick search).
+ * <p>The detection is <em>scoped</em> to a chosen owner component (typically the editor's root
+ * pane). We snapshot popups visible under that owner before invoking the action and only act on
+ * popups not present in the baseline. This avoids touching unrelated popups (e.g. tool-window
+ * quick search).
  *
- * <p>This handles the heavyweight-popup freeze case only. Lightweight popups (overlaid on
- * {@link javax.swing.JLayeredPane} without a nested event loop) cannot freeze the EDT and are
- * intentionally out of scope.
+ * <p>Lightweight popups (overlaid on {@link javax.swing.JLayeredPane} without a nested event
+ * loop) cannot freeze the EDT and are intentionally out of scope.
  *
- * <p>All methods must be called from the EDT.
+ * <p>All public methods must be called from the EDT.
  *
  * @see DialogInterceptor for the analogous pattern targeting modal {@link java.awt.Dialog}s.
  */
@@ -60,8 +80,24 @@ final class PopupInterceptor {
 
     /**
      * Snapshot returned to the caller after invocation.
+     *
+     * @param popupWasOpened whether at least one new popup opened during {@code action.run()}.
+     * @param popupTitles    titles of the new popups (best-effort).
+     * @param cancelled      whether <em>all</em> intercepted popups were dismissed (only
+     *                       meaningful in {@link PopupHandler.Cancel} and
+     *                       {@link PopupHandler.Snapshot} modes).
+     * @param snapshot       structural extraction of the first intercepted popup; non-null only
+     *                       when handler is {@link PopupHandler.Snapshot} and extraction
+     *                       succeeded.
+     * @param selectionScheduled true when a {@link PopupHandler.SelectByValue} replay scheduled
+     *                       a selection via {@code invokeLater}; the popup will close
+     *                       asynchronously after this method returns.
      */
-    record Result(boolean popupWasOpened, @NotNull List<String> popupTitles, boolean cancelled) {
+    record Result(boolean popupWasOpened,
+                  @NotNull List<String> popupTitles,
+                  boolean cancelled,
+                  @Nullable PopupSnapshot snapshot,
+                  boolean selectionScheduled) {
 
         @NotNull
         String describe() {
@@ -76,20 +112,34 @@ final class PopupInterceptor {
     }
 
     /**
-     * Runs {@code action}, cancelling any new {@link JBPopup} that opens under {@code owner}'s
-     * window during invocation. Returns a {@link Result} describing what was caught (if anything).
-     *
-     * @param owner  optional component used to scope popup detection. Pass the editor component
-     *               or root pane. {@code null} falls back to a global scan across all frames.
-     * @param action the EDT-bound action whose popup-opening side-effect should be intercepted.
+     * Convenience overload that uses {@link PopupHandler.Cancel}. Maintained for callers that
+     * want PR #363's original behavior.
      */
     @NotNull
     static Result runDetectingPopups(@Nullable Component owner, @NotNull Runnable action) {
-        // Snapshot the popups already open under this owner so we cancel ONLY new ones.
+        return runDetectingPopups(owner, new PopupHandler.Cancel(), action);
+    }
+
+    /**
+     * Runs {@code action} with the given {@link PopupHandler}. See the class Javadoc for the
+     * handler-mode semantics.
+     *
+     * @param owner   optional component used to scope popup detection. Pass the editor component
+     *                or root pane. {@code null} falls back to a global scan across all frames.
+     * @param handler what to do when a popup is detected.
+     * @param action  the EDT-bound action whose popup-opening side-effect should be intercepted.
+     */
+    @NotNull
+    static Result runDetectingPopups(@Nullable Component owner,
+                                     @NotNull PopupHandler handler,
+                                     @NotNull Runnable action) {
         Set<JBPopup> baseline = collectActivePopups(owner);
         AtomicReference<List<JBPopup>> capturedRef = new AtomicReference<>(List.of());
+        AtomicReference<PopupSnapshot> snapshotRef = new AtomicReference<>();
+        AtomicReference<Boolean> selectionScheduledRef = new AtomicReference<>(false);
 
-        AWTEventListener listener = event -> onWindowEvent(event, owner, baseline, capturedRef);
+        AWTEventListener listener = event -> onWindowEvent(
+            event, owner, baseline, capturedRef, handler, snapshotRef, selectionScheduledRef);
 
         Toolkit.getDefaultToolkit().addAWTEventListener(listener, AWTEvent.WINDOW_EVENT_MASK);
         try {
@@ -100,22 +150,52 @@ final class PopupInterceptor {
 
         List<JBPopup> captured = capturedRef.get();
         if (captured.isEmpty()) {
-            return new Result(false, List.of(), false);
+            return new Result(false, List.of(), false, null, false);
         }
 
         List<String> titles = new ArrayList<>(captured.size());
-        boolean allCancelled = cancelAndCollectTitles(captured, titles);
-        return new Result(true, List.copyOf(titles), allCancelled);
+        for (JBPopup popup : captured) {
+            titles.add(extractPopupTitle(popup));
+        }
+
+        boolean isSelect = handler instanceof PopupHandler.SelectByValue;
+        boolean allCancelled = false;
+        if (!isSelect) {
+            // Cancel/Snapshot: ensure popups are gone (defensive — listener may have raced).
+            allCancelled = ensureCancelled(captured);
+        }
+
+        return new Result(
+            true,
+            List.copyOf(titles),
+            allCancelled,
+            snapshotRef.get(),
+            Boolean.TRUE.equals(selectionScheduledRef.get())
+        );
     }
 
-    private static void onWindowEvent(@NotNull AWTEvent event, @Nullable Component owner,
+    private static boolean ensureCancelled(@NotNull List<JBPopup> popups) {
+        boolean allCancelled = true;
+        for (JBPopup popup : popups) {
+            if (!tryCancel(popup) || !popup.isDisposed()) {
+                allCancelled = false;
+            }
+        }
+        return allCancelled;
+    }
+
+    private static void onWindowEvent(@NotNull AWTEvent event,
+                                      @Nullable Component owner,
                                       @NotNull Set<JBPopup> baseline,
-                                      @NotNull AtomicReference<List<JBPopup>> capturedRef) {
+                                      @NotNull AtomicReference<List<JBPopup>> capturedRef,
+                                      @NotNull PopupHandler handler,
+                                      @NotNull AtomicReference<PopupSnapshot> snapshotRef,
+                                      @NotNull AtomicReference<Boolean> selectionScheduledRef) {
         if (!(event instanceof WindowEvent we) || we.getID() != WindowEvent.WINDOW_OPENED) {
             return;
         }
         if (!capturedRef.get().isEmpty()) {
-            return; // already captured one set; ignore further window-opens
+            return;
         }
         try {
             List<JBPopup> newPopups = diffNewPopups(owner, baseline);
@@ -123,31 +203,105 @@ final class PopupInterceptor {
                 return;
             }
             capturedRef.set(newPopups);
-            // cancel() must run on the EDT inside the popup's nested event loop so the loop
-            // exits and action.invoke() returns. The AWT listener fires on the EDT, so we
-            // call cancel() right here — the very same EDT cycle the popup opened in.
-            for (JBPopup popup : newPopups) {
-                tryCancel(popup);
-            }
+            handlePopupCaptured(newPopups, handler, snapshotRef, selectionScheduledRef);
         } catch (Exception | LinkageError t) {
-            // Defensive: never let a diagnostic listener crash the EDT.
             LOG.warn("PopupInterceptor: failed while inspecting opened window", t);
         }
     }
 
-    private static boolean cancelAndCollectTitles(@NotNull List<JBPopup> popups,
-                                                  @NotNull List<String> titlesOut) {
-        boolean allCancelled = true;
-        for (JBPopup popup : popups) {
-            titlesOut.add(extractPopupTitle(popup));
-            // Defensive second cancel pass for the unusual case where the listener saw the
-            // window AFTER action.run() returned (the new window event was queued but not yet
-            // dispatched while the action was still on the stack).
-            if (!tryCancel(popup) || !popup.isDisposed()) {
-                allCancelled = false;
+    private static void handlePopupCaptured(@NotNull List<JBPopup> popups,
+                                            @NotNull PopupHandler handler,
+                                            @NotNull AtomicReference<PopupSnapshot> snapshotRef,
+                                            @NotNull AtomicReference<Boolean> selectionScheduledRef) {
+        JBPopup first = popups.getFirst();
+        switch (handler) {
+            case PopupHandler.Cancel ignored -> {
+                for (JBPopup p : popups) tryCancel(p);
+            }
+            case PopupHandler.Snapshot snap -> {
+                PopupSnapshot ps = PopupContentExtractor.extract(first);
+                snapshotRef.set(ps);
+                try {
+                    snap.sink().accept(ps);
+                } catch (Exception | LinkageError t) {
+                    LOG.warn("PopupInterceptor: snapshot sink threw", t);
+                }
+                for (JBPopup p : popups) tryCancel(p);
+            }
+            case PopupHandler.SelectByValue sel -> {
+                if (first instanceof ListPopupImpl listPopup) {
+                    selectionScheduledRef.set(true);
+                    ApplicationManager.getApplication().invokeLater(
+                        () -> selectInListPopup(listPopup, sel),
+                        ModalityState.any()
+                    );
+                } else {
+                    LOG.warn("PopupInterceptor: SelectByValue requires ListPopupImpl, got "
+                        + first.getClass().getName() + " — cancelling");
+                    for (JBPopup p : popups) tryCancel(p);
+                }
             }
         }
-        return allCancelled;
+    }
+
+    /**
+     * Locates the value matching {@code sel.valueId()} in {@code popup}'s
+     * {@link ListPopupStep} and invokes {@link ListPopupImpl#selectAndExecuteValue(Object)}.
+     * Falls back to {@code sel.fallbackIndex()} only when the captured value can't be found
+     * by id but the index is still valid and selectable. Cancels the popup on failure.
+     */
+    private static void selectInListPopup(@NotNull ListPopupImpl popup,
+                                          @NotNull PopupHandler.SelectByValue sel) {
+        try {
+            if (popup.isDisposed()) {
+                LOG.warn("PopupInterceptor: popup disposed before selection could run");
+                return;
+            }
+            ListPopupStep<Object> step = PlatformApiCompat.getListStep(popup);
+            if (step == null) {
+                LOG.warn("PopupInterceptor: SelectByValue — no ListPopupStep available");
+                tryCancel(popup);
+                return;
+            }
+            List<?> values = step.getValues();
+            Object chosen = findValueByValueId(step, values, sel);
+            if (chosen == null) {
+                LOG.warn("PopupInterceptor: SelectByValue — value '" + sel.valueId()
+                    + "' not found and fallback (index=" + sel.fallbackIndex() + ", text='"
+                    + sel.fallbackText() + "') did not match. Cancelling popup.");
+                tryCancel(popup);
+                return;
+            }
+            popup.selectAndExecuteValue(chosen);
+        } catch (Exception | LinkageError t) {
+            LOG.warn("PopupInterceptor: SelectByValue dispatch failed; cancelling popup", t);
+            tryCancel(popup);
+        }
+    }
+
+    @Nullable
+    private static Object findValueByValueId(@NotNull ListPopupStep<Object> step,
+                                             @NotNull List<?> values,
+                                             @NotNull PopupHandler.SelectByValue sel) {
+        for (int i = 0; i < values.size(); i++) {
+            Object v = values.get(i);
+            String text = step.getTextFor(v);
+            String id = PopupChoice.buildValueId(text == null ? "(unnamed)" : text, i);
+            if (id.equals(sel.valueId()) && step.isSelectable(v)) {
+                return v;
+            }
+        }
+        // Fallback by index+text — protects against minor reordering.
+        int fi = sel.fallbackIndex();
+        if (fi >= 0 && fi < values.size()) {
+            Object v = values.get(fi);
+            String text = step.getTextFor(v);
+            String fbText = sel.fallbackText();
+            if (fbText != null && fbText.equals(text) && step.isSelectable(v)) {
+                return v;
+            }
+        }
+        return null;
     }
 
     private static boolean tryCancel(@NotNull JBPopup popup) {
@@ -164,11 +318,6 @@ final class PopupInterceptor {
 
     // ── Pure helpers (unit-testable) ──────────────────────────
 
-    /**
-     * Returns the popups visible <em>now</em> that were not in {@code baseline}. Pure function
-     * over the live UI state — exposed at package-private level so the listener path and tests
-     * use the same logic.
-     */
     @NotNull
     static List<JBPopup> diffNewPopups(@Nullable Component owner, @NotNull Set<JBPopup> baseline) {
         List<JBPopup> result = new ArrayList<>();
@@ -180,10 +329,6 @@ final class PopupInterceptor {
         return result;
     }
 
-    /**
-     * Collects active {@link JBPopup}s anchored under {@code owner}'s window. When {@code owner}
-     * is {@code null} (no editor available), falls back to scanning every {@link Frame}.
-     */
     @NotNull
     static Set<JBPopup> collectActivePopups(@Nullable Component owner) {
         Set<JBPopup> result = new HashSet<>();
@@ -223,11 +368,6 @@ final class PopupInterceptor {
         return component instanceof JComponent jc ? jc : null;
     }
 
-    /**
-     * Best-effort title for a popup. JBPopup has no public title accessor, so we look for a
-     * window title (heavyweight popups carry the title there) and fall back to the first visible
-     * label inside the popup content. Returns {@code "(untitled popup)"} if nothing is found.
-     */
     @NotNull
     static String extractPopupTitle(@NotNull JBPopup popup) {
         try {
@@ -262,7 +402,8 @@ final class PopupInterceptor {
     }
 
     /**
-     * Formats the agent-facing error returned when a popup was intercepted. Pure function.
+     * Formats the agent-facing error returned when a popup was intercepted in
+     * {@link PopupHandler.Cancel} mode (PR #363 fallback path).
      */
     @NotNull
     static String formatPopupBlockedError(@NotNull String actionName, @NotNull Result result) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupRespondTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupRespondTool.java
@@ -1,0 +1,259 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.github.catatafishen.agentbridge.psi.tools.Tool;
+import com.github.catatafishen.agentbridge.ui.renderers.SimpleStatusRenderer;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Resolves a pending {@link PendingPopupService.Pending} popup by re-running the original
+ * tool with a {@link PopupHandler.SelectByValue} (or by cancelling).
+ *
+ * <p><b>Why this exists — DO NOT REMOVE without reading
+ * {@code .agent-work/popup-interaction-design-2026-04-30.md}.</b>
+ *
+ * <p>Companion to {@link ApplyActionTool} / {@link ApplyQuickfixTool}: when one of those tools
+ * intercepts a popup chooser, the popup is cancelled (the EDT cannot stay frozen waiting for an
+ * out-of-band agent decision), the choices are snapshotted, and the original call returns
+ * success with a {@code popup_id}. The agent then calls {@code popup_respond} with that id and
+ * either {@code "select"} (with {@code value_id} or {@code index}) or {@code "cancel"}.
+ *
+ * <h2>v1 limitations (intentional)</h2>
+ * <ul>
+ *   <li>Selecting a row with {@code hasSubstep=true} is rejected — the popup-cancel-and-replay
+ *       model does not yet handle chained popups (the chained popup would re-freeze the EDT
+ *       inside the replay).</li>
+ *   <li>If replay opens a brand-new popup that is identical to the previous one (loop), the
+ *       call returns an error pointing the agent at {@code edit_text}.</li>
+ * </ul>
+ */
+public final class PopupRespondTool extends QualityTool {
+
+    private static final Logger LOG = Logger.getInstance(PopupRespondTool.class);
+
+    private static final String PARAM_POPUP_ID = "popup_id";
+    private static final String PARAM_ACTION = "action";
+    private static final String PARAM_VALUE_ID = "value_id";
+    private static final String PARAM_INDEX = "index";
+    private static final String ACTION_SELECT = "select";
+    private static final String ACTION_CANCEL = "cancel";
+
+    private final Map<String, Replayable> replayables;
+
+    /**
+     * @param replayables map from {@link Tool#id()} to the {@link Replayable} implementation —
+     *                    typically {@code apply_action → ApplyActionTool},
+     *                    {@code apply_quickfix → ApplyQuickfixTool}.
+     */
+    public PopupRespondTool(@NotNull Project project, @NotNull Map<String, Replayable> replayables) {
+        super(project);
+        this.replayables = Map.copyOf(replayables);
+    }
+
+    @Override
+    public @NotNull String id() {
+        return PopupGateLogic.POPUP_RESPOND_TOOL;
+    }
+
+    @Override
+    public @NotNull String displayName() {
+        return "Popup Respond";
+    }
+
+    @Override
+    public @NotNull String description() {
+        return "Resolve a pending IDE popup chooser opened by apply_action or apply_quickfix. "
+            + "When one of those tools opens a popup (e.g. an ambiguous-import chooser) the "
+            + "tool returns a popup_id and the list of choices instead of failing. Use this "
+            + "tool to either select a choice (action='select' with value_id or index) or "
+            + "dismiss the popup (action='cancel'). Selecting a substep choice is not yet "
+            + "supported.";
+    }
+
+    @Override
+    public @NotNull Kind kind() {
+        return Kind.EDIT;
+    }
+
+    @Override
+    public boolean requiresInteractiveEdt() {
+        return true;
+    }
+
+    @Override
+    public @NotNull JsonObject inputSchema() {
+        return schema(
+            Param.required(PARAM_POPUP_ID, TYPE_STRING,
+                "The popup_id returned by the tool that opened the popup"),
+            Param.required(PARAM_ACTION, TYPE_STRING,
+                "Either 'select' to choose a row, or 'cancel' to dismiss the popup"),
+            Param.optional(PARAM_VALUE_ID, TYPE_STRING,
+                "Stable value_id of the row to select (preferred over 'index')"),
+            Param.optional(PARAM_INDEX, TYPE_INTEGER,
+                "0-based row index to select; only used when value_id is not provided")
+        );
+    }
+
+    @Override
+    public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        if (!args.has(PARAM_POPUP_ID) || !args.has(PARAM_ACTION)) {
+            return "Error: 'popup_id' and 'action' parameters are required";
+        }
+        String popupId = args.get(PARAM_POPUP_ID).getAsString();
+        String action = args.get(PARAM_ACTION).getAsString();
+
+        PendingPopupService pps = PendingPopupService.getInstance();
+        PendingPopupService.Pending pending = pps.peek();
+        if (pending == null) {
+            return "Error: no popup is currently pending. The popup may have already been "
+                + "resolved, expired (5 min), or auto-cancelled (5 unrelated tool calls).";
+        }
+        if (!pending.id().equals(popupId)) {
+            return "Error: popup_id mismatch (got '" + popupId + "', current pending id is '"
+                + pending.id() + "'). The earlier popup has likely been resolved already.";
+        }
+
+        if (ACTION_CANCEL.equalsIgnoreCase(action)) {
+            pps.cancelAndClear(popupId);
+            return "Popup '" + pending.snapshot().popupTitle()
+                + "' (id=" + popupId + ") cancelled. The original action ('"
+                + pending.fingerprint().actionIdentity() + "') was NOT applied.";
+        }
+        if (!ACTION_SELECT.equalsIgnoreCase(action)) {
+            return "Error: action must be 'select' or 'cancel' (got '" + action + "').";
+        }
+
+        // Locate the chosen row.
+        PopupChoice chosen = resolveChoice(pending.snapshot().choices(), args);
+        if (chosen == null) {
+            return "Error: could not resolve a choice from the provided value_id/index. "
+                + "Available value_ids: " + pending.snapshot().choices().stream()
+                    .map(c -> "'" + c.valueId() + "'").toList();
+        }
+        if (!chosen.selectable()) {
+            return "Error: choice '" + chosen.text() + "' is marked non-selectable in the popup.";
+        }
+        if (chosen.hasSubstep()) {
+            return "Error: choice '" + chosen.text() + "' opens a submenu (chained popup). "
+                + "Chained popups are not yet supported by popup_respond. Pick a leaf choice "
+                + "or use edit_text to make the change manually.";
+        }
+
+        // Validate fingerprint before replaying — if the file changed since snapshot, the
+        // action may now do the wrong thing.
+        ContextFingerprint current = currentFingerprintFor(pending.fingerprint());
+        if (!pending.fingerprint().matches(current)) {
+            pps.cancelAndClear(popupId);
+            return "Error: context changed since the popup was captured ("
+                + pending.fingerprint().describeMismatch(current)
+                + "). The pending popup has been discarded; please retry the original tool call.";
+        }
+
+        Replayable replayable = replayables.get(pending.originalTool());
+        if (replayable == null) {
+            pps.cancelAndClear(popupId);
+            return "Error: original tool '" + pending.originalTool()
+                + "' does not implement replay; cannot complete popup. The pending popup has been discarded.";
+        }
+
+        // Take the slot before invoking — replay may itself attempt to register a new pending
+        // (chained popup case), and we want the slot free for that. If replay fails we don't
+        // resurrect it: the agent should re-issue the original call.
+        PendingPopupService.Pending taken = pps.take(popupId);
+        if (taken == null) {
+            return "Error: pending popup vanished between peek and take (race). Please retry.";
+        }
+
+        PopupHandler.SelectByValue handler = new PopupHandler.SelectByValue(
+            chosen.valueId(), chosen.index(), chosen.text());
+        try {
+            String result = invokeReplay(replayable, taken.originalArgs(), handler);
+            // After replay, if a NEW pending was registered for a chained popup with the same
+            // content digest as before, that's a loop — discard and tell the agent.
+            PendingPopupService.Pending after = pps.peek();
+            if (after != null && after.snapshot().contentDigest()
+                .equals(taken.snapshot().contentDigest())) {
+                pps.cancelAndClear(after.id());
+                return "Error: popup loop detected — replaying the action opened the same "
+                    + "chooser again. The action will not converge non-interactively. Use "
+                    + "edit_text instead.";
+            }
+            return result;
+        } catch (Exception e) {
+            LOG.warn("popup_respond: replay of '" + taken.originalTool() + "' failed", e);
+            return "Error: replay failed: " + e.getMessage();
+        }
+    }
+
+    @Override
+    public @NotNull Object resultRenderer() {
+        return SimpleStatusRenderer.INSTANCE;
+    }
+
+    @Nullable
+    private static PopupChoice resolveChoice(@NotNull List<PopupChoice> choices,
+                                             @NotNull JsonObject args) {
+        if (args.has(PARAM_VALUE_ID)) {
+            String wantId = args.get(PARAM_VALUE_ID).getAsString();
+            for (PopupChoice c : choices) {
+                if (c.valueId().equals(wantId)) return c;
+            }
+        }
+        if (args.has(PARAM_INDEX)) {
+            int idx = args.get(PARAM_INDEX).getAsInt();
+            if (idx >= 0 && idx < choices.size()) return choices.get(idx);
+        }
+        return null;
+    }
+
+    /**
+     * Builds a fingerprint of the <em>current</em> document state for the file the snapshot
+     * targeted, for comparison against the snapshot's stored fingerprint. Returns a fingerprint
+     * with {@code documentModStamp = -1} when the file can't be resolved (which still passes
+     * {@link ContextFingerprint#matches} because the original may also have had no stamp).
+     */
+    @NotNull
+    private ContextFingerprint currentFingerprintFor(@NotNull ContextFingerprint snapshotFp) {
+        long stamp = -1;
+        if (snapshotFp.filePath() != null) {
+            VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(snapshotFp.filePath());
+            if (vf != null) {
+                var doc = FileDocumentManager.getInstance().getDocument(vf);
+                if (doc != null) stamp = doc.getModificationStamp();
+            }
+        }
+        return new ContextFingerprint(
+            project.getName(), snapshotFp.filePath(), stamp, snapshotFp.actionIdentity());
+    }
+
+    private static String invokeReplay(@NotNull Replayable replayable,
+                                       @NotNull JsonObject args,
+                                       @NotNull PopupHandler.SelectByValue handler) throws Exception {
+        // Replay needs to run on the EDT (same as the original execute()) because most quality
+        // tools dispatch their core work via EdtUtil.invokeLater. Calling replay directly from
+        // an MCP worker thread would just chain another invokeLater — that's fine, but we
+        // future-proof by also providing the worker-thread fallback in case a Replayable is
+        // synchronous.
+        CompletableFuture<String> f = new CompletableFuture<>();
+        EdtUtil.invokeLater(() -> {
+            try {
+                f.complete(replayable.replay(args, handler));
+            } catch (Exception e) {
+                f.completeExceptionally(e);
+            }
+        });
+        return f.get(60, TimeUnit.SECONDS);
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupSnapshot.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupSnapshot.java
@@ -1,0 +1,60 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Immutable snapshot of a {@link com.intellij.openapi.ui.popup.JBPopup} chooser captured by
+ * {@link PopupInterceptor} in {@link PopupHandler.Snapshot} mode.
+ *
+ * <p><b>Why this exists — DO NOT REMOVE without reading
+ * {@code .agent-work/popup-interaction-design-2026-04-30.md}.</b>
+ *
+ * <p>{@code popupKind} values:
+ * <ul>
+ *   <li>{@code "list-step"} — extracted via {@code ListPopupStep} (preferred, structurally accurate)</li>
+ *   <li>{@code "list-fallback"} — extracted via raw {@code JBList}+{@code ListCellRenderer} walk
+ *       (best-effort; structural metadata like {@code selectable}/{@code hasSubstep} unreliable)</li>
+ *   <li>{@code "tree"} — flattened tree, depth ≤ 3</li>
+ *   <li>{@code "unsupported"} — popup content not understood; choices empty</li>
+ * </ul>
+ *
+ * <p>The popup is <em>cancelled</em> after the snapshot is taken (see {@link PopupInterceptor}
+ * for why we cannot keep the popup open across tool calls). Replay re-invokes the original
+ * action with {@link PopupHandler.SelectByValue}.
+ */
+public record PopupSnapshot(
+    @NotNull String popupTitle,
+    @NotNull List<PopupChoice> choices,
+    @NotNull String popupKind
+) {
+
+    public static final String KIND_LIST_STEP = "list-step";
+    public static final String KIND_LIST_FALLBACK = "list-fallback";
+    public static final String KIND_TREE = "tree";
+    public static final String KIND_UNSUPPORTED = "unsupported";
+
+    public PopupSnapshot {
+        choices = List.copyOf(choices);
+    }
+
+    /** True when the snapshot has no actionable selectable rows and replay would be pointless. */
+    public boolean isEmpty() {
+        return choices.isEmpty() || KIND_UNSUPPORTED.equals(popupKind);
+    }
+
+    /**
+     * Stable digest of the snapshot's distinguishing content. Used by
+     * {@link PendingPopupService} to detect popup-replay loops where the same chooser opens
+     * again after replay (indicating the action will never converge non-interactively).
+     */
+    @NotNull
+    public String contentDigest() {
+        StringBuilder sb = new StringBuilder(popupTitle).append('\u0001').append(popupKind);
+        for (PopupChoice c : choices) {
+            sb.append('\u0001').append(c.valueId());
+        }
+        return Integer.toHexString(sb.toString().hashCode());
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/QualityToolFactory.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/QualityToolFactory.java
@@ -27,13 +27,21 @@ public final class QualityToolFactory {
         tools.add(new GetHighlightsTool(project));
         tools.add(new GetAvailableActionsTool(project));
         tools.add(new GetActionOptionsTool(project));
-        tools.add(new ApplyQuickfixTool(project));
-        tools.add(new ApplyActionTool(project));
+        ApplyQuickfixTool applyQuickfix = new ApplyQuickfixTool(project);
+        ApplyActionTool applyAction = new ApplyActionTool(project);
+        tools.add(applyQuickfix);
+        tools.add(applyAction);
         tools.add(new SuppressInspectionTool(project));
         tools.add(new OptimizeImportsTool(project));
         tools.add(new FormatCodeTool(project));
         tools.add(new AddToDictionaryTool(project));
         tools.add(new GetCompilationErrorsTool(project));
+        // popup_respond — replays apply_action / apply_quickfix when their popup was suspended.
+        // See .agent-work/popup-interaction-design-2026-04-30.md and PopupRespondTool javadoc.
+        tools.add(new PopupRespondTool(project, java.util.Map.of(
+            applyAction.id(), applyAction,
+            applyQuickfix.id(), applyQuickfix
+        )));
 
         if (PlatformApiCompat.isPluginInstalled("org.jetbrains.qodana")) {
             QodanaAnalyzer qodana = new QodanaAnalyzer(project);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/Replayable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/Replayable.java
@@ -1,0 +1,37 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import com.google.gson.JsonObject;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Implemented by quality tools whose actions can open popups and that support being
+ * <em>re-invoked with a {@link PopupHandler.SelectByValue}</em> by
+ * {@link PopupRespondTool}.
+ *
+ * <p><b>Why this exists — DO NOT REMOVE without reading
+ * {@code .agent-work/popup-interaction-design-2026-04-30.md}.</b>
+ *
+ * <p>The original tool call captures a {@link PopupSnapshot} and registers a
+ * {@link PendingPopupService.Pending} entry. When the agent calls {@code popup_respond},
+ * the dispatcher looks up the originating tool by id ({@code apply_action}/{@code apply_quickfix})
+ * and calls {@link #replay(JsonObject, PopupHandler.SelectByValue)} with the original arguments
+ * and the user's selection. The implementing tool re-runs its full action pipeline but with the
+ * select-by-value handler instead of the snapshot handler.
+ *
+ * <p>The design rationale for replaying via the same in-process tool method (rather than
+ * re-dispatching through {@code PsiBridgeService.callTool}) is to avoid double-counting in
+ * permission prompts, lock acquisitions, and tool-call telemetry.
+ */
+public interface Replayable {
+
+    /**
+     * Re-invokes the tool's action pipeline with the given {@link PopupHandler.SelectByValue}.
+     *
+     * @param originalArgs JSON arguments of the original tool call (preserved verbatim)
+     * @param handler      selection captured from the agent's {@code popup_respond} call
+     * @return human-readable result string, identical in format to the tool's normal {@code execute}.
+     */
+    @NotNull
+    String replay(@NotNull JsonObject originalArgs,
+                  @NotNull PopupHandler.SelectByValue handler) throws Exception;
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpCallContext.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpCallContext.java
@@ -1,0 +1,62 @@
+package com.github.catatafishen.agentbridge.services;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Thread-local that lets quality tools (especially the popup-handling ones) discover the
+ * MCP session key of the caller without plumbing it through every tool's signature.
+ *
+ * <p><b>Why this exists — DO NOT REMOVE without reading
+ * {@code .agent-work/popup-interaction-design-2026-04-30.md}.</b>
+ *
+ * <p>The popup gate logic ({@link com.github.catatafishen.agentbridge.psi.tools.quality.PopupGateLogic})
+ * needs to know which MCP session a tool call belongs to so it can correctly count
+ * {@code MAX_UNRELATED_CALLS} per owning session. The MCP protocol handler sets this before
+ * dispatching {@code bridge.callTool} and clears it in a {@code finally}. Tools that
+ * <em>register</em> a pending popup (via
+ * {@link com.github.catatafishen.agentbridge.psi.tools.quality.PendingPopupService}) read the
+ * session key from here.
+ *
+ * <p>Outside MCP (e.g. unit tests calling tools directly), the key is {@code null} and the
+ * pending-popup tracking falls back to a synthetic {@code "test:thread-N"} key so registration
+ * still works but the per-session counter never matches another caller. Time-based expiry still
+ * applies.
+ */
+public final class McpCallContext {
+
+    private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+
+    private McpCallContext() {
+    }
+
+    /**
+     * Sets the session key for the current thread. Call from {@code McpProtocolHandler.handleToolsCall}
+     * before {@code bridge.callTool} and pair with {@link #clear()} in a {@code finally}.
+     */
+    public static void setCurrent(@NotNull String sessionKey) {
+        CURRENT.set(sessionKey);
+    }
+
+    public static void clear() {
+        CURRENT.remove();
+    }
+
+    /**
+     * Returns the session key for the current thread or a synthetic fallback derived from the
+     * thread name when no MCP context is bound (e.g. unit tests).
+     */
+    @NotNull
+    public static String currentOrFallback() {
+        String s = CURRENT.get();
+        return s != null ? s : "test:" + Thread.currentThread().getName();
+    }
+
+    /**
+     * Returns the session key for the current thread, or {@code null} when none is bound.
+     */
+    @Nullable
+    public static String current() {
+        return CURRENT.get();
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpProtocolHandler.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpProtocolHandler.java
@@ -484,16 +484,42 @@ public final class McpProtocolHandler {
             LOG.info("[MCP] tools/call: " + toolName);
         }
 
+        // Popup gate: if a previous apply_action / apply_quickfix call suspended on a
+        // popup chooser, every subsequent tool call must either be popup_respond, the
+        // auto-cancel threshold call, or be blocked. See PopupGateLogic javadoc and
+        // .agent-work/popup-interaction-design-2026-04-30.md for the full design.
+        String sessionKey = project.getLocationHash() + ":" + System.identityHashCode(this);
+        com.github.catatafishen.agentbridge.psi.tools.quality.PendingPopupService pps =
+            com.github.catatafishen.agentbridge.psi.tools.quality.PendingPopupService.getInstance();
+        com.github.catatafishen.agentbridge.psi.tools.quality.PopupGateLogic.Decision decision =
+            com.github.catatafishen.agentbridge.psi.tools.quality.PopupGateLogic.evaluate(
+                pps.peek(), toolName, sessionKey, java.time.Instant.now());
+        String resultPrefix = "";
+        if (decision instanceof com.github.catatafishen.agentbridge.psi.tools.quality.PopupGateLogic.Block b) {
+            return buildToolResult(msg, b.message(), true);
+        }
+        if (decision instanceof com.github.catatafishen.agentbridge.psi.tools.quality.PopupGateLogic.AllowWithCancelNote a) {
+            pps.cancelAndClear(a.cancelled().id());
+            resultPrefix = a.note() + "\n\n";
+        } else if (!com.github.catatafishen.agentbridge.psi.tools.quality.PopupGateLogic.POPUP_RESPOND_TOOL.equals(toolName)
+            && pps.peek() != null) {
+            // Same-session call within budget — count toward auto-cancel.
+            pps.recordUnrelatedCall(sessionKey);
+        }
+
         // Delegate to PsiBridgeService
+        com.github.catatafishen.agentbridge.services.McpCallContext.setCurrent(sessionKey);
         try {
             PsiBridgeService bridge = PsiBridgeService.getInstance(project);
             String resultText = bridge.callTool(toolName, arguments, toolUseId);
             resultText = truncateIfNeeded(resultText);
             boolean isError = resultText != null && resultText.startsWith("Error");
-            return buildToolResult(msg, resultText, isError);
+            return buildToolResult(msg, resultPrefix + resultText, isError);
         } catch (Exception e) {
             LOG.warn("[MCP] tool error: " + toolName, e);
             return buildToolResult(msg, "Error: " + e.getMessage(), true);
+        } finally {
+            com.github.catatafishen.agentbridge.services.McpCallContext.clear();
         }
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/ContextFingerprintTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/ContextFingerprintTest.java
@@ -1,0 +1,81 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ContextFingerprintTest {
+
+    private static ContextFingerprint fp(String project, String file, long stamp, String action) {
+        return new ContextFingerprint(project, file, stamp, action);
+    }
+
+    @Test
+    void matchesIdenticalFingerprint() {
+        ContextFingerprint a = fp("p", "/a/b.java", 100, "act|insp");
+        ContextFingerprint b = fp("p", "/a/b.java", 100, "act|insp");
+        assertTrue(a.matches(b));
+    }
+
+    @Test
+    void rejectsDifferentProject() {
+        ContextFingerprint a = fp("p1", "/x", 1, "act");
+        ContextFingerprint b = fp("p2", "/x", 1, "act");
+        assertFalse(a.matches(b));
+    }
+
+    @Test
+    void rejectsDifferentAction() {
+        ContextFingerprint a = fp("p", "/x", 1, "act1");
+        ContextFingerprint b = fp("p", "/x", 1, "act2");
+        assertFalse(a.matches(b));
+    }
+
+    @Test
+    void rejectsDifferentFilePathWhenBothPresent() {
+        ContextFingerprint a = fp("p", "/x", 1, "act");
+        ContextFingerprint b = fp("p", "/y", 1, "act");
+        assertFalse(a.matches(b));
+    }
+
+    @Test
+    void toleratesNullFilePathOnEitherSide() {
+        ContextFingerprint a = fp("p", null, 1, "act");
+        ContextFingerprint b = fp("p", "/x", 1, "act");
+        assertTrue(a.matches(b));
+        assertTrue(b.matches(a));
+    }
+
+    @Test
+    void rejectsDifferentDocumentModStamp() {
+        ContextFingerprint a = fp("p", "/x", 100, "act");
+        ContextFingerprint b = fp("p", "/x", 101, "act");
+        assertFalse(a.matches(b));
+    }
+
+    @Test
+    void toleratesNegativeModStampOnEitherSide() {
+        ContextFingerprint a = fp("p", "/x", -1, "act");
+        ContextFingerprint b = fp("p", "/x", 999, "act");
+        assertTrue(a.matches(b));
+        assertTrue(b.matches(a));
+    }
+
+    @Test
+    void describeMismatchReportsSpecificDifference() {
+        ContextFingerprint a = fp("p", "/x", 100, "act");
+        ContextFingerprint b = fp("p", "/x", 200, "act");
+        String desc = a.describeMismatch(b);
+        assertTrue(desc.contains("document modified"), () -> "got: " + desc);
+        assertTrue(desc.contains("100"));
+        assertTrue(desc.contains("200"));
+    }
+
+    @Test
+    void describeMismatchOnIdenticalReturnsGeneric() {
+        ContextFingerprint a = fp("p", "/x", 1, "act");
+        assertEquals("fingerprint mismatch", a.describeMismatch(a));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupChoiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupChoiceTest.java
@@ -1,0 +1,25 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class PopupChoiceTest {
+
+    @Test
+    void buildValueIdIsDeterministic() {
+        assertEquals("Cell|0", PopupChoice.buildValueId("Cell", 0));
+        assertEquals("com.x.Y|3", PopupChoice.buildValueId("com.x.Y", 3));
+    }
+
+    @Test
+    void buildValueIdIsUniqueAcrossDifferentInputs() {
+        String a = PopupChoice.buildValueId("Cell", 0);
+        String b = PopupChoice.buildValueId("Cell", 1);
+        String c = PopupChoice.buildValueId("Other", 0);
+        assertNotEquals(a, b);
+        assertNotEquals(a, c);
+        assertNotEquals(b, c);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupGateLogicTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupGateLogicTest.java
@@ -1,0 +1,137 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PopupGateLogicTest {
+
+    private static final String OWNING = "session-A";
+    private static final String FOREIGN = "session-B";
+    private static final Instant T0 = Instant.parse("2026-04-30T12:00:00Z");
+
+    private static PendingPopupService.Pending pending(int unrelatedCalls) {
+        return pending(unrelatedCalls, T0);
+    }
+
+    private static PendingPopupService.Pending pending(int unrelatedCalls, Instant createdAt) {
+        PopupChoice c = new PopupChoice(PopupChoice.buildValueId("foo", 0), 0,
+            "foo", null, true, false);
+        PopupSnapshot snap = new PopupSnapshot("Choose Foo", List.of(c),
+            PopupSnapshot.KIND_LIST_STEP);
+        ContextFingerprint fp = new ContextFingerprint("proj", "/x", 1L, "act|insp");
+        return new PendingPopupService.Pending(
+            "popup-1", "apply_action", new JsonObject(), null, fp, snap,
+            createdAt, OWNING, unrelatedCalls, null
+        );
+    }
+
+    @Test
+    void popupRespondAlwaysAllowed() {
+        PendingPopupService.Pending p = pending(0);
+        PopupGateLogic.Decision d = PopupGateLogic.evaluate(
+            p, PopupGateLogic.POPUP_RESPOND_TOOL, FOREIGN, T0);
+        assertInstanceOf(PopupGateLogic.Allow.class, d);
+    }
+
+    @Test
+    void noPendingAllowsAnyTool() {
+        PopupGateLogic.Decision d = PopupGateLogic.evaluate(
+            null, "search_text", OWNING, T0);
+        assertInstanceOf(PopupGateLogic.Allow.class, d);
+    }
+
+    @Test
+    void blocksWhenPendingFromOwningSession() {
+        PendingPopupService.Pending p = pending(0);
+        PopupGateLogic.Decision d = PopupGateLogic.evaluate(p, "search_text", OWNING, T0);
+        PopupGateLogic.Block block = assertInstanceOf(PopupGateLogic.Block.class, d);
+        assertTrue(block.message().startsWith("Error:"));
+        assertTrue(block.message().contains("popup-1"));
+        assertTrue(block.message().contains("Auto-cancels"));
+    }
+
+    @Test
+    void blocksCrossSessionWithDifferentMessage() {
+        PendingPopupService.Pending p = pending(0);
+        PopupGateLogic.Decision d = PopupGateLogic.evaluate(p, "search_text", FOREIGN, T0);
+        PopupGateLogic.Block block = assertInstanceOf(PopupGateLogic.Block.class, d);
+        assertTrue(block.message().contains("different MCP session"));
+    }
+
+    @Test
+    void allowsWithCancelNoteOnFinalUnrelatedCall() {
+        // unrelated calls so far = MAX-1 (4); the next (5th) call exhausts the budget
+        PendingPopupService.Pending p = pending(PendingPopupService.MAX_UNRELATED_CALLS - 1);
+        PopupGateLogic.Decision d = PopupGateLogic.evaluate(p, "search_text", OWNING, T0);
+        PopupGateLogic.AllowWithCancelNote awcn =
+            assertInstanceOf(PopupGateLogic.AllowWithCancelNote.class, d);
+        assertSame(p, awcn.cancelled());
+        assertTrue(awcn.note().contains("auto-cancelled"));
+        assertTrue(awcn.note().contains("popup-1"));
+    }
+
+    @Test
+    void crossSessionDoesNotTriggerAutoCancel() {
+        PendingPopupService.Pending p = pending(PendingPopupService.MAX_UNRELATED_CALLS - 1);
+        PopupGateLogic.Decision d = PopupGateLogic.evaluate(p, "search_text", FOREIGN, T0);
+        // Foreign sessions get blocked even at the final-call boundary — they don't progress.
+        assertInstanceOf(PopupGateLogic.Block.class, d);
+    }
+
+    @Test
+    void allowsWithCancelNoteOnTimeExpiry() {
+        PendingPopupService.Pending p = pending(0, T0);
+        Instant later = T0.plus(PendingPopupService.MAX_AGE).plus(Duration.ofSeconds(1));
+        PopupGateLogic.Decision d = PopupGateLogic.evaluate(p, "search_text", FOREIGN, later);
+        PopupGateLogic.AllowWithCancelNote awcn =
+            assertInstanceOf(PopupGateLogic.AllowWithCancelNote.class, d);
+        assertTrue(awcn.note().contains("older than"));
+    }
+
+    @Test
+    void blockMessageRemainingCounterDecrements() {
+        PendingPopupService.Pending p0 = pending(0);
+        PendingPopupService.Pending p1 = pending(1);
+        String m0 = ((PopupGateLogic.Block) PopupGateLogic.evaluate(p0, "x", OWNING, T0)).message();
+        String m1 = ((PopupGateLogic.Block) PopupGateLogic.evaluate(p1, "x", OWNING, T0)).message();
+        // First block reports MAX-1 = 4 remaining; second reports MAX-2 = 3
+        assertTrue(m0.contains("4 more"), () -> m0);
+        assertTrue(m1.contains("3 more"), () -> m1);
+    }
+
+    @Test
+    void timeoutPathReportsAge() {
+        PendingPopupService.Pending p = pending(0, T0);
+        Instant later = T0.plus(PendingPopupService.MAX_AGE).plus(Duration.ofSeconds(42));
+        PopupGateLogic.AllowWithCancelNote awcn = (PopupGateLogic.AllowWithCancelNote)
+            PopupGateLogic.evaluate(p, "search_text", OWNING, later);
+        // age should mention seconds count
+        long expected = PendingPopupService.MAX_AGE.toSeconds() + 42;
+        assertTrue(awcn.note().contains(expected + "s"), () -> awcn.note());
+    }
+
+    @Test
+    void allowedAtBoundaryMinusOne() {
+        // unrelatedCalls = MAX-2 → next call would be MAX-1 → should still be Block (not last)
+        PendingPopupService.Pending p = pending(PendingPopupService.MAX_UNRELATED_CALLS - 2);
+        PopupGateLogic.Decision d = PopupGateLogic.evaluate(p, "search_text", OWNING, T0);
+        assertInstanceOf(PopupGateLogic.Block.class, d);
+    }
+
+    @Test
+    void evaluateIsPureNoMutation() {
+        PendingPopupService.Pending p = pending(0);
+        int before = p.unrelatedCallsSinceCreated();
+        PopupGateLogic.evaluate(p, "search_text", OWNING, T0);
+        assertEquals(before, p.unrelatedCallsSinceCreated());
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupInterceptorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupInterceptorTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import javax.swing.JLabel;
-import javax.swing.JPanel;
+import javax.swing.*;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,21 +38,21 @@ class PopupInterceptorTest {
         @Test
         @DisplayName("describe with empty titles → unidentified marker")
         void describeEmpty() {
-            var r = new PopupInterceptor.Result(true, List.of(), true);
+            var r = new PopupInterceptor.Result(true, List.of(), true, null, false);
             assertEquals("(unidentified popup)", r.describe());
         }
 
         @Test
         @DisplayName("describe with one title → quoted title")
         void describeOne() {
-            var r = new PopupInterceptor.Result(true, List.of("Choose Class"), true);
+            var r = new PopupInterceptor.Result(true, List.of("Choose Class"), true, null, false);
             assertEquals("'Choose Class'", r.describe());
         }
 
         @Test
         @DisplayName("describe with multiple titles → comma-joined quoted")
         void describeMany() {
-            var r = new PopupInterceptor.Result(true, List.of("A", "B", "C"), false);
+            var r = new PopupInterceptor.Result(true, List.of("A", "B", "C"), false, null, false);
             assertEquals("'A', 'B', 'C'", r.describe());
         }
 
@@ -61,7 +60,7 @@ class PopupInterceptorTest {
         @DisplayName("popupTitles is exposed as immutable List")
         void titlesAccessor() {
             List<String> titles = List.of("X");
-            var r = new PopupInterceptor.Result(true, titles, true);
+            var r = new PopupInterceptor.Result(true, titles, true, null, false);
             assertEquals(titles, r.popupTitles());
             assertTrue(r.popupWasOpened());
             assertTrue(r.cancelled());
@@ -130,7 +129,7 @@ class PopupInterceptorTest {
         @Test
         @DisplayName("starts with 'Error:' so MCP detects isError=true")
         void startsWithErrorPrefix() {
-            var r = new PopupInterceptor.Result(true, List.of("X"), true);
+            var r = new PopupInterceptor.Result(true, List.of("X"), true, null, false);
             String msg = PopupInterceptor.formatPopupBlockedError("Import class 'Cell'", r);
             assertTrue(msg.startsWith("Error: "), "expected 'Error: ' prefix, got: " + msg);
         }
@@ -138,7 +137,7 @@ class PopupInterceptorTest {
         @Test
         @DisplayName("includes the action name and popup description")
         void includesActionAndDescription() {
-            var r = new PopupInterceptor.Result(true, List.of("Choose Class"), true);
+            var r = new PopupInterceptor.Result(true, List.of("Choose Class"), true, null, false);
             String msg = PopupInterceptor.formatPopupBlockedError("Import class 'Cell'", r);
             assertTrue(msg.contains("Import class 'Cell'"), msg);
             assertTrue(msg.contains("'Choose Class'"), msg);
@@ -147,7 +146,7 @@ class PopupInterceptorTest {
         @Test
         @DisplayName("when cancelled → confirms the popup was cancelled")
         void cancelledMessage() {
-            var r = new PopupInterceptor.Result(true, List.of("X"), true);
+            var r = new PopupInterceptor.Result(true, List.of("X"), true, null, false);
             String msg = PopupInterceptor.formatPopupBlockedError("act", r);
             assertTrue(msg.contains("cancelled"), msg);
             assertFalse(msg.contains("may still be visible"), msg);
@@ -156,7 +155,7 @@ class PopupInterceptorTest {
         @Test
         @DisplayName("when not cancelled → warns that the popup may still be visible")
         void notCancelledMessage() {
-            var r = new PopupInterceptor.Result(true, List.of("X"), false);
+            var r = new PopupInterceptor.Result(true, List.of("X"), false, null, false);
             String msg = PopupInterceptor.formatPopupBlockedError("act", r);
             assertTrue(msg.contains("may still be visible"), msg);
         }
@@ -164,7 +163,7 @@ class PopupInterceptorTest {
         @Test
         @DisplayName("guides the agent to edit_text instead")
         void guidesToEditText() {
-            var r = new PopupInterceptor.Result(true, List.of("X"), true);
+            var r = new PopupInterceptor.Result(true, List.of("X"), true, null, false);
             String msg = PopupInterceptor.formatPopupBlockedError("act", r);
             assertTrue(msg.contains("edit_text"), msg);
         }
@@ -172,7 +171,7 @@ class PopupInterceptorTest {
         @Test
         @DisplayName("clarifies that popup choosers are NOT 'option' parameter selections")
         void clarifiesOptionDistinction() {
-            var r = new PopupInterceptor.Result(true, List.of("X"), true);
+            var r = new PopupInterceptor.Result(true, List.of("X"), true, null, false);
             String msg = PopupInterceptor.formatPopupBlockedError("act", r);
             // We do NOT want the message to (mis)direct the agent to use the 'option' param,
             // since 'option' currently only handles dialog-radio selection, not popup choosers.
@@ -190,7 +189,7 @@ class PopupInterceptorTest {
         @Test
         @DisplayName("no popup → popupWasOpened=false, no titles, not cancelled")
         void noPopup() {
-            var r = new PopupInterceptor.Result(false, List.of(), false);
+            var r = new PopupInterceptor.Result(false, List.of(), false, null, false);
             assertFalse(r.popupWasOpened());
             assertNotNull(r.popupTitles());
             assertTrue(r.popupTitles().isEmpty());

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupSnapshotTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupSnapshotTest.java
@@ -1,0 +1,75 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PopupSnapshotTest {
+
+    private static PopupChoice choice(String text, int idx) {
+        return new PopupChoice(PopupChoice.buildValueId(text, idx), idx, text, null, true, false);
+    }
+
+    @Test
+    void emptyChoicesIsEmpty() {
+        PopupSnapshot s = new PopupSnapshot("title", List.of(), PopupSnapshot.KIND_LIST_STEP);
+        assertTrue(s.isEmpty());
+    }
+
+    @Test
+    void unsupportedKindIsEmptyEvenWithChoices() {
+        PopupSnapshot s = new PopupSnapshot("title", List.of(choice("a", 0)),
+            PopupSnapshot.KIND_UNSUPPORTED);
+        assertTrue(s.isEmpty());
+    }
+
+    @Test
+    void populatedListStepIsNotEmpty() {
+        PopupSnapshot s = new PopupSnapshot("title", List.of(choice("a", 0)),
+            PopupSnapshot.KIND_LIST_STEP);
+        assertFalse(s.isEmpty());
+    }
+
+    @Test
+    void contentDigestIsStableAcrossEquivalentSnapshots() {
+        PopupSnapshot a = new PopupSnapshot("Choose Class",
+            List.of(choice("com.x.Cell", 0), choice("com.y.Cell", 1)),
+            PopupSnapshot.KIND_LIST_STEP);
+        PopupSnapshot b = new PopupSnapshot("Choose Class",
+            List.of(choice("com.x.Cell", 0), choice("com.y.Cell", 1)),
+            PopupSnapshot.KIND_LIST_STEP);
+        assertEquals(a.contentDigest(), b.contentDigest());
+    }
+
+    @Test
+    void contentDigestChangesWhenChoicesDiffer() {
+        PopupSnapshot a = new PopupSnapshot("title",
+            List.of(choice("a", 0), choice("b", 1)), PopupSnapshot.KIND_LIST_STEP);
+        PopupSnapshot b = new PopupSnapshot("title",
+            List.of(choice("a", 0)), PopupSnapshot.KIND_LIST_STEP);
+        assertNotEquals(a.contentDigest(), b.contentDigest());
+    }
+
+    @Test
+    void contentDigestChangesWhenTitleDiffers() {
+        PopupSnapshot a = new PopupSnapshot("Title A",
+            List.of(choice("a", 0)), PopupSnapshot.KIND_LIST_STEP);
+        PopupSnapshot b = new PopupSnapshot("Title B",
+            List.of(choice("a", 0)), PopupSnapshot.KIND_LIST_STEP);
+        assertNotEquals(a.contentDigest(), b.contentDigest());
+    }
+
+    @Test
+    void choicesListIsCopiedDefensively() {
+        java.util.ArrayList<PopupChoice> mutable = new java.util.ArrayList<>();
+        mutable.add(choice("a", 0));
+        PopupSnapshot s = new PopupSnapshot("t", mutable, PopupSnapshot.KIND_LIST_STEP);
+        mutable.add(choice("b", 1));
+        assertEquals(1, s.choices().size());
+    }
+}


### PR DESCRIPTION
Stacked on #363. After #363 lands, this PR adds a path for the agent to actually
**respond** to a JBPopup chooser instead of just being told the action failed.

## What changes for the agent

**Before this PR:** \`apply_action(action_name=\"Import class 'Cell'\")\` (or any
quick-fix that opens a chooser) returns \`Error: ...\`, and the agent has to fall
back to \`edit_text\`.

**After this PR:** the same call returns success with a \`popup_id\` and the popup's
choice list:

\`\`\`
The action 'Import class 'Cell'' opened a popup chooser: 'Choose Class'.
The popup is suspended awaiting your selection (popup_id=abc-123).

Choices:
  0: com.intellij.ui.dsl.builder.Cell
  1: com.intellij.openapi.ui.Cell
  2: com.intellij.psi.PsiElement.Cell

To complete: popup_respond(popup_id=\"abc-123\", action=\"select\", value_id=\"…\")
To cancel:   popup_respond(popup_id=\"abc-123\", action=\"cancel\")
\`\`\`

The agent calls \`popup_respond\`, which re-invokes the original action with a
\`PopupHandler.SelectByValue\` that drives the popup to the chosen value.

While a popup is pending, **all other tool calls are blocked** with a clear error
message (the EDT must stay free, and other tools could mutate state). After **5
unrelated calls or 5 minutes**, the pending popup is auto-cancelled and the
guarding call succeeds with a prefix note.

## Architecture (transactional snapshot + replay)

\`JBPopup\` runs a nested AWT loop on the EDT, so we cannot leave a popup open
between tool calls. Instead the action runs **twice**: once to snapshot the
choices (popup is then cancelled), once on \`popup_respond\` to drive the chosen
value via \`ListPopupStep.onChosen\`.

| Component | Role |
|---|---|
| \`PopupChoice\`, \`PopupSnapshot\` (records) | Popup row / full snapshot, with \`contentDigest()\` for loop guard |
| \`PopupContentExtractor\` | \`JBPopup\` → \`PopupSnapshot\` via \`ListPopupStep\` |
| \`PopupInterceptor\` | Sealed \`PopupHandler\` (\`Cancel\` / \`Snapshot\` / \`SelectByValue\`) + AWT listener |
| \`ContextFingerprint\` | Project + file + mod-stamp + action identity for replay validation |
| \`PendingPopupService\` (\`@Service(APP)\`, single-slot) | Holds at most one Pending, per-session counter, time expiry |
| \`PopupGateLogic\` | **Pure** \`evaluate(...)\` decision function, fully unit-tested |
| \`Replayable\` | Implemented by \`ApplyActionTool\` / \`ApplyQuickfixTool\` |
| \`PopupRespondTool\` | Validates fingerprint, refuses \`hasSubstep\`, detects loops, dispatches replay |
| \`McpCallContext\` (thread-local) | Carries owning session key from \`McpProtocolHandler\` to tool execution |

## Mod-stamp rollback guard

Some quick-fixes mutate the document **before** opening their chooser. Without a
guard we'd leak that partial edit on cancel. Two strategies:

- **\`ApplyActionTool\`**: capture mod-stamp before invocation; on intercept, if
  it changed, attempt \`UndoManager.undoLastAction()\` and re-check. If still
  changed → refuse to suspend, fall back to PR #363 error.
- **\`ApplyQuickfixTool\`**: refuses to suspend on **any** pre-popup mutation
  (no undo attempt — quick-fix popup-then-mutate is unusual; the simpler path
  is safer). Asymmetry is documented in code.

## Tests

28 new tests, all green, pure JUnit 5 (no IntelliJ Application required):

- \`PopupChoiceTest\` (2): \`valueId\` determinism + uniqueness
- \`PopupSnapshotTest\` (6): \`isEmpty\`, \`contentDigest\` stability/divergence, defensive copy
- \`ContextFingerprintTest\` (9): \`matches\` / \`describeMismatch\` across all fields
- \`PopupGateLogicTest\` (11): all 4 decision branches, time expiry, owning vs foreign session, counter math, purity
- \`PopupInterceptorTest\` (16): updated for new \`Result\` fields

## Docs

- \`.agent-work/popup-interaction-design-2026-04-30.md\` — full design + DO NOT REMOVE
  anchors for load-bearing pieces (mod-stamp guard, cross-session branch, undo-then-recheck,
  asymmetric quickfix refusal, contentDigest loop guard)
- \`.agent-work/freeze-investigation-2026-04-30.md\` — resolution note pointing here

## v1 limitations (deferred)

- **Chained popups**: \`PopupRespondTool\` refuses to pick a choice with
  \`hasSubstep=true\`. Surfaces a clear error.
- **Replay-opens-popup**: if the replay opens a *new* popup we do snapshot + register a
  new pending. If it opens the **same** popup (\`contentDigest\` match) we discard +
  return error pointing at \`edit_text\`.
- **Non-list popups** (WizardPopup, etc.): \`popupKind=\"unsupported\"\` — choices
  empty, agent gets PR #363's fallback error.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>