### PR TITLE
fix(memory): preserve inline code; reject leading-punct objects

### DIFF
--- a/docs/MEMORY-IMPROVEMENTS.md
+++ b/docs/MEMORY-IMPROVEMENTS.md
@@ -282,3 +282,94 @@ Phase 3 and 4 improve recall and context quality. Phase 5 and 6 are refinements.
 
 After each phase, re-mine history and compare drawer/triple quality against a
 baseline sample to validate improvement.
+
+---
+
+## Audit (April 2026)
+
+A follow-up audit of the live memory store revealed that **most of this plan has
+been implemented** across commits `a74f9fc`, `60e808a`, `647bba9`, and
+`d900b44`, but the live database (1 drawer + 1 triple, both garbage) showed two
+specific extraction bugs were still actively producing nonsense output, plus one
+config value was filtering out too many real exchanges.
+
+### Status of original phases
+
+| Phase | Item | Status |
+|-------|------|--------|
+| 1 | Agent narration filter | ✅ `NarrationFilter.java` (11 pattern groups) |
+| 1 | Tool-evidence separation | ✅ `ExchangeChunker.appendToolResultEvidence` only emits `[tool:NAME file:PATH]` markers |
+| 2 | Negation guard on triples | ✅ `TripleExtractor.NEGATION_PATTERN` |
+| 2 | Object trimming + word caps | ✅ `MAX_OBJECT_WORDS=8`, leading/trailing weak-word trim |
+| 2 | Cross-run dedup on KG insert | ✅ `KnowledgeGraph.existsValidTriple` + compound `idx_spo_valid` |
+| 3 | Markdown stripping before embedding | ✅ `TextPreprocessor.forEmbedding` |
+| 3 | Response-first ordering for embedding | ✅ `forEmbedding` emits `response \n\n prompt` |
+| 4 | Wake-up room diversity | ✅ `MemoryStore.getTopDrawersDiverse` round-robins by room |
+| 4 | Smarter snippets (skip echoed prompt) | ⏳ Deferred — content-truncation in `EssentialStoryLayer` still naive |
+| 5 | Confidence threshold + weighted keywords | ✅ `MIN_CONFIDENCE=2`, multi-word patterns score 2 |
+| 6 | Schema rename `source_closet → source_drawer` | ✅ Migration in `KnowledgeGraph.migrateSchema` |
+| 6 | Compound `(s,p,o,valid_until)` index | ✅ `idx_spo_valid` |
+| 6 | Length-aware dedup threshold | ⏳ Deferred — fixed `0.9` similarity used for all lengths |
+
+### Bugs found in the live store and fixed in this audit
+
+**Live evidence (before fixes):**
+- Single drawer, body fragment: `"with reports single-line preferred width before layout..."`  
+  — note the missing subject. The actual sentence was about
+  `JLabel.getPreferredSize()`, but the inline-code spans containing the class and
+  method names were stripped to a single space, deleting all the technical
+  vocabulary.
+- Single triple: `agentbridge → depends-on → ") the text wraps but is clipped"`  
+  — leading `)` is residue from the same code-stripping step; it survived
+  because the object-quality check only inspected the first *cleaned* word, which
+  became empty after punctuation was scrubbed, and the loop fell through and
+  accepted the object anyway.
+
+#### Bug 1 — Inline code spans were nuked, not unwrapped
+
+`TextPreprocessor.stripMarkdown` replaced ``` `inline code` ``` with a single
+space. In developer conversations, inline code spans almost always contain
+class/method/field/file names — the substantive technical vocabulary. Stripping
+the contents leaves sentences full of holes and makes the preprocessed text
+useless both for embedding and for triple extraction.
+
+**Fix:** `result.replaceAll("`([^`\\n]+)`", "$1")` — drop only the backticks,
+keep the contents. Fenced code blocks (``` ``` ```) are still removed entirely
+since their bodies are multi-line code, not prose.
+
+#### Bug 2 — Object-quality check accepted leading punctuation
+
+`TripleExtractor.cleanObject` stripped trailing `[.,:;!?]+` but not leading
+non-word characters, so an object like `") the text wraps"` passed through.
+`isQualityObject` then computed `firstCleaned = words[0].replaceAll("[^a-z]", "")`
+and only rejected if `firstCleaned` was a known weak word — when `firstCleaned`
+was empty (because `words[0]` was pure punctuation) the check fell through and
+the object was accepted as long as at least one later word was substantive.
+
+**Fix (two parts):**
+1. `cleanObject` now strips `^[^\\p{L}\\p{N}]+` before the existing trailing
+   strip.
+2. `isQualityObject` now hard-rejects when `firstCleaned.isEmpty()`. This
+   eliminates objects starting with `)`, `}`, `-`, `>`, etc.
+
+#### Tuning — `QualityFilter.MAX_COMBINED_LENGTH` raised 4000 → 8000
+
+The 4000-char ceiling on combined prompt+response length was too tight for real
+engineering exchanges and was a likely contributor to the "1 drawer per session"
+yield observed in the live store. 8000 still excludes multi-page transcript
+dumps but accommodates detailed technical Q&A.
+
+### Remaining deferred work
+
+- **Smarter wake-up snippets** (Phase 4) — `EssentialStoryLayer` still truncates
+  drawer content from the start, which often shows the user prompt rather than
+  the response. Could detect the prompt prefix and skip past the first
+  `\\n\\n` boundary.
+- **Length-aware dedup similarity threshold** (Phase 6) — a fixed `0.9` is
+  conservative for short drawers and too loose for long ones. Could scale by
+  drawer length.
+- **One-time DB cleanup migration** — invalidate any historical triple whose
+  object starts with non-letter characters. Not strictly required (the live
+  store was wiped manually as part of this audit), but worth adding for users
+  upgrading from a buggy build.
+

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractor.java
@@ -181,9 +181,13 @@ public final class TripleExtractor {
         String[] words = object.toLowerCase().split("[\\s-]+");
         if (words.length > MAX_OBJECT_WORDS) return false;
 
-        // Reject if the first word is a weak/generic word (article, preposition, pronoun)
+        // Reject if the first word starts with non-letter garbage (markdown
+        // residue, stray punctuation). The empty-firstCleaned case must be a
+        // hard reject — previously the loop fell through and accepted the
+        // object if any later word was non-stopword.
         String firstCleaned = words[0].replaceAll("[^a-z]", "");
-        if (!firstCleaned.isEmpty() && LEADING_WEAK_WORDS.contains(firstCleaned)) return false;
+        if (firstCleaned.isEmpty()) return false;
+        if (LEADING_WEAK_WORDS.contains(firstCleaned)) return false;
 
         // Reject if ALL words are stopwords
         for (String word : words) {
@@ -249,7 +253,13 @@ public final class TripleExtractor {
     }
 
     private static @NotNull String cleanObject(@NotNull String raw) {
-        String cleaned = raw.replaceAll("[.,:;!?]+$", "").strip();
+        // Strip leading punctuation/symbols that are residue from markdown
+        // stripping (e.g., a trailing close-paren left after an inline code span
+        // was unwrapped) — without this, objects like ") the text wraps" pass
+        // through and pollute the KG.
+        String cleaned = raw.replaceAll("^[^\\p{L}\\p{N}]+", "")
+            .replaceAll("[.,:;!?]+$", "")
+            .strip();
         if (cleaned.length() > MAX_OBJECT_LENGTH) {
             int cutoff = cleaned.lastIndexOf(' ', MAX_OBJECT_LENGTH);
             if (cutoff > 30) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/QualityFilter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/QualityFilter.java
@@ -38,7 +38,7 @@ public final class QualityFilter {
      * knowledge. The threshold is generous enough to accommodate detailed technical
      * explanations but filters out multi-page transcript dumps.
      */
-    private static final int MAX_COMBINED_LENGTH = 4000;
+    private static final int MAX_COMBINED_LENGTH = 8000;
 
     /**
      * Minimum prompt length (chars) when the response is very long. Short prompts

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/TextPreprocessor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/TextPreprocessor.java
@@ -23,10 +23,13 @@ public final class TextPreprocessor {
      * are removed to prevent false pattern matches.
      */
     public static @NotNull String stripMarkdown(@NotNull String text) {
-        // Remove fenced code blocks entirely (content is code, not prose)
+        // Remove fenced code blocks entirely (content is multi-line code, not prose)
         String result = text.replaceAll("```[\\s\\S]*?```", " ");
-        // Remove inline code spans
-        result = result.replaceAll("`[^`]+`", " ");
+        // Unwrap inline code spans — keep the contents (typically class/method names),
+        // drop only the backticks. Stripping the contents leaves sentences full of
+        // holes ("the JLabel reports single-line ..." → "the reports single-line ...")
+        // which destroys the technical meaning of code-related discussions.
+        result = result.replaceAll("`([^`\\n]+)`", "$1");
         // Remove tool evidence brackets: [tool:...], [...result:...]
         result = result.replaceAll("\\[tool:[^]]*]", " ");
         result = result.replaceAll("\\[[^]]{0,40} result:[^]]*]", " ");

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractorTest.java
@@ -186,14 +186,16 @@ class TripleExtractorTest {
     }
 
     @Test
-    void inlineCodeIsRemoved() {
-        String text = "We use `HashMap<String, Object>` for caching.";
-        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
+    void inlineCodeContentIsPreserved() {
+        // Inline code spans are unwrapped (backticks dropped, contents kept)
+        // because they typically contain class/method/field names that are the
+        // substantive technical content of code-related discussions. Stripping
+        // the contents leaves sentences full of holes and destroys meaning.
+        String result = TripleExtractor.stripMarkdown("We use `HashMap<String, Object>` for caching.");
 
-        for (TripleExtractor.ExtractedTriple triple : triples) {
-            assertFalse(triple.object().contains("HashMap"),
-                "Extracted inline code content: " + triple.object());
-        }
+        assertTrue(result.contains("HashMap"),
+            "Inline code content should be preserved after backticks are unwrapped: " + result);
+        assertFalse(result.contains("`"), "Backticks should be removed: " + result);
     }
 
     @Test
@@ -315,6 +317,20 @@ class TripleExtractorTest {
         assertFalse(TripleExtractor.isQualityObject("cases | Shelve for later]"));
         assertFalse(TripleExtractor.isQualityObject("config [deprecated]"));
         assertFalse(TripleExtractor.isQualityObject("value > threshold"));
+    }
+
+    @Test
+    void rejectsObjectsStartingWithPunctuation() {
+        // Residue from markdown stripping (e.g., a stray close-paren left after
+        // an inline code span was unwrapped) used to sneak through because
+        // isQualityObject only checked the first cleaned word, which became
+        // empty after punctuation was scrubbed and the loop fell through.
+        assertFalse(TripleExtractor.isQualityObject(") the text wraps"),
+            "Object starting with ) should be rejected");
+        assertFalse(TripleExtractor.isQualityObject("} the closing brace"),
+            "Object starting with } should be rejected");
+        assertFalse(TripleExtractor.isQualityObject("- a dashed phrase"),
+            "Object starting with - should be rejected");
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/QualityFilterTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/QualityFilterTest.java
@@ -125,7 +125,7 @@ class QualityFilterTest {
     @Test
     void exceedsMaxCombinedLength_fails() {
         String longPrompt = "How should we structure the project?";
-        String longResponse = "x".repeat(4000);
+        String longResponse = "x".repeat(8100);
         assertFalse(filter.passes(longPrompt, longResponse));
     }
 


### PR DESCRIPTION
## Audit findings

After the substantial memory pipeline work that landed in commits a74f9fc, 60e808a, 647bba9, d900b44, the live memory store still produced **one garbage drawer + one nonsense triple per session**. Audit traced this to two extraction bugs and one over-tight length filter.

### Live evidence (before)

- Drawer body: `"with reports single-line preferred width before layout..."` — the actual sentence was about `JLabel.getPreferredSize()` but inline code spans were stripped out, removing all the technical vocabulary.
- Triple: `agentbridge → depends-on → ") the text wraps but is clipped"` — leading `)` is residue from inline-code stripping that the object-quality check failed to reject.

### Bugs fixed

**1. `TextPreprocessor.stripMarkdown` deleted inline code spans.** Now unwraps backticks and keeps the content. Fenced code blocks (multi-line) are still removed entirely.

**2. `TripleExtractor.cleanObject` only stripped trailing punctuation.** Now also strips leading non-letter/digit chars.

**3. `TripleExtractor.isQualityObject` silently accepted leading garbage.** When `firstCleaned` was empty (because `words[0]` was pure punctuation) the guard `!firstCleaned.isEmpty() && ...` made the loop fall through. Now hard-rejects empty `firstCleaned`.

### Tuning

`QualityFilter.MAX_COMBINED_LENGTH` raised **4000 → 8000**. The old ceiling was too tight for real engineering exchanges and was a likely contributor to the "one drawer per session" yield observed in the live store.

## Tests

- `TextPreprocessor` inline-code preservation (replaces the old `inlineCodeIsRemoved` assertion which was asserting the bug).
- `TripleExtractor` rejection of objects starting with `)`, `}`, `-`.
- `QualityFilter` boundary updated to 8100.
- Full suite: 8029 tests, no regressions related to this change.

## Docs

`docs/MEMORY-IMPROVEMENTS.md` gains an **Audit (April 2026)** section documenting:
- Phase-by-phase status of the original plan (~85% already done across earlier commits)
- The three bugs above with before/after evidence
- Remaining deferred work (smarter wake-up snippets, length-aware dedup, optional one-time DB cleanup migration for users upgrading from a buggy build)

## Manual verification

Wiped local `.agentbridge/memory/` so the next mining run starts fresh on the fixed extractor.