### PR TITLE
feat: add storage location modes

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemoryService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemoryService.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 @Service(Service.Level.PROJECT)
 public final class MemoryService implements Disposable {
@@ -174,13 +175,25 @@ public final class MemoryService implements Disposable {
         if (projectBasePath == null) {
             return;
         }
-        Path legacyMemoryDir = Path.of(projectBasePath, ".agent-work", "memory");
-        if (!Files.exists(legacyMemoryDir) || Files.exists(newMemoryDir)) {
+        if (Files.exists(newMemoryDir)) {
             return;
         }
-        Files.createDirectories(newMemoryDir.getParent());
-        Files.move(legacyMemoryDir, newMemoryDir);
-        LOG.info("Migrated memory directory from " + legacyMemoryDir + " to " + newMemoryDir);
+        for (Path legacyMemoryDir : legacyMemoryDirs(projectBasePath)) {
+            if (!Files.exists(legacyMemoryDir) || legacyMemoryDir.equals(newMemoryDir)) {
+                continue;
+            }
+            Files.createDirectories(newMemoryDir.getParent());
+            Files.move(legacyMemoryDir, newMemoryDir);
+            LOG.info("Migrated memory directory from " + legacyMemoryDir + " to " + newMemoryDir);
+            return;
+        }
+    }
+
+    private static @NotNull List<Path> legacyMemoryDirs(@NotNull String projectBasePath) {
+        return List.of(
+            Path.of(projectBasePath, ".agentbridge", "memory"),
+            Path.of(projectBasePath, ".agent-work", "memory")
+        );
     }
 
     private @NotNull Path getMemoryBasePath() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -33,9 +33,9 @@ import java.util.Set;
  * and provides query methods for the Tool Statistics UI panel.
  *
  * <p>The database location is resolved via {@link AgentBridgeStorageSettings},
- * which defaults to {@code ~/.agentbridge/projects/<project>-<hash>/tool-stats.db}
- * but can be overridden by the user. Stats collection can also be disabled
- * entirely via the same settings page (see issue #351).</p>
+ * which defaults to {@code {project}/.agentbridge/tool-stats.db}. Users can
+ * choose a shared user-home root or a custom root instead. Stats collection can
+ * also be disabled entirely via the same settings page.</p>
  *
  * <p>Subscribes to {@link PsiBridgeService#TOOL_CALL_TOPIC} on the project
  * message bus. Records are appended on the calling thread (MCP handler threads)
@@ -72,9 +72,8 @@ public final class ToolCallStatisticsService implements Disposable {
                 "Cannot initialize ToolCallStatisticsService: project has no base path");
         }
         AgentBridgeStorageSettings storageSettings = AgentBridgeStorageSettings.getInstance();
-        // Compute the target path before the enabled check so migration runs unconditionally.
-        // Even when stats collection is disabled, the legacy {project}/.agentbridge/tool-stats.db
-        // must be moved out of the project tree so it no longer pollutes VCS views.
+        // Compute the target path before the enabled check so an actively selected
+        // external location can move existing project-local data even if recording is off.
         Path dbDir = storageSettings.getProjectStorageDir(project);
         Path dbPath = dbDir.resolve(DB_FILENAME);
         migrateLegacyDb(project.getBasePath(), dbPath);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageConfigurable.kt
@@ -1,89 +1,203 @@
 package com.github.catatafishen.agentbridge.settings
 
+import com.github.catatafishen.agentbridge.settings.AgentBridgeStorageSettings.StorageLocationMode
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
-import com.intellij.openapi.options.BoundConfigurable
+import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.options.SearchableConfigurable
-import com.intellij.openapi.ui.TextBrowseFolderListener
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
-import com.intellij.ui.dsl.builder.AlignX
-import com.intellij.ui.dsl.builder.RightGap
-import com.intellij.ui.dsl.builder.bindText
-import com.intellij.ui.dsl.builder.panel
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.FormBuilder
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import java.awt.BorderLayout
+import javax.swing.*
 
 /**
- * Root settings page for AgentBridge storage. Holds the shared storage root
- * directory; child pages (Tool Statistics, Memory, Chat History) configure
- * specific stores below it.
- *
- * Built with the official IntelliJ Platform Kotlin UI DSL v2 (BoundConfigurable).
+ * Root settings page for AgentBridge storage. Holds the shared storage
+ * location choice; child pages (Tool Statistics, Memory, Chat History)
+ * configure specific stores below it.
  */
-class AgentBridgeStorageConfigurable :
-    BoundConfigurable("Storage"),
-    SearchableConfigurable {
+class AgentBridgeStorageConfigurable @Suppress("unused") constructor(
+    private val project: Project
+) : SearchableConfigurable {
 
     private val settings = AgentBridgeStorageSettings.getInstance()
 
+    private var mainPanel: JPanel? = null
+    private var projectDefaultButton: JRadioButton? = null
+    private var userHomeButton: JRadioButton? = null
+    private var customButton: JRadioButton? = null
+    private var customField: TextFieldWithBrowseButton? = null
+
+    override fun getDisplayName(): String = "Storage"
+
     override fun getId(): String = ID
 
-    override fun createPanel() = panel {
-        row {
-            comment(
-                "Configure where AgentBridge stores per-project data files such as " +
-                    "tool-call statistics and semantic memory."
-            )
+    override fun createComponent(): JComponent {
+        val projectDefault = JRadioButton("Project directory (default)")
+        val userHome = JRadioButton("User home directory")
+        val custom = JRadioButton("Custom directory")
+        val pathField = createCustomPathField()
+
+        ButtonGroup().apply {
+            add(projectDefault)
+            add(userHome)
+            add(custom)
         }
-        separator()
-        row("Storage root:") {
-            val descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
-                .withTitle("Select AgentBridge Storage Directory")
-                .withDescription(
-                    "AgentBridge per-project data files such as tool-call statistics and " +
-                        "semantic memory will be stored under this directory."
+
+        val updateCustomField = {
+            pathField.isEnabled = custom.isSelected
+        }
+        listOf(projectDefault, userHome, custom).forEach { button ->
+            button.addActionListener { updateCustomField() }
+        }
+
+        projectDefaultButton = projectDefault
+        userHomeButton = userHome
+        customButton = custom
+        customField = pathField
+
+        mainPanel = FormBuilder.createFormBuilder()
+            .addComponent(
+                JBLabel(
+                    "<html><body style='width: 520px'>Configure where AgentBridge stores per-project data files " +
+                        "such as tool-call statistics and semantic memory.</body></html>"
                 )
-            val field = TextFieldWithBrowseButton().apply {
-                @Suppress("DEPRECATION")
-                addBrowseFolderListener(TextBrowseFolderListener(descriptor))
-                textField.let { tf ->
-                    if (tf is com.intellij.ui.components.JBTextField) {
-                        tf.emptyText.text = AgentBridgeStorageSettings.getDefaultStorageRoot().toString()
-                    }
+            )
+            .addSeparator(8)
+            .addComponent(optionPanel(projectDefault, "{project}/.agentbridge", projectDefaultStoragePath()))
+            .addComponent(
+                optionPanel(
+                    userHome,
+                    "Shared home directory",
+                    "${pathForHtml(AgentBridgeStorageSettings.getUserHomeStorageRoot())}/projects/&lt;project-name&gt;-&lt;hash&gt;"
+                )
+            )
+            .addComponent(customOptionPanel(custom, pathField))
+            .addSeparator(12)
+            .addComponent(
+                contextLabel(
+                    "<b>Note:</b> the project directory option keeps existing Marketplace users on the original " +
+                        "layout. Selecting a shared or custom location moves project-local data there on next use. " +
+                        "Changing the storage location takes effect on the next IDE restart."
+                )
+            )
+            .addSeparator(12)
+            .addComponent(
+                contextLabel(
+                    "Configure individual stores below: <b>Tool Statistics</b>, <b>Memory</b>, and <b>Chat History</b>."
+                )
+            )
+            .addComponentFillVertically(JPanel(), 0)
+            .panel
+            .apply {
+                border = JBUI.Borders.empty(8)
+            }
+
+        reset()
+        updateCustomField()
+        return requireNotNull(mainPanel)
+    }
+
+    override fun isModified(): Boolean {
+        val selectedMode = selectedMode()
+        return selectedMode != settings.storageLocationMode ||
+            customPathText() != (settings.customStorageRoot ?: "")
+    }
+
+    @Throws(ConfigurationException::class)
+    override fun apply() {
+        val mode = selectedMode()
+        val customPath = customPathText()
+        if (mode == StorageLocationMode.CUSTOM && customPath.isBlank()) {
+            throw ConfigurationException("Select a custom AgentBridge storage directory.")
+        }
+        settings.storageLocationMode = mode
+        settings.customStorageRoot = customPath.ifBlank { null }
+    }
+
+    override fun reset() {
+        when (settings.storageLocationMode) {
+            StorageLocationMode.PROJECT -> projectDefaultButton?.isSelected = true
+            StorageLocationMode.USER_HOME -> userHomeButton?.isSelected = true
+            StorageLocationMode.CUSTOM -> customButton?.isSelected = true
+        }
+        customField?.text = settings.customStorageRoot ?: ""
+        customField?.isEnabled = customButton?.isSelected == true
+    }
+
+    override fun disposeUIResources() {
+        mainPanel = null
+        projectDefaultButton = null
+        userHomeButton = null
+        customButton = null
+        customField = null
+    }
+
+    private fun selectedMode(): StorageLocationMode = when {
+        userHomeButton?.isSelected == true -> StorageLocationMode.USER_HOME
+        customButton?.isSelected == true -> StorageLocationMode.CUSTOM
+        else -> StorageLocationMode.PROJECT
+    }
+
+    private fun customPathText(): String = customField?.text?.trim().orEmpty()
+
+    private fun createCustomPathField(): TextFieldWithBrowseButton {
+        val descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
+            .withTitle("Select AgentBridge Storage Directory")
+            .withDescription(
+                "AgentBridge per-project data files such as tool-call statistics and semantic memory " +
+                    "will be stored under this directory."
+            )
+        return TextFieldWithBrowseButton().apply {
+            addBrowseFolderListener(project, descriptor)
+            textField.let { field ->
+                if (field is com.intellij.ui.components.JBTextField) {
+                    field.emptyText.text = AgentBridgeStorageSettings.getUserHomeStorageRoot().toString()
                 }
             }
-            val cellRef = cell(field)
-                .align(AlignX.FILL)
-                .resizableColumn()
-                .gap(RightGap.SMALL)
-                .bindText(
-                    { settings.customStorageRoot ?: "" },
-                    { settings.customStorageRoot = it.trim().ifEmpty { null } }
-                )
-            button("Reset to Default") { cellRef.component.text = "" }
-        }
-        row {
-            comment(
-                "Default: <code>${AgentBridgeStorageSettings.getDefaultStorageRoot()}</code><br/>" +
-                    "Per-project data lives under " +
-                    "<code>&lt;root&gt;/projects/&lt;project-name&gt;-&lt;hash&gt;/</code>."
-            )
-        }
-        separator()
-        row {
-            comment(
-                "<b>Note:</b> if legacy data exists under " +
-                    "<code>{project}/.agentbridge/tool-stats.db</code> or " +
-                    "<code>{project}/.agent-work/memory/</code>, it is moved to the new " +
-                    "location automatically on first use. Changing the storage root takes " +
-                    "effect on the next IDE restart."
-            )
-        }
-        separator()
-        row {
-            comment(
-                "Configure individual stores below: <b>Tool Statistics</b>, " +
-                    "<b>Memory</b>, and <b>Chat History</b>."
-            )
         }
     }
+
+    private fun optionPanel(button: JRadioButton, label: String, path: String): JPanel =
+        JPanel(BorderLayout()).apply {
+            isOpaque = false
+            add(button, BorderLayout.NORTH)
+            add(contextLabel("$label: <code>$path</code>").indented(), BorderLayout.CENTER)
+        }
+
+    private fun customOptionPanel(button: JRadioButton, field: TextFieldWithBrowseButton): JPanel =
+        JPanel().apply {
+            isOpaque = false
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            add(button)
+            add(contextLabel("Chosen root stores data under <code>&lt;path&gt;/projects/&lt;project-name&gt;-&lt;hash&gt;</code>.").indented())
+            add(Box.createVerticalStrut(4))
+            add(field.indented())
+        }
+
+    private fun contextLabel(html: String): JBLabel =
+        JBLabel("<html><body style='width: 520px'>$html</body></html>").apply {
+            foreground = UIUtil.getContextHelpForeground()
+            font = JBUI.Fonts.smallFont()
+        }
+
+    private fun JComponent.indented(): JComponent =
+        JPanel(BorderLayout()).apply {
+            isOpaque = false
+            border = JBUI.Borders.emptyLeft(24)
+            add(this@indented, BorderLayout.CENTER)
+        }
+
+    private fun projectDefaultStoragePath(): String {
+        val basePath = project.basePath ?: return "{project}/.agentbridge"
+        return pathForHtml(java.nio.file.Path.of(basePath, ".agentbridge"))
+    }
+
+    private fun pathForHtml(path: java.nio.file.Path): String =
+        StringUtil.escapeXmlEntities(path.toString())
 
     companion object {
         const val ID = "com.github.catatafishen.agentbridge.storage"

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageConfigurable.kt
@@ -12,6 +12,7 @@ import com.intellij.util.ui.FormBuilder
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import java.awt.BorderLayout
+import java.awt.Component
 import javax.swing.*
 
 /**
@@ -36,7 +37,7 @@ class AgentBridgeStorageConfigurable @Suppress("unused") constructor(
     override fun getId(): String = ID
 
     override fun createComponent(): JComponent {
-        val projectDefault = JRadioButton("Project directory (default)")
+        val projectDefault = JRadioButton("Project directory")
         val userHome = JRadioButton("User home directory")
         val custom = JRadioButton("Custom directory")
         val pathField = createCustomPathField()
@@ -79,15 +80,7 @@ class AgentBridgeStorageConfigurable @Suppress("unused") constructor(
             .addSeparator(12)
             .addComponent(
                 contextLabel(
-                    "<b>Note:</b> the project directory option keeps existing Marketplace users on the original " +
-                        "layout. Selecting a shared or custom location moves project-local data there on next use. " +
-                        "Changing the storage location takes effect on the next IDE restart."
-                )
-            )
-            .addSeparator(12)
-            .addComponent(
-                contextLabel(
-                    "Configure individual stores below: <b>Tool Statistics</b>, <b>Memory</b>, and <b>Chat History</b>."
+                    "<b>Note:</b> Changing the storage location takes effect on the next IDE restart."
                 )
             )
             .addComponentFillVertically(JPanel(), 0)
@@ -172,10 +165,17 @@ class AgentBridgeStorageConfigurable @Suppress("unused") constructor(
         JPanel().apply {
             isOpaque = false
             layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            button.alignmentX = Component.LEFT_ALIGNMENT
             add(button)
-            add(contextLabel("Chosen root stores data under <code>&lt;path&gt;/projects/&lt;project-name&gt;-&lt;hash&gt;</code>.").indented())
+            add(
+                contextLabel("Chosen root stores data under <code>&lt;path&gt;/projects/&lt;project-name&gt;-&lt;hash&gt;</code>.").indented()
+                    .apply {
+                        alignmentX = Component.LEFT_ALIGNMENT
+                    })
             add(Box.createVerticalStrut(4))
-            add(field.indented())
+            add(field.indented().apply {
+                alignmentX = Component.LEFT_ALIGNMENT
+            })
         }
 
     private fun contextLabel(html: String): JBLabel =

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettings.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettings.java
@@ -82,12 +82,16 @@ public final class AgentBridgeStorageSettings
 
     /**
      * The project-local default storage root: {@code {project}/.agentbridge}.
+     * Returns {@code null} for projects without a base path (e.g. the
+     * IntelliJ {@code DefaultProject} surfaced during dispose or
+     * {@code buildSearchableOptions}); callers should fall back to the
+     * shared user-home location in that case.
      */
-    @NotNull
+    @Nullable
     public static Path getProjectDefaultStorageRoot(@NotNull Project project) {
         String basePath = project.getBasePath();
         if (basePath == null) {
-            throw new IllegalStateException("Cannot resolve AgentBridge project storage: project has no base path");
+            return null;
         }
         return Paths.get(basePath, DEFAULT_DIR_NAME);
     }
@@ -109,7 +113,12 @@ public final class AgentBridgeStorageSettings
     @NotNull
     public Path getProjectStorageDir(@NotNull Project project) {
         return switch (getStorageLocationMode()) {
-            case PROJECT -> getProjectDefaultStorageRoot(project);
+            case PROJECT -> {
+                Path projectRoot = getProjectDefaultStorageRoot(project);
+                yield projectRoot != null
+                    ? projectRoot
+                    : getNamespacedProjectStorageDir(getUserHomeStorageRoot(), project);
+            }
             case USER_HOME -> getNamespacedProjectStorageDir(getUserHomeStorageRoot(), project);
             case CUSTOM -> getNamespacedProjectStorageDir(getRequiredCustomStorageRoot(), project);
         };

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettings.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettings.java
@@ -18,11 +18,10 @@ import java.util.Locale;
  * per-project data files (e.g. the tool-call statistics database and semantic
  * memory files).
  *
- * <p>Resolves to {@code ~/.agentbridge/} by default. Users can override the
- * root via the "Storage" settings page. Per-project data lives under
- * {@code <root>/projects/<project-name>-<hash>/}, keeping stats scoped to
- * individual projects while moving them out of the project tree (see issue
- * #351).</p>
+ * <p>Resolves to {@code {project}/.agentbridge/} by default. Users can choose
+ * the shared {@code ~/.agentbridge/} root or an absolute custom root via the
+ * "Storage" settings page. Shared roots namespace each project under
+ * {@code <root>/projects/<project-name>-<hash>/}.</p>
  */
 @Service(Service.Level.APP)
 @State(name = "AgentBridgeStorageSettings",
@@ -40,59 +39,97 @@ public final class AgentBridgeStorageSettings
         return PlatformApiCompat.getApplicationService(AgentBridgeStorageSettings.class);
     }
 
+    public enum StorageLocationMode {
+        PROJECT,
+        USER_HOME,
+        CUSTOM
+    }
+
     /**
-     * Returns the user-configured custom root, or {@code null} if the default
-     * should be used.
+     * Returns the user-configured custom root, or {@code null} if the custom
+     * root field is empty.
      */
     @Nullable
     public String getCustomStorageRoot() {
-        String s = myState.customStorageRoot;
+        String s = myState.getCustomStorageRoot();
         return (s == null || s.isBlank()) ? null : s.trim();
     }
 
     public void setCustomStorageRoot(@Nullable String path) {
-        myState.customStorageRoot = (path == null || path.isBlank()) ? null : path.trim();
+        myState.setCustomStorageRoot((path == null || path.isBlank()) ? null : path.trim());
+    }
+
+    @NotNull
+    public StorageLocationMode getStorageLocationMode() {
+        StorageLocationMode mode = myState.getStorageLocationMode();
+        if (mode != null) {
+            return mode;
+        }
+        return getCustomStorageRoot() == null ? StorageLocationMode.PROJECT : StorageLocationMode.CUSTOM;
+    }
+
+    public void setStorageLocationMode(@NotNull StorageLocationMode mode) {
+        myState.setStorageLocationMode(mode);
     }
 
     public boolean isToolStatsEnabled() {
-        return myState.toolStatsEnabled;
+        return myState.isToolStatsEnabled();
     }
 
     public void setToolStatsEnabled(boolean enabled) {
-        myState.toolStatsEnabled = enabled;
+        myState.setToolStatsEnabled(enabled);
     }
 
     /**
-     * The default storage root: {@code <user.home>/.agentbridge}. This matches
-     * the location already used by the embedding model cache, so all plugin
-     * data lives in one user-visible directory.
+     * The project-local default storage root: {@code {project}/.agentbridge}.
      */
     @NotNull
-    public static Path getDefaultStorageRoot() {
+    public static Path getProjectDefaultStorageRoot(@NotNull Project project) {
+        String basePath = project.getBasePath();
+        if (basePath == null) {
+            throw new IllegalStateException("Cannot resolve AgentBridge project storage: project has no base path");
+        }
+        return Paths.get(basePath, DEFAULT_DIR_NAME);
+    }
+
+    /**
+     * The shared user-home storage root: {@code <user.home>/.agentbridge}.
+     */
+    @NotNull
+    public static Path getUserHomeStorageRoot() {
         return Paths.get(System.getProperty("user.home"), DEFAULT_DIR_NAME);
     }
 
     /**
-     * Returns the effective storage root — the user override if set, otherwise
-     * the default.
-     */
-    @NotNull
-    public Path getEffectiveStorageRoot() {
-        String custom = getCustomStorageRoot();
-        return custom != null ? Paths.get(custom) : getDefaultStorageRoot();
-    }
-
-    /**
-     * Returns the per-project data directory under the effective storage root.
-     * The directory is namespaced by project name plus a hash of the project
-     * base path so that projects with identical names do not collide.
+     * Returns the per-project data directory for the selected storage mode.
+     * Project-local mode uses {@code {project}/.agentbridge}; shared roots use
+     * {@code <root>/projects/<project-name>-<hash>/} so projects with
+     * identical names do not collide.
      */
     @NotNull
     public Path getProjectStorageDir(@NotNull Project project) {
+        return switch (getStorageLocationMode()) {
+            case PROJECT -> getProjectDefaultStorageRoot(project);
+            case USER_HOME -> getNamespacedProjectStorageDir(getUserHomeStorageRoot(), project);
+            case CUSTOM -> getNamespacedProjectStorageDir(getRequiredCustomStorageRoot(), project);
+        };
+    }
+
+    @NotNull
+    private Path getRequiredCustomStorageRoot() {
+        String custom = getCustomStorageRoot();
+        if (custom == null) {
+            throw new IllegalStateException("Custom AgentBridge storage location is selected but no path is configured");
+        }
+        return Paths.get(custom);
+    }
+
+    @NotNull
+    private static Path getNamespacedProjectStorageDir(@NotNull Path root, @NotNull Project project) {
         String safeName = sanitize(project.getName());
         String hashSource = project.getBasePath() != null ? project.getBasePath() : project.getName();
         String hash = Integer.toHexString(hashSource.hashCode());
-        return getEffectiveStorageRoot().resolve(PROJECTS_DIR_NAME).resolve(safeName + "-" + hash);
+        return root.resolve(PROJECTS_DIR_NAME).resolve(safeName + "-" + hash);
     }
 
     /**
@@ -130,6 +167,7 @@ public final class AgentBridgeStorageSettings
 
     public static class State {
         private String customStorageRoot = null;
+        private StorageLocationMode storageLocationMode = null;
         private boolean toolStatsEnabled = true;
 
         public String getCustomStorageRoot() {
@@ -138,6 +176,14 @@ public final class AgentBridgeStorageSettings
 
         public void setCustomStorageRoot(String customStorageRoot) {
             this.customStorageRoot = customStorageRoot;
+        }
+
+        public StorageLocationMode getStorageLocationMode() {
+            return storageLocationMode;
+        }
+
+        public void setStorageLocationMode(StorageLocationMode storageLocationMode) {
+            this.storageLocationMode = storageLocationMode;
         }
 
         public boolean isToolStatsEnabled() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolStatsConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolStatsConfigurable.kt
@@ -8,7 +8,7 @@ import com.intellij.ui.dsl.builder.panel
 /**
  * Settings page controlling the tool-call statistics database. Lives under
  * the **Storage** parent page; the underlying file location is governed by
- * the shared storage root configured there.
+ * the storage location configured there.
  *
  * Built with the official IntelliJ Platform Kotlin UI DSL v2.
  */
@@ -33,7 +33,7 @@ class ToolStatsConfigurable :
         separator()
         row {
             comment(
-                "The database file is stored under the storage root configured on the " +
+                "The database file is stored under the storage location configured on the " +
                     "parent <b>Storage</b> page."
             )
         }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/MemoryServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/MemoryServiceTest.java
@@ -18,6 +18,21 @@ class MemoryServiceTest {
     Path tempDir;
 
     @Test
+    void migrateLegacyMemoryDirMovesProjectAgentBridgeMemoryIntoStorageRoot() throws IOException {
+        Path projectBase = tempDir.resolve("project");
+        Path projectMemoryDir = projectBase.resolve(".agentbridge").resolve("memory");
+        Files.createDirectories(projectMemoryDir);
+        Files.writeString(projectMemoryDir.resolve("identity.txt"), "identity", StandardCharsets.UTF_8);
+
+        Path newMemoryDir = tempDir.resolve("storage").resolve("projects").resolve("demo-123").resolve("memory");
+        MemoryService.migrateLegacyMemoryDir(projectBase.toString(), newMemoryDir);
+
+        assertFalse(Files.exists(projectMemoryDir), "Project-local memory directory should be moved");
+        assertEquals("identity",
+            Files.readString(newMemoryDir.resolve("identity.txt"), StandardCharsets.UTF_8));
+    }
+
+    @Test
     void migrateLegacyMemoryDirMovesProjectAgentWorkMemoryIntoStorageRoot() throws IOException {
         Path projectBase = tempDir.resolve("project");
         Path legacyMemoryDir = projectBase.resolve(".agent-work").resolve("memory");

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettingsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettingsTest.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.settings;
 
+import com.github.catatafishen.agentbridge.settings.AgentBridgeStorageSettings.StorageLocationMode;
 import com.intellij.openapi.project.Project;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -9,6 +10,7 @@ import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -19,53 +21,88 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class AgentBridgeStorageSettingsTest {
 
     @Test
-    void defaultStorageRootIsUserHomeDotAgentbridge() {
+    void defaultStorageModeIsProjectDirectory() {
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        assertEquals(StorageLocationMode.PROJECT, settings.getStorageLocationMode());
+    }
+
+    @Test
+    void projectDefaultStorageRootIsProjectDotAgentbridge() {
+        Project project = project("Demo", "/home/user/demo");
+        assertEquals(Paths.get("/home/user/demo/.agentbridge"),
+            AgentBridgeStorageSettings.getProjectDefaultStorageRoot(project));
+    }
+
+    @Test
+    void userHomeStorageRootIsUserHomeDotAgentbridge() {
         Path expected = Paths.get(System.getProperty("user.home"), ".agentbridge");
-        assertEquals(expected, AgentBridgeStorageSettings.getDefaultStorageRoot());
+        assertEquals(expected, AgentBridgeStorageSettings.getUserHomeStorageRoot());
     }
 
     @Test
-    void effectiveRootUsesCustomWhenSet() {
+    void projectStorageDirDefaultsToProjectDotAgentbridge() {
+        Project project = project("demo", "/home/user/demo");
+
         AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
-        settings.setCustomStorageRoot("/tmp/custom-ab");
-        assertEquals(Paths.get("/tmp/custom-ab"), settings.getEffectiveStorageRoot());
+
+        assertEquals(Paths.get("/home/user/demo/.agentbridge"), settings.getProjectStorageDir(project));
     }
 
     @Test
-    void effectiveRootFallsBackToDefaultWhenBlank() {
+    void projectStorageDirUsesUserHomeRootWhenSelected() {
+        Project project = project("My Cool Project!", "/home/user/projects/cool");
+
         AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
-        settings.setCustomStorageRoot("   ");
-        assertEquals(AgentBridgeStorageSettings.getDefaultStorageRoot(),
-            settings.getEffectiveStorageRoot());
+        settings.setStorageLocationMode(StorageLocationMode.USER_HOME);
+
+        Path dir = settings.getProjectStorageDir(project);
+        assertTrue(dir.toString().contains("/projects/my_cool_project_-"),
+            "Expected sanitized project name in path: " + dir);
+        assertTrue(dir.startsWith(AgentBridgeStorageSettings.getUserHomeStorageRoot().resolve("projects")),
+            "Path was: " + dir);
     }
 
     @Test
-    void projectStorageDirIsNamespacedAndSanitized() {
-        Project project = Mockito.mock(Project.class);
-        Mockito.when(project.getName()).thenReturn("My Cool Project!");
-        Mockito.when(project.getBasePath()).thenReturn("/home/user/projects/cool");
+    void projectStorageDirUsesCustomRootWhenSelected() {
+        Project project = project("My Cool Project!", "/home/user/projects/cool");
 
         AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        settings.setStorageLocationMode(StorageLocationMode.CUSTOM);
         settings.setCustomStorageRoot("/data/ab");
 
         Path dir = settings.getProjectStorageDir(project);
-        // sanitized: spaces and ! become '_', lower-cased
         assertTrue(dir.toString().contains("/projects/my_cool_project_-"),
             "Expected sanitized project name in path: " + dir);
         assertTrue(dir.startsWith(Paths.get("/data/ab/projects/")), "Path was: " + dir);
     }
 
     @Test
-    void projectStorageDirDifferentForProjectsWithSameName() {
-        Project p1 = Mockito.mock(Project.class);
-        Mockito.when(p1.getName()).thenReturn("demo");
-        Mockito.when(p1.getBasePath()).thenReturn("/home/a/demo");
-
-        Project p2 = Mockito.mock(Project.class);
-        Mockito.when(p2.getName()).thenReturn("demo");
-        Mockito.when(p2.getBasePath()).thenReturn("/home/b/demo");
+    void blankCustomRootFailsWhenCustomModeSelected() {
+        Project project = project("demo", "/home/user/demo");
 
         AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        settings.setStorageLocationMode(StorageLocationMode.CUSTOM);
+        settings.setCustomStorageRoot("   ");
+
+        assertThrows(IllegalStateException.class, () -> settings.getProjectStorageDir(project));
+    }
+
+    @Test
+    void legacyCustomRootSelectsCustomMode() {
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        settings.setCustomStorageRoot("/data/ab");
+
+        assertEquals(StorageLocationMode.CUSTOM, settings.getStorageLocationMode());
+    }
+
+    @Test
+    void projectStorageDirDifferentForProjectsWithSameNameInSharedRoot() {
+        Project p1 = project("demo", "/home/a/demo");
+        Project p2 = project("demo", "/home/b/demo");
+
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        settings.setStorageLocationMode(StorageLocationMode.USER_HOME);
+
         assertNotEquals(settings.getProjectStorageDir(p1),
             settings.getProjectStorageDir(p2),
             "Projects with the same name but different base paths must get distinct directories");
@@ -73,11 +110,10 @@ class AgentBridgeStorageSettingsTest {
 
     @Test
     void projectMemoryDirLivesUnderProjectStorageDir() {
-        Project project = Mockito.mock(Project.class);
-        Mockito.when(project.getName()).thenReturn("demo");
-        Mockito.when(project.getBasePath()).thenReturn("/home/user/demo");
+        Project project = project("demo", "/home/user/demo");
 
         AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+        settings.setStorageLocationMode(StorageLocationMode.CUSTOM);
         settings.setCustomStorageRoot("/data/ab");
 
         assertEquals(settings.getProjectStorageDir(project).resolve("memory"),
@@ -88,5 +124,12 @@ class AgentBridgeStorageSettingsTest {
     void toolStatsEnabledDefaultsTrue() {
         AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
         assertTrue(settings.isToolStatsEnabled());
+    }
+
+    private static Project project(String name, String basePath) {
+        Project project = Mockito.mock(Project.class);
+        Mockito.when(project.getName()).thenReturn(name);
+        Mockito.when(project.getBasePath()).thenReturn(basePath);
+        return project;
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettingsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/AgentBridgeStorageSettingsTest.java
@@ -126,6 +126,24 @@ class AgentBridgeStorageSettingsTest {
         assertTrue(settings.isToolStatsEnabled());
     }
 
+    @Test
+    void projectStorageDirFallsBackToUserHomeWhenBasePathMissing() {
+        Project project = project("Headless", null);
+
+        AgentBridgeStorageSettings settings = new AgentBridgeStorageSettings();
+
+        Path dir = settings.getProjectStorageDir(project);
+        assertTrue(dir.startsWith(AgentBridgeStorageSettings.getUserHomeStorageRoot().resolve("projects")),
+            "Expected fallback under user-home projects/, got: " + dir);
+    }
+
+    @Test
+    void projectDefaultStorageRootReturnsNullWhenBasePathMissing() {
+        Project project = project("Headless", null);
+        org.junit.jupiter.api.Assertions.assertNull(
+            AgentBridgeStorageSettings.getProjectDefaultStorageRoot(project));
+    }
+
     private static Project project(String name, String basePath) {
         Project project = Mockito.mock(Project.class);
         Mockito.when(project.getName()).thenReturn(name);


### PR DESCRIPTION
## Summary
- restore project-local .agentbridge as the default storage location
- add Storage settings radio buttons for project-local, user-home shared root, and custom shared root with directory chooser
- preserve project-local data by default and migrate it only when an external storage mode is selected

## Validation
- MemoryServiceTest
- ToolCallStatisticsServiceMigrationTest
- AgentBridgeStorageSettingsTest
- plugin-core IDE build