### PR TITLE
fix: wrap tool descriptions in Settings → MCP → Tools

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolsConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolsConfigurable.kt
@@ -26,14 +26,10 @@ import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Component
 import java.awt.Dimension
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
 import java.util.concurrent.ExecutionException
-import javax.swing.Box
-import javax.swing.BoxLayout
-import javax.swing.JButton
-import javax.swing.JComponent
-import javax.swing.JEditorPane
-import javax.swing.ScrollPaneConstants
-import javax.swing.SwingWorker
+import javax.swing.*
 import javax.swing.event.HyperlinkEvent
 
 class ToolsConfigurable(private val project: Project) :
@@ -180,12 +176,35 @@ class ToolsConfigurable(private val project: Project) :
         toolsPanel.add(buildColorPickerSection(settings))
         toolsPanel.add(Box.createVerticalGlue())
 
+        // Revalidate when the panel's width changes. BoxLayout commits to each child's
+        // preferredSize.height before layout assigns them a real width. JBLabel with
+        // isAllowAutoWrapping=true can only recalculate its wrapped height once getWidth()>0,
+        // so we need a second layout pass after the first width arrives.
+        toolsPanel.addComponentListener(object : ComponentAdapter() {
+            private var lastWidth = -1
+            override fun componentResized(e: ComponentEvent) {
+                val w = toolsPanel.width
+                if (w > 0 && w != lastWidth) {
+                    lastWidth = w
+                    SwingUtilities.invokeLater {
+                        toolsPanel.revalidate()
+                        toolsPanel.repaint()
+                    }
+                }
+            }
+        })
+
         val scrollContent = JBPanel<JBPanel<*>>(BorderLayout()).apply {
             add(toolsPanel, BorderLayout.NORTH)
         }
         val scrollPane = JBScrollPane(scrollContent).apply {
             border = JBUI.Borders.empty()
             horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+            // Cap preferred width so the Settings dialog does not grow to fit the
+            // full single-line text width of tool descriptions. AlignX.FILL in
+            // createPanel() will expand the pane to the actual dialog width anyway;
+            // this only controls what the dialog uses when computing its own preferred size.
+            preferredSize = Dimension(JBUI.scale(580), JBUI.scale(480))
         }
         updateCounter()
         return scrollPane

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolsConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolsConfigurable.kt
@@ -28,6 +28,7 @@ import java.awt.Component
 import java.awt.Dimension
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
+import java.util.*
 import java.util.concurrent.ExecutionException
 import javax.swing.*
 import javax.swing.event.HyperlinkEvent
@@ -132,46 +133,7 @@ class ToolsConfigurable(private val project: Project) :
         }
         toolsPanel.add(topRow)
 
-        val tools = McpToolFilter.getConfigurableTools(project)
-        var currentCategory: ToolRegistry.Category? = null
-        for (tool in tools) {
-            if (tool.category() != currentCategory) {
-                currentCategory = tool.category()
-                toolsPanel.add(buildCategoryHeader(currentCategory))
-            }
-            val kindColor = kindColorFor(tool, settings)
-            val toolRow = JBPanel<JBPanel<*>>().apply {
-                layout = BoxLayout(this, BoxLayout.X_AXIS)
-                alignmentX = Component.LEFT_ALIGNMENT
-                maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
-            }
-            val dot = JBLabel("● ").apply {
-                foreground = kindColor
-                border = JBUI.Borders.empty(1, 16, 0, 0)
-            }
-            toolRow.add(dot)
-            val cb = JBCheckBox(tool.displayName(), settings.isToolEnabled(tool.id())).apply {
-                border = JBUI.Borders.emptyTop(1)
-                addItemListener { updateCounter() }
-            }
-            toolCheckboxes[tool.id()] = cb
-            categoryCheckboxes.getOrPut(tool.category()) { mutableListOf() }.add(cb)
-            toolRow.add(cb)
-            toolRow.add(Box.createHorizontalGlue())
-            toolsPanel.add(toolRow)
-
-            val desc = tool.description()
-            if (desc.isNotBlank()) {
-                val descLabel = JBLabel("<html>$desc</html>").apply {
-                    font = font.deriveFont((JBUI.Fonts.label().size - 1).toFloat())
-                    foreground = UIUtil.getContextHelpForeground()
-                    border = JBUI.Borders.empty(0, 36, 3, 0)
-                    alignmentX = Component.LEFT_ALIGNMENT
-                    isAllowAutoWrapping = true
-                }
-                toolsPanel.add(descLabel)
-            }
-        }
+        addToolRows(toolsPanel, settings)
 
         toolsPanel.add(buildColorPickerSection(settings))
         toolsPanel.add(Box.createVerticalGlue())
