### PR TITLE
chore: exclude generated coverage reports from Sonar

### DIFF
--- a/sonar.properties
+++ b/sonar.properties
@@ -7,4 +7,6 @@ sonar.exclusions=\
   **/build/**,\
   **/out/**,\
   .gradle/**,\
-  gradle/wrapper/**
+  gradle/wrapper/**,\
+  **/js-tests/coverage/**,\
+  **/coverage/lcov-report/**


### PR DESCRIPTION
## Summary

Exclude generated Istanbul coverage HTML reports from SonarQube analysis.

The current Sonar baseline is dominated by generated files under `plugin-core/js-tests/coverage/lcov-report/**`, producing thousands of noisy Web findings like deprecated anchor `name` attributes and empty anchors. Those files are coverage output, not maintained source, so excluding them lets the remaining findings focus on real source issues.

## Notes

- The Sonar plugin appears to keep returning cached findings in this session, so I used the export/tool baseline to confirm the noise source and local highlights for the touched config file.
- After the generated coverage-report findings, the remaining visible issues are the larger Java/Kotlin source refactors and cleanup items that should be handled separately.