### PR TITLE
feat(prompt): paste images and binary files into chat

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/AttachmentKind.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/AttachmentKind.kt
@@ -1,0 +1,18 @@
+package com.github.catatafishen.agentbridge.ui
+
+/**
+ * Kind of attachment a context chip refers to.
+ *
+ * - [TEXT]   — a text file or selection; content is read as text and sent as a
+ *              `Resource` link with embedded text.
+ * - [IMAGE]  — a raster image (e.g. pasted screenshot) on disk; sent inline as a
+ *              base64 `Image` content block (standard ACP format) so vision-capable
+ *              agents can consume it directly.
+ * - [BINARY] — any other binary file (PDF, archive, etc.) on disk; sent as a
+ *              `Resource` link with mime type but without inline content.
+ */
+enum class AttachmentKind {
+    TEXT,
+    IMAGE,
+    BINARY,
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -105,6 +105,7 @@ class ChatToolWindowContent(
     private lateinit var processingTimerPanel: ProcessingTimerPanel
     private lateinit var promptOrchestrator: PromptOrchestrator
     private lateinit var pasteToScratchHandler: PasteToScratchHandler
+    private lateinit var pasteAttachmentHandler: PasteAttachmentHandler
 
     // Plans tree (populated from ACP plan updates)
     private lateinit var planTreeModel: javax.swing.tree.DefaultTreeModel
@@ -872,6 +873,7 @@ class ChatToolWindowContent(
         contextManager = PromptContextManager(project, promptTextArea) { text -> appendResponse(text) }
 
         pasteToScratchHandler = PasteToScratchHandler(project, promptTextArea, contextManager)
+        pasteAttachmentHandler = PasteAttachmentHandler(project, promptTextArea, contextManager)
         promptOrchestrator = PromptOrchestrator(
             project, agentManager, billing, contextManager, authService,
             { consolePanel }, { copilotBanner }, { statusBanner },
@@ -2031,14 +2033,20 @@ class ChatToolWindowContent(
         contentComponent: JComponent,
         pasteStrokes: Set<KeyStroke>
     ): Boolean {
-        val chatInputSettings = com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance()
-        if (!chatInputSettings.isSmartPasteEnabled) return false
         if (event !is java.awt.event.KeyEvent) return false
         if (editor.isDisposed) return false
         if (event.id != java.awt.event.KeyEvent.KEY_PRESSED) return false
         if (KeyStroke.getKeyStrokeForEvent(event) !in pasteStrokes) return false
         val focused = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner
         if (!SwingUtilities.isDescendingFrom(focused, contentComponent)) return false
+
+        // Image and file pastes take precedence over the smart-paste-to-scratch text path.
+        // They are handled regardless of the smart-paste setting because they have no
+        // sensible "insert as plain text" fallback in the prompt editor.
+        if (handleImageOrFilePaste(event)) return true
+
+        val chatInputSettings = com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance()
+        if (!chatInputSettings.isSmartPasteEnabled) return false
 
         val clipText = contextManager.getClipboardText()
         val minLines = chatInputSettings.smartPasteMinLines
@@ -2056,6 +2064,61 @@ class ChatToolWindowContent(
             }
         }
         return true
+    }
+
+    /**
+     * Detect a non-text clipboard payload (raster image or file list) and route it to
+     * [pasteAttachmentHandler]. Returns true (and consumes [event]) when a payload was
+     * handled — meaning callers must not fall through to text paste handling.
+     *
+     * Images take priority: many apps (e.g. browsers) put both the image bytes AND a
+     * placeholder string on the clipboard; we want the image, not the string.
+     */
+    private fun handleImageOrFilePaste(event: java.awt.event.KeyEvent): Boolean {
+        val clipboard = try {
+            Toolkit.getDefaultToolkit().systemClipboard
+        } catch (_: Exception) {
+            return false
+        }
+        val contents = try {
+            clipboard.getContents(null) ?: return false
+        } catch (_: IllegalStateException) {
+            return false
+        }
+
+        if (contents.isDataFlavorSupported(java.awt.datatransfer.DataFlavor.imageFlavor)) {
+            val image = try {
+                contents.getTransferData(java.awt.datatransfer.DataFlavor.imageFlavor) as? Image
+            } catch (_: Exception) {
+                null
+            }
+            if (image != null) {
+                event.consume()
+                ApplicationManager.getApplication().executeOnPooledThread {
+                    pasteAttachmentHandler.handleImagePaste(image)
+                }
+                return true
+            }
+        }
+
+        if (contents.isDataFlavorSupported(java.awt.datatransfer.DataFlavor.javaFileListFlavor)) {
+            @Suppress("UNCHECKED_CAST")
+            val files = try {
+                contents.getTransferData(java.awt.datatransfer.DataFlavor.javaFileListFlavor)
+                    as? List<java.io.File>
+            } catch (_: Exception) {
+                null
+            }
+            if (!files.isNullOrEmpty()) {
+                event.consume()
+                ApplicationManager.getApplication().executeOnPooledThread {
+                    pasteAttachmentHandler.handleFilePaste(files)
+                }
+                return true
+            }
+        }
+
+        return false
     }
 
     private fun registerPasteIntercept(editor: EditorEx, contentComponent: JComponent) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ContextChipRenderer.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ContextChipRenderer.kt
@@ -1,25 +1,35 @@
 package com.github.catatafishen.agentbridge.ui
 
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.editor.EditorCustomElementRenderer
 import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.editor.colors.EditorFontType
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.ui.JBColor
 import java.awt.*
+import javax.swing.Icon
 import javax.swing.UIManager
 
 class ContextChipRenderer(val contextData: ContextItemData) : EditorCustomElementRenderer {
 
     private companion object {
         private const val H_PAD = 3
+        private const val ICON_GAP = 3
     }
 
     private val label: String = contextData.name
 
+    private val leadingIcon: Icon? = when (contextData.attachmentKind) {
+        AttachmentKind.IMAGE -> AllIcons.FileTypes.Image
+        AttachmentKind.BINARY -> AllIcons.FileTypes.Any_type
+        AttachmentKind.TEXT -> null
+    }
+
     override fun calcWidthInPixels(inlay: Inlay<*>): Int {
         val metrics =
             inlay.editor.contentComponent.getFontMetrics(inlay.editor.colorsScheme.getFont(EditorFontType.PLAIN))
-        return H_PAD + metrics.stringWidth(label) + H_PAD
+        val iconWidth = leadingIcon?.let { it.iconWidth + ICON_GAP } ?: 0
+        return H_PAD + iconWidth + metrics.stringWidth(label) + H_PAD
     }
 
     override fun calcHeightInPixels(inlay: Inlay<*>): Int {
@@ -40,8 +50,16 @@ class ContextChipRenderer(val contextData: ContextItemData) : EditorCustomElemen
             val metrics = g2.fontMetrics
             val textY = targetRegion.y + (targetRegion.height + metrics.ascent - metrics.descent) / 2
 
+            var x = targetRegion.x + H_PAD
+            val icon = leadingIcon
+            if (icon != null) {
+                val iconY = targetRegion.y + (targetRegion.height - icon.iconHeight) / 2
+                icon.paintIcon(inlay.editor.contentComponent, g2, x, iconY)
+                x += icon.iconWidth + ICON_GAP
+            }
+
             g2.color = linkColor
-            g2.drawString(label, targetRegion.x + H_PAD, textY)
+            g2.drawString(label, x, textY)
         } finally {
             g2.dispose()
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ContextItemData.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ContextItemData.kt
@@ -4,12 +4,17 @@ package com.github.catatafishen.agentbridge.ui
  * Data associated with an inline context chip.
  * Mirrors the fields of the old `ContextItem` but is a standalone data class
  * so the renderer can carry it without depending on the tool window's private types.
+ *
+ * [attachmentKind] selects how the chip is rendered and how the attachment is encoded
+ * when building ACP content blocks for the prompt. Defaults to [AttachmentKind.TEXT]
+ * for backwards compatibility with existing call-sites.
  */
-data class ContextItemData(
+data class ContextItemData @JvmOverloads constructor(
     val path: String,
     val name: String,
     val startLine: Int,
     val endLine: Int,
     val fileTypeName: String?,
-    val isSelection: Boolean
+    val isSelection: Boolean,
+    val attachmentKind: AttachmentKind = AttachmentKind.TEXT,
 )

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PasteAttachmentHandler.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PasteAttachmentHandler.kt
@@ -1,0 +1,197 @@
+package com.github.catatafishen.agentbridge.ui
+
+import com.github.catatafishen.agentbridge.settings.AgentBridgeStorageSettings
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.ui.EditorTextField
+import java.awt.Image
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import javax.imageio.ImageIO
+
+/**
+ * Handles pasting non-text clipboard content (raster images, binary files) into the
+ * chat prompt. Saves the bytes/files into the AgentBridge storage directory's `pastes/`
+ * subfolder and inserts an inline context chip referencing the saved file.
+ *
+ * Image attachments are also encoded as inline base64 [com.github.catatafishen.agentbridge.acp.model.ContentBlock.Image]
+ * blocks at prompt-send time (see [PromptContextManager.buildPromptAttachments]).
+ */
+internal class PasteAttachmentHandler(
+    private val project: Project,
+    private val promptTextArea: EditorTextField,
+    private val contextManager: PromptContextManager,
+) {
+    private val log = Logger.getInstance(PasteAttachmentHandler::class.java)
+
+    /**
+     * Save [image] as a PNG into the storage `pastes/` directory and insert an IMAGE chip
+     * at the current caret. Returns true on success so callers can know whether they
+     * actually consumed the paste.
+     */
+    fun handleImagePaste(image: Image): Boolean {
+        return try {
+            val buffered = toBufferedImage(image)
+            val pngBytes = encodeAsPng(buffered)
+            val target = uniqueTarget(pastesDir(), defaultImageName())
+            Files.write(target, pngBytes)
+            refreshAndInsertChip(target, AttachmentKind.IMAGE)
+            true
+        } catch (e: IOException) {
+            log.warn("Failed to save pasted image", e)
+            false
+        } catch (e: RuntimeException) {
+            log.warn("Failed to save pasted image", e)
+            false
+        }
+    }
+
+    /**
+     * Copy each pasted file into the storage `pastes/` directory and insert one chip per
+     * file. The chip's [AttachmentKind] is [AttachmentKind.IMAGE] for raster image file
+     * types and [AttachmentKind.BINARY] for everything else.
+     *
+     * Returns true if at least one file was copied successfully.
+     */
+    fun handleFilePaste(files: List<File>): Boolean {
+        if (files.isEmpty()) return false
+        var any = false
+        for (source in files) {
+            val saved = copySingleFile(source) ?: continue
+            val kind = if (isImageFile(source.name)) AttachmentKind.IMAGE else AttachmentKind.BINARY
+            refreshAndInsertChip(saved, kind)
+            any = true
+        }
+        return any
+    }
+
+    private fun copySingleFile(source: File): Path? {
+        return try {
+            if (!source.exists() || !source.isFile) {
+                log.warn("Pasted file does not exist or is not a regular file: ${source.path}")
+                return null
+            }
+            val target = uniqueTarget(pastesDir(), source.name)
+            Files.copy(source.toPath(), target, StandardCopyOption.REPLACE_EXISTING)
+            target
+        } catch (e: IOException) {
+            log.warn("Failed to copy pasted file ${source.path}", e)
+            null
+        }
+    }
+
+    private fun pastesDir(): Path {
+        val root = AgentBridgeStorageSettings.getInstance().getProjectStorageDir(project)
+        val pastes = root.resolve(PASTES_SUBDIR)
+        Files.createDirectories(pastes)
+        return pastes
+    }
+
+    private fun refreshAndInsertChip(file: Path, kind: AttachmentKind) {
+        ApplicationManager.getApplication().invokeLater {
+            val vf = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(file)
+            val fileTypeName = vf?.fileType?.name
+                ?: FileTypeManager.getInstance().getFileTypeByFileName(file.fileName.toString()).name
+            val data = ContextItemData(
+                path = file.toAbsolutePath().toString(),
+                name = file.fileName.toString(),
+                startLine = 1,
+                endLine = 0,
+                fileTypeName = fileTypeName,
+                isSelection = false,
+                attachmentKind = kind,
+            )
+            val editor = promptTextArea.editor as? EditorEx ?: return@invokeLater
+            contextManager.insertInlineChip(editor, data)
+        }
+    }
+
+    private fun defaultImageName(): String {
+        val ts = LocalDateTime.now().format(TIMESTAMP_FORMAT)
+        return "screenshot-$ts.png"
+    }
+
+    private fun isImageFile(name: String): Boolean {
+        val lower = name.lowercase()
+        return IMAGE_EXTENSIONS.any { lower.endsWith(it) }
+    }
+
+    companion object {
+        private const val PASTES_SUBDIR = "pastes"
+        private val TIMESTAMP_FORMAT: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS")
+        private val IMAGE_EXTENSIONS = setOf(
+            ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tiff", ".tif",
+        )
+
+        /**
+         * Convert any [Image] (e.g. the one returned by `Toolkit.systemClipboard`) into a
+         * [BufferedImage] suitable for [ImageIO]. Pure: no IO, no UI dependencies.
+         * Visible for testing.
+         */
+        fun toBufferedImage(image: Image): BufferedImage {
+            if (image is BufferedImage) return image
+            val width = image.getWidth(null).coerceAtLeast(1)
+            val height = image.getHeight(null).coerceAtLeast(1)
+            // Use raw BufferedImage (not UIUtil.createImage): we want the clipboard's
+            // actual pixel data unscaled for HiDPI — UIUtil's HiDPI image would multiply
+            // dimensions by the system scale and skew the saved file.
+            @Suppress("UndesirableClassUsage")
+            val buffered = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+            val g = buffered.createGraphics()
+            try {
+                g.drawImage(image, 0, 0, null)
+            } finally {
+                g.dispose()
+            }
+            return buffered
+        }
+
+        /** Encode a [BufferedImage] as PNG bytes. Visible for testing. */
+        fun encodeAsPng(image: BufferedImage): ByteArray {
+            val baos = ByteArrayOutputStream()
+            if (!ImageIO.write(image, "PNG", baos)) {
+                throw IOException("No PNG writer available for the given image")
+            }
+            return baos.toByteArray()
+        }
+
+        /**
+         * Resolve a non-colliding target path in [dir] for [requestedName]. If a file with
+         * the same name already exists, appends `-1`, `-2`, ... before the extension until
+         * an unused name is found. Visible for testing.
+         */
+        fun uniqueTarget(dir: Path, requestedName: String): Path {
+            val safe = sanitizeFileName(requestedName)
+            val first = dir.resolve(safe)
+            if (!Files.exists(first)) return first
+            val dot = safe.lastIndexOf('.')
+            val (stem, ext) = if (dot > 0) safe.substring(0, dot) to safe.substring(dot)
+            else safe to ""
+            var i = 1
+            while (true) {
+                val candidate = dir.resolve("$stem-$i$ext")
+                if (!Files.exists(candidate)) return candidate
+                i++
+            }
+        }
+
+        private fun sanitizeFileName(name: String): String {
+            val cleaned = name.map { c ->
+                if (c.isLetterOrDigit() || c == '.' || c == '-' || c == '_') c else '_'
+            }.joinToString("")
+            return cleaned.ifEmpty { "pasted" }
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptAttachment.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptAttachment.kt
@@ -1,0 +1,43 @@
+package com.github.catatafishen.agentbridge.ui
+
+/**
+ * Typed view of an attachment that has been resolved against the file system and is
+ * ready to be turned into an ACP `ContentBlock` when sending the prompt.
+ *
+ * The three variants map to the three ACP content-block types we currently emit:
+ *
+ * - [TextRef]   → `ContentBlock.Resource(ResourceLink(uri, _, mime, text, _))`
+ *                 with the file's text inlined (or an "// Selected lines …" snippet).
+ * - [ImageRef]  → `ContentBlock.Image(base64, mime)` — proper inline ACP image.
+ * - [BinaryRef] → `ContentBlock.Resource(ResourceLink(uri, name, mime, null, null))`
+ *                 — file URI + mime type only; agents that support file links can pull
+ *                 the bytes themselves.
+ *
+ * All variants carry [uri] so `PromptOrchestrator.addContextEntries` can render a
+ * uniform "context files" entry in the chat history.
+ */
+sealed interface PromptAttachment {
+    val uri: String
+    val mimeType: String?
+    val displayName: String
+
+    data class TextRef(
+        override val uri: String,
+        override val mimeType: String?,
+        override val displayName: String,
+        val text: String,
+    ) : PromptAttachment
+
+    data class ImageRef(
+        override val uri: String,
+        override val mimeType: String,
+        override val displayName: String,
+        val base64Data: String,
+    ) : PromptAttachment
+
+    data class BinaryRef(
+        override val uri: String,
+        override val mimeType: String?,
+        override val displayName: String,
+    ) : PromptAttachment
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptContextManager.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptContextManager.kt
@@ -269,6 +269,87 @@ class PromptContextManager(
         return references
     }
 
+    /**
+     * Build a typed [PromptAttachment] list from the chip data. Uses each chip's
+     * [ContextItemData.attachmentKind] to decide whether to read text, encode an image
+     * as base64, or just record a binary file reference. Items that fail to load are
+     * skipped with a console warning (same behaviour as [buildContextReferences]).
+     */
+    fun buildPromptAttachments(items: List<ContextItemData>? = null): List<PromptAttachment> {
+        val contextItems = items ?: collectInlineContextItems()
+        val attachments = mutableListOf<PromptAttachment>()
+        for (item in contextItems) {
+            try {
+                val attachment = buildSingleAttachment(item)
+                if (attachment != null) attachments.add(attachment)
+            } catch (_: Exception) {
+                appendResponse("\u26a0 Could not read context: ${item.name}\n")
+            }
+        }
+        return attachments
+    }
+
+    private fun buildSingleAttachment(item: ContextItemData): PromptAttachment? {
+        return when (item.attachmentKind) {
+            AttachmentKind.TEXT -> buildTextAttachment(item)
+            AttachmentKind.IMAGE -> buildImageAttachment(item)
+            AttachmentKind.BINARY -> buildBinaryAttachment(item)
+        }
+    }
+
+    private fun buildTextAttachment(item: ContextItemData): PromptAttachment.TextRef? {
+        val ref = buildSingleReference(item) ?: return null
+        return PromptAttachment.TextRef(
+            uri = ref.uri(),
+            mimeType = ref.mimeType(),
+            displayName = item.name,
+            text = ref.text(),
+        )
+    }
+
+    private fun buildImageAttachment(item: ContextItemData): PromptAttachment.ImageRef? {
+        val file = java.io.File(item.path)
+        if (!file.exists() || !file.isFile) return null
+        val bytes = file.readBytes()
+        val mime = guessImageMime(item.path)
+        val base64 = java.util.Base64.getEncoder().encodeToString(bytes)
+        return PromptAttachment.ImageRef(
+            uri = "file://${item.path.replace("\\", "/")}",
+            mimeType = mime,
+            displayName = item.name,
+            base64Data = base64,
+        )
+    }
+
+    private fun buildBinaryAttachment(item: ContextItemData): PromptAttachment.BinaryRef {
+        return PromptAttachment.BinaryRef(
+            uri = "file://${item.path.replace("\\", "/")}",
+            mimeType = guessBinaryMime(item.path),
+            displayName = item.name,
+        )
+    }
+
+    private fun guessImageMime(path: String): String {
+        val lower = path.lowercase()
+        return when {
+            lower.endsWith(".png") -> "image/png"
+            lower.endsWith(".jpg") || lower.endsWith(".jpeg") -> "image/jpeg"
+            lower.endsWith(".gif") -> "image/gif"
+            lower.endsWith(".webp") -> "image/webp"
+            lower.endsWith(".bmp") -> "image/bmp"
+            lower.endsWith(".tiff") || lower.endsWith(".tif") -> "image/tiff"
+            else -> "image/png"
+        }
+    }
+
+    private fun guessBinaryMime(path: String): String? {
+        return try {
+            java.nio.file.Files.probeContentType(java.nio.file.Paths.get(path))
+        } catch (_: Exception) {
+            null
+        }
+    }
+
     private fun buildSingleReference(item: ContextItemData): ResourceReference? {
         val file = com.intellij.openapi.vfs.LocalFileSystem.getInstance().findFileByPath(item.path)
             ?: return null

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
@@ -2,7 +2,6 @@ package com.github.catatafishen.agentbridge.ui
 
 import com.github.catatafishen.agentbridge.acp.model.ContentBlock
 import com.github.catatafishen.agentbridge.acp.model.PromptRequest
-import com.github.catatafishen.agentbridge.acp.model.ResourceReference
 import com.github.catatafishen.agentbridge.acp.model.SessionUpdate
 import com.github.catatafishen.agentbridge.agent.AbstractAgentClient
 import com.github.catatafishen.agentbridge.bridge.PermissionResponse
@@ -176,11 +175,11 @@ class PromptOrchestrator(
             wirePermissionListener(client)
 
             val modelId = prepareModelAndTurnState(selectedModelId)
-            val references = contextManager.buildContextReferences(contextItems.ifEmpty { null })
+            val attachments = contextManager.buildPromptAttachments(contextItems.ifEmpty { null })
             val effectivePrompt = buildEffectivePrompt(prompt)
-            addContextEntries(references, contextItems)
+            addContextEntries(attachments, contextItems)
 
-            dispatchPromptWithRetry(client, sessionId, effectivePrompt, modelId, references)
+            dispatchPromptWithRetry(client, sessionId, effectivePrompt, modelId, attachments)
             // If stop() was called, the remote turn may have ended cleanly (via turn/interrupt
             // response) without throwing. Treat it as a cancellation so handlePromptCompletion
             // is not invoked and the stale thread interrupt doesn't leak into the next turn.
@@ -295,8 +294,8 @@ class PromptOrchestrator(
         return selectedModelId
     }
 
-    private fun addContextEntries(references: List<ResourceReference>, contextItems: List<ContextItemData>) {
-        if (references.isNotEmpty() && contextItems.isNotEmpty()) {
+    private fun addContextEntries(attachments: List<PromptAttachment>, contextItems: List<ContextItemData>) {
+        if (attachments.isNotEmpty() && contextItems.isNotEmpty()) {
             val contextFiles = contextItems.map { Pair(it.name, it.path) }
             consolePanel().addContextFilesEntry(contextFiles)
         }
@@ -324,9 +323,9 @@ class PromptOrchestrator(
         initialSessionId: String,
         effectivePrompt: String,
         modelId: String,
-        references: List<ResourceReference>,
+        attachments: List<PromptAttachment>,
     ) {
-        val promptBlocks = buildPromptBlocks(effectivePrompt, references)
+        val promptBlocks = buildPromptBlocks(effectivePrompt, attachments)
         val onUpdate = java.util.function.Consumer<SessionUpdate> { update ->
             handlePromptStreamingUpdate(update)
         }
@@ -338,35 +337,72 @@ class PromptOrchestrator(
         sendWithSessionRetry(client, initialSessionId, sendCall)
     }
 
-    private fun buildPromptBlocks(prompt: String, references: List<ResourceReference>): List<ContentBlock> {
+    private fun buildPromptBlocks(prompt: String, attachments: List<PromptAttachment>): List<ContentBlock> {
         // Check if the active agent supports resource references
         val profile = agentManager.activeProfile
-        if (!profile.isSendResourceReferences && references.isNotEmpty()) {
-            // Append context content directly to the prompt text for agents that don't support resources
-            val promptWithContext = buildString {
-                append(prompt)
-                append("\n\n")
-                for ((index, ref) in references.withIndex()) {
-                    if (index > 0) append("\n\n")
-                    append("--- Context: ${ref.uri()} ---\n")
-                    append(ref.text())
-                }
-            }
-            return listOf(ContentBlock.Text(promptWithContext))
+        if (!profile.isSendResourceReferences && attachments.isNotEmpty()) {
+            return buildPromptBlocksAsTextFallback(prompt, attachments)
         }
 
-        // Standard path: send resources as separate content blocks
+        // Standard path: send each attachment as the appropriate ACP content block.
         val blocks = mutableListOf<ContentBlock>(ContentBlock.Text(prompt))
-        for (ref in references) {
-            blocks.add(
-                ContentBlock.Resource(
-                    ContentBlock.ResourceLink(
-                        ref.uri(), null, ref.mimeType(), ref.text(), null
+        for (attachment in attachments) {
+            when (attachment) {
+                is PromptAttachment.TextRef -> blocks.add(
+                    ContentBlock.Resource(
+                        ContentBlock.ResourceLink(
+                            attachment.uri, null, attachment.mimeType, attachment.text, null
+                        )
                     )
                 )
-            )
+
+                is PromptAttachment.ImageRef -> blocks.add(
+                    ContentBlock.Image(attachment.base64Data, attachment.mimeType)
+                )
+
+                is PromptAttachment.BinaryRef -> blocks.add(
+                    ContentBlock.Resource(
+                        ContentBlock.ResourceLink(
+                            attachment.uri, attachment.displayName, attachment.mimeType, null, null
+                        )
+                    )
+                )
+            }
         }
         return blocks
+    }
+
+    /**
+     * Fallback for agents that do not accept ACP `Resource` content blocks (see
+     * [com.github.catatafishen.agentbridge.services.AgentProfile.isSendResourceReferences]).
+     * Inlines text attachments into the prompt; drops image/binary attachments with a
+     * console note since base64 image blocks are not supported by these agents either.
+     */
+    private fun buildPromptBlocksAsTextFallback(
+        prompt: String,
+        attachments: List<PromptAttachment>,
+    ): List<ContentBlock> {
+        val textRefs = attachments.filterIsInstance<PromptAttachment.TextRef>()
+        val skipped = attachments.size - textRefs.size
+        if (skipped > 0) {
+            val agentName = agentManager.activeProfile.displayName
+            ApplicationManager.getApplication().invokeLater {
+                consolePanel().addErrorEntry(
+                    "\u26a0 $agentName does not support image or binary attachments — " +
+                        "$skipped attachment(s) were not sent."
+                )
+            }
+        }
+        val promptWithContext = buildString {
+            append(prompt)
+            if (textRefs.isNotEmpty()) append("\n\n")
+            for ((index, ref) in textRefs.withIndex()) {
+                if (index > 0) append("\n\n")
+                append("--- Context: ${ref.uri} ---\n")
+                append(ref.text)
+            }
+        }
+        return listOf(ContentBlock.Text(promptWithContext))
     }
 
     /**

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/PasteAttachmentHandlerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/PasteAttachmentHandlerTest.java
@@ -1,0 +1,107 @@
+package com.github.catatafishen.agentbridge.ui;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pure-logic tests for {@link PasteAttachmentHandler}'s static helpers. No IDE / Project
+ * fixture is required — these cover the encoding, conversion, and naming logic that
+ * runs on the pool thread when a paste is intercepted.
+ */
+class PasteAttachmentHandlerTest {
+
+    @Test
+    void encodeAsPng_roundTripsThroughImageIO() throws Exception {
+        BufferedImage original = new BufferedImage(8, 4, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = original.createGraphics();
+        try {
+            g.setColor(Color.RED);
+            g.fillRect(0, 0, 8, 4);
+        } finally {
+            g.dispose();
+        }
+
+        byte[] bytes = PasteAttachmentHandler.Companion.encodeAsPng(original);
+
+        assertNotNull(bytes);
+        assertTrue(bytes.length > 8, "PNG payload should be non-trivial");
+        // PNG magic header
+        assertEquals((byte) 0x89, bytes[0]);
+        assertEquals((byte) 0x50, bytes[1]); // 'P'
+        assertEquals((byte) 0x4E, bytes[2]); // 'N'
+        assertEquals((byte) 0x47, bytes[3]); // 'G'
+
+        BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(bytes));
+        assertNotNull(decoded, "PNG bytes must decode back via ImageIO");
+        assertEquals(8, decoded.getWidth());
+        assertEquals(4, decoded.getHeight());
+    }
+
+    @Test
+    void toBufferedImage_returnsSameInstanceWhenAlreadyBuffered() {
+        BufferedImage original = new BufferedImage(2, 2, BufferedImage.TYPE_INT_ARGB);
+        BufferedImage result = PasteAttachmentHandler.Companion.toBufferedImage(original);
+        assertSame(original, result);
+    }
+
+    @Test
+    void toBufferedImage_convertsArbitraryImage() {
+        Image volatileImage = new BufferedImage(5, 7, BufferedImage.TYPE_INT_RGB)
+                .getScaledInstance(5, 7, Image.SCALE_FAST);
+        BufferedImage result = PasteAttachmentHandler.Companion.toBufferedImage(volatileImage);
+        assertEquals(5, result.getWidth());
+        assertEquals(7, result.getHeight());
+    }
+
+    @Test
+    void uniqueTarget_returnsRequestedNameWhenFree(@TempDir Path dir) {
+        Path target = PasteAttachmentHandler.Companion.uniqueTarget(dir, "screenshot.png");
+        assertEquals(dir.resolve("screenshot.png"), target);
+    }
+
+    @Test
+    void uniqueTarget_appendsSuffixOnCollision(@TempDir Path dir) throws Exception {
+        Files.createFile(dir.resolve("screenshot.png"));
+        Path target = PasteAttachmentHandler.Companion.uniqueTarget(dir, "screenshot.png");
+        assertEquals(dir.resolve("screenshot-1.png"), target);
+    }
+
+    @Test
+    void uniqueTarget_incrementsSuffixUntilFree(@TempDir Path dir) throws Exception {
+        Files.createFile(dir.resolve("file.bin"));
+        Files.createFile(dir.resolve("file-1.bin"));
+        Files.createFile(dir.resolve("file-2.bin"));
+        Path target = PasteAttachmentHandler.Companion.uniqueTarget(dir, "file.bin");
+        assertEquals(dir.resolve("file-3.bin"), target);
+    }
+
+    @Test
+    void uniqueTarget_handlesNamesWithoutExtension(@TempDir Path dir) throws Exception {
+        Files.createFile(dir.resolve("README"));
+        Path target = PasteAttachmentHandler.Companion.uniqueTarget(dir, "README");
+        assertEquals(dir.resolve("README-1"), target);
+    }
+
+    @Test
+    void uniqueTarget_sanitizesUnsafeCharacters(@TempDir Path dir) {
+        Path target = PasteAttachmentHandler.Companion.uniqueTarget(dir, "weird name?*.png");
+        assertEquals(dir.resolve("weird_name__.png"), target);
+    }
+
+    @Test
+    void uniqueTarget_fallsBackToPastedForEmptyName(@TempDir Path dir) {
+        Path target = PasteAttachmentHandler.Companion.uniqueTarget(dir, "");
+        assertEquals(dir.resolve("pasted"), target);
+    }
+}


### PR DESCRIPTION
## What

Pasting non-text clipboard content into the chat prompt now produces the same inline attachment chip UX as text snippets.

- **Raster images** (clipboard `imageFlavor`, e.g. screenshots): saved as PNG to `<storage>/pastes/screenshot-<ts>.png` and sent to the agent as an inline base64 `ContentBlock.Image`.
- **Other files** (clipboard `javaFileListFlavor` from a file manager): copied into `<storage>/pastes/` and sent as `ContentBlock.Resource` links with detected MIME types. Image-typed files get the IMAGE chip rendering.
- **Text** behaviour is **unchanged** — smart-paste / paste-to-scratch / project-source detection still wins.

## How

- New \`PasteAttachmentHandler\` with pure helpers (\`encodeAsPng\`, \`toBufferedImage\`, \`uniqueTarget\`) covered by unit tests.
- \`ContextItemData\` gains \`attachmentKind\` (\`TEXT\` / \`IMAGE\` / \`BINARY\`); the constructor is annotated \`@JvmOverloads\` so existing Java callers keep working.
- \`ContextChipRenderer\` draws a leading \`AllIcons.FileTypes.Image\` / \`Any_type\` icon for non-text chips so users can distinguish them at a glance.
- \`PromptContextManager\` exposes \`buildPromptAttachments()\` returning a sealed \`PromptAttachment\` hierarchy (\`TextRef\` / \`ImageRef\` / \`BinaryRef\`); the legacy \`buildContextReferences\` path is preserved.
- \`PromptOrchestrator\` emits the right ACP block per attachment kind. For agents whose \`AgentProfile.isSendResourceReferences\` is \`false\`, it falls back to text-only and prints a console warning saying the binary attachments were dropped.

## Tests

- New \`PasteAttachmentHandlerTest\` (PNG round-trip via \`ImageIO\`, \`BufferedImage\` passthrough, \`uniqueTarget\` collision suffixing, sanitisation, empty-name fallback).
- Existing \`PromptBubbleBuilderTest\` / \`ContextTextUtilsTest\` continue to pass (the \`@JvmOverloads\` keeps the old 6-arg \`ContextItemData\` constructor binary-compatible).
- Full \`Unit Tests\` Gradle task green except for one pre-existing flake (\`EmbeddingServiceTest.disposeClosesOpenSafetensorsReader\`, unrelated to this change).

## Open questions

- No size limit on pasted images today — a 4K screenshot can be several MB of base64 in the prompt. If we hit transport limits we can scale or warn.
- Files in \`<storage>/pastes/\` persist forever. A TTL/cleanup pass can be added later.