@@ -208,6 +170,68 @@ class ToolsConfigurable(private val project: Project) :
         }
         updateCounter()
         return scrollPane
+    }
+
+    private fun addToolRows(toolsPanel: JPanel, settings: McpServerSettings) {
+        var currentCategory: ToolRegistry.Category? = null
+        for (tool in sortedConfigurableTools()) {
+            val category = tool.category()
+            if (category != currentCategory) {
+                currentCategory = category
+                toolsPanel.add(buildCategoryHeader(category))
+            }
+            addToolRow(toolsPanel, tool, category, settings)
+        }
+    }
+
+    private fun sortedConfigurableTools(): List<ToolDefinition> =
+        McpToolFilter.getConfigurableTools(project)
+            .sortedWith(
+                compareBy<ToolDefinition> { it.category().displayName.lowercase(Locale.ROOT) }
+                    .thenBy { it.displayName().lowercase(Locale.ROOT) }
+                    .thenBy { it.id() }
+            )
+
+    private fun addToolRow(
+        toolsPanel: JPanel,
+        tool: ToolDefinition,
+        category: ToolRegistry.Category,
+        settings: McpServerSettings
+    ) {
+        val kindColor = kindColorFor(tool, settings)
+        val toolRow = JBPanel<JBPanel<*>>().apply {
+            layout = BoxLayout(this, BoxLayout.X_AXIS)
+            alignmentX = Component.LEFT_ALIGNMENT
+            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+        }
+        val dot = JBLabel("● ").apply {
+            foreground = kindColor
+            border = JBUI.Borders.empty(1, 16, 0, 0)
+        }
+        toolRow.add(dot)
+        val cb = JBCheckBox(tool.displayName(), settings.isToolEnabled(tool.id())).apply {
+            border = JBUI.Borders.emptyTop(1)
+            addItemListener { updateCounter() }
+        }
+        toolCheckboxes[tool.id()] = cb
+        categoryCheckboxes.getOrPut(category) { mutableListOf() }.add(cb)
+        toolRow.add(cb)
+        toolRow.add(Box.createHorizontalGlue())
+        toolsPanel.add(toolRow)
+        addToolDescription(toolsPanel, tool)
+    }
+
+    private fun addToolDescription(toolsPanel: JPanel, tool: ToolDefinition) {
+        val desc = tool.description()
+        if (desc.isBlank()) return
+        val descLabel = JBLabel("<html>$desc</html>").apply {
+            font = font.deriveFont((JBUI.Fonts.label().size - 1).toFloat())
+            foreground = UIUtil.getContextHelpForeground()
+            border = JBUI.Borders.empty(0, 36, 3, 0)
+            alignmentX = Component.LEFT_ALIGNMENT
+            isAllowAutoWrapping = true
+        }
+        toolsPanel.add(descLabel)
     }
 
     private fun countEnabled(): Int = toolCheckboxes.values.count { it.isSelected }
@@ -318,6 +342,7 @@ class ToolsConfigurable(private val project: Project) :
             ToolDefinition.Kind.SEARCH -> ToolKindColors.searchColor(settings)
             ToolDefinition.Kind.EDIT, ToolDefinition.Kind.WRITE,
             ToolDefinition.Kind.DELETE, ToolDefinition.Kind.MOVE -> ToolKindColors.editColor(settings)
+
             ToolDefinition.Kind.EXECUTE -> ToolKindColors.executeColor(settings)
             else -> ToolKindColors.readColor(settings)
         }


### PR DESCRIPTION
## Problem

In Settings → MCP → Tools, tool descriptions were overflowing horizontally instead of wrapping. The Settings dialog grew very wide to accommodate full single-line description text.

## Root cause

`JBLabel` with `isAllowAutoWrapping=true` can only calculate its wrapped height once `getWidth() > 0`. On first layout, `BoxLayout` queries each child's `preferredSize.height` before assigning real widths — so all labels report single-line height, and the dialog expands to fit the full text width.

## Fix

- Added a `ComponentAdapter` to `toolsPanel` that triggers `revalidate()` + `repaint()` whenever the panel width changes. On the second layout pass, labels have a real width and `isAllowAutoWrapping` wraps them correctly, growing the container to the correct multi-line height.
- Capped the `JBScrollPane` preferred size to 580×480 px so the dialog does not grow to fit single-line text. `AlignX.FILL` in the outer `panel {}` DSL call still expands the pane to the actual dialog width at runtime.