### PR TITLE
feat(ask-user): visible countdown and "I need more time" button

### DIFF
--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -626,7 +626,7 @@ const ChatController = {
         this._container()?.scheduleScrollIfNeeded();
     },
 
-    showAskUserRequest(turnId: string, agentId: string, reqId: string, question: string, options: string[]): void {
+    showAskUserRequest(turnId: string, agentId: string, reqId: string, question: string, options: string[], deadlineEpochMs: number): void {
         this.disableQuickReplies();
         const ctx = this._ensureMsg(turnId, agentId);
         this._collapseThinkingFor(ctx);
@@ -638,6 +638,32 @@ const ChatController = {
             if (i > 0) bubble.appendChild(document.createElement('br'));
             bubble.appendChild(document.createTextNode(line));
         });
+
+        // Countdown row + "I need more time" extension button.
+        const countdownRow = document.createElement('div');
+        countdownRow.className = 'ask-countdown';
+        countdownRow.dataset.reqId = reqId;
+        countdownRow.dataset.deadlineMs = String(deadlineEpochMs);
+
+        const countdownLabel = document.createElement('span');
+        countdownLabel.className = 'ask-countdown-label';
+        countdownLabel.textContent = '⏱';
+        countdownRow.appendChild(countdownLabel);
+
+        const remainingSpan = document.createElement('span');
+        remainingSpan.className = 'ask-remaining';
+        countdownRow.appendChild(remainingSpan);
+
+        const extendBtn = document.createElement('button');
+        extendBtn.type = 'button';
+        extendBtn.className = 'ask-extend';
+        extendBtn.textContent = 'I need more time';
+        extendBtn.onclick = () => (globalThis as any)._bridge?.extendAskUser(reqId);
+        countdownRow.appendChild(extendBtn);
+
+        bubble.appendChild(document.createElement('br'));
+        bubble.appendChild(countdownRow);
+
         ctx.msg!.appendChild(bubble);
 
         if (options?.length) {
@@ -647,12 +673,76 @@ const ChatController = {
             ctx.msg!.appendChild(replies);
         }
 
+        this._startAskUserCountdown(reqId);
+
         this._container()?.scheduleScrollIfNeeded();
         const notificationWithActions = Notification as typeof Notification & { readonly maxActions?: number };
         const actions = options?.length
             ? options.slice(0, notificationWithActions.maxActions ?? 2).map(o => ({action: o, title: o}))
             : undefined;
         _showNotification('Agent is asking you something', question, actions?.length ? actions : undefined);
+    },
+
+    /**
+     * Backend reset the deadline (user clicked "I need more time" and Java extended it by 120s).
+     * Find the countdown row, write the new deadline; the existing interval picks it up next tick.
+     */
+    updateAskUserDeadline(reqId: string, deadlineEpochMs: number): void {
+        const row = document.querySelector<HTMLElement>(`.ask-countdown[data-req-id="${CSS.escape(reqId)}"]`);
+        if (!row) return;
+        row.dataset.deadlineMs = String(deadlineEpochMs);
+        row.classList.remove('ask-countdown--warn', 'ask-countdown--danger');
+        // Render once immediately so the user sees their click had effect (don't wait for next interval tick).
+        this._renderAskUserRemaining(row);
+    },
+
+    /**
+     * Backend has terminated the request (answered, timed out, or cancelled). Stop the interval,
+     * hide the extension button, and visually retire the countdown.
+     */
+    closeAskUserRequest(reqId: string, status: string): void {
+        const row = document.querySelector<HTMLElement>(`.ask-countdown[data-req-id="${CSS.escape(reqId)}"]`);
+        if (!row) return;
+        const intervalId = Number(row.dataset.intervalId ?? '0');
+        if (intervalId) clearInterval(intervalId);
+        row.dataset.intervalId = '';
+        row.classList.add('ask-countdown--closed');
+        const btn = row.querySelector<HTMLButtonElement>('.ask-extend');
+        if (btn) btn.style.display = 'none';
+        const remaining = row.querySelector<HTMLElement>('.ask-remaining');
+        if (remaining) {
+            if (status === 'answered') remaining.textContent = '';
+            else if (status === 'cancelled') remaining.textContent = '(cancelled)';
+            else if (status === 'timed_out') remaining.textContent = '(timed out)';
+        }
+    },
+
+    _startAskUserCountdown(reqId: string): void {
+        const row = document.querySelector<HTMLElement>(`.ask-countdown[data-req-id="${CSS.escape(reqId)}"]`);
+        if (!row) return;
+        this._renderAskUserRemaining(row);
+        const intervalId = globalThis.setInterval(() => {
+            const stillThere = document.querySelector<HTMLElement>(`.ask-countdown[data-req-id="${CSS.escape(reqId)}"]`);
+            if (!stillThere || stillThere.classList.contains('ask-countdown--closed')) {
+                clearInterval(intervalId);
+                return;
+            }
+            this._renderAskUserRemaining(stillThere);
+        }, 1000);
+        row.dataset.intervalId = String(intervalId);
+    },
+
+    _renderAskUserRemaining(row: HTMLElement): void {
+        const deadline = Number(row.dataset.deadlineMs ?? '0');
+        const remainMs = Math.max(0, deadline - Date.now());
+        const remainSec = Math.ceil(remainMs / 1000);
+        const span = row.querySelector<HTMLElement>('.ask-remaining');
+        if (!span) return;
+        const mm = Math.floor(remainSec / 60);
+        const ss = remainSec % 60;
+        span.textContent = `${mm}:${ss.toString().padStart(2, '0')}`;
+        row.classList.toggle('ask-countdown--danger', remainSec <= 10);
+        row.classList.toggle('ask-countdown--warn', remainSec > 10 && remainSec <= 30);
     },
 
     showQuickReplies(options: string[]): void {

--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -1168,6 +1168,64 @@ hr {
     pointer-events: none;
 }
 
+/* ── Ask-user countdown ────────────────────────────────── */
+
+.ask-countdown {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--sp-2);
+    margin-top: var(--sp-2);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    color: var(--fg-muted);
+    background: var(--think-a08);
+    transition: color 0.2s, background 0.2s;
+}
+
+.ask-countdown-label {
+    opacity: 0.8;
+}
+
+.ask-remaining {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    min-width: 3em;
+}
+
+.ask-extend {
+    margin-left: var(--sp-2);
+    padding: 2px 8px;
+    font-size: 0.9em;
+    background: transparent;
+    color: var(--user);
+    border: 1px solid var(--user);
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.ask-extend:hover {
+    background: var(--user-a16);
+}
+
+.ask-countdown--warn {
+    color: #d49a00;
+    background: rgba(212, 154, 0, 0.12);
+}
+
+.ask-countdown--danger {
+    color: #d04545;
+    background: rgba(208, 69, 69, 0.16);
+}
+
+.ask-countdown--closed .ask-extend {
+    display: none;
+}
+
+.ask-countdown--closed {
+    opacity: 0.6;
+}
+
 /* ── Permission request ────────────────────────────────── */
 
 .perm-actions {

--- a/plugin-core/chat-ui/src/index.ts
+++ b/plugin-core/chat-ui/src/index.ts
@@ -48,8 +48,14 @@ globalThis.ChatController = ChatController;
 (globalThis as any).showPermissionRequest = (turnId: string, agentId: string, reqId: string, toolDisplayName: string, argsJson: string) => {
     ChatController.showPermissionRequest(turnId, agentId, reqId, toolDisplayName, argsJson);
 };
-(globalThis as any).showAskUserRequest = (turnId: string, agentId: string, reqId: string, question: string, options: string[]) => {
-    ChatController.showAskUserRequest(turnId, agentId, reqId, question, options);
+(globalThis as any).showAskUserRequest = (turnId: string, agentId: string, reqId: string, question: string, options: string[], deadlineEpochMs: number) => {
+    ChatController.showAskUserRequest(turnId, agentId, reqId, question, options, deadlineEpochMs);
+};
+(globalThis as any).updateAskUserDeadline = (reqId: string, deadlineEpochMs: number) => {
+    ChatController.updateAskUserDeadline(reqId, deadlineEpochMs);
+};
+(globalThis as any).closeAskUserRequest = (reqId: string, status: string) => {
+    ChatController.closeAskUserRequest(reqId, status);
 };
 
 // ── Global event handlers ─────────────────────────────

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/AskUserTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/AskUserTool.java
@@ -29,7 +29,7 @@ public final class AskUserTool extends InfrastructureTool {
 
     private static final String PARAM_QUESTION = "question";
     private static final String PARAM_OPTIONS = "options";
-    private static final int RESPONSE_TIMEOUT_SECONDS = 120;
+    private static final long RESPONSE_TIMEOUT_MS = 120_000L;
 
     public AskUserTool(Project project) {
         super(project);
@@ -91,18 +91,39 @@ public final class AskUserTool extends InfrastructureTool {
         notifyIfUnfocused(question);
 
         CompletableFuture<String> responseFuture = new CompletableFuture<>();
+        // Deadline is shared mutable state — written by the EDT extend handler, read by this pooled thread.
+        // System.currentTimeMillis() is used (not nanoTime) so JS and Java agree on the absolute deadline.
+        final long[] deadlineMs = {System.currentTimeMillis() + RESPONSE_TIMEOUT_MS};
         String reqId = UUID.randomUUID().toString();
+
         EdtUtil.invokeLater(() ->
-            panel.showAskUserRequest(reqId, question, options, response -> {
-                responseFuture.complete(response);
-                return kotlin.Unit.INSTANCE;
-            })
+            panel.showAskUserRequest(
+                reqId,
+                question,
+                options,
+                deadlineMs[0],
+                response -> {
+                    responseFuture.complete(response);
+                    return kotlin.Unit.INSTANCE;
+                },
+                () -> {
+                    // Backend always controls the extension amount — never trust the client.
+                    long newDeadline = System.currentTimeMillis() + RESPONSE_TIMEOUT_MS;
+                    deadlineMs[0] = newDeadline;
+                    return newDeadline;
+                },
+                () -> {
+                    // Superseded (a newer ask_user replaced this one) or panel cleared.
+                    if (!responseFuture.isDone()) {
+                        responseFuture.complete("__cancelled__");
+                    }
+                    return kotlin.Unit.INSTANCE;
+                }
+            )
         );
 
         try {
-            return responseFuture.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        } catch (TimeoutException e) {
-            return "Error: user response timed out";
+            return awaitWithExtensibleDeadline(responseFuture, deadlineMs);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return "Error: ask-user request interrupted";
@@ -110,6 +131,34 @@ public final class AskUserTool extends InfrastructureTool {
             return "Error: failed to read user response";
         } finally {
             EdtUtil.invokeLater(() -> panel.clearPendingAskUserRequest(reqId));
+        }
+    }
+
+    /**
+     * Wait for {@code future} to complete, retrying on TimeoutException so that deadline extensions
+     * made by the user via the "I need more time" button are picked up by the wait loop.
+     *
+     * @param deadlineMs single-element array used as a writable shared cell; index 0 holds the
+     *                   absolute epoch-millis deadline that the EDT extend handler updates.
+     */
+    private static @NotNull String awaitWithExtensibleDeadline(
+        @NotNull CompletableFuture<String> future,
+        long @NotNull [] deadlineMs
+    ) throws InterruptedException, ExecutionException {
+        while (true) {
+            long remaining = deadlineMs[0] - System.currentTimeMillis();
+            if (remaining <= 0) {
+                return "Error: user response timed out";
+            }
+            try {
+                String result = future.get(remaining, TimeUnit.MILLISECONDS);
+                if ("__cancelled__".equals(result)) {
+                    return "Error: ask-user request cancelled (superseded by another request)";
+                }
+                return result;
+            } catch (TimeoutException ignored) {
+                // Deadline may have been extended in flight — re-check the loop condition.
+            }
         }
     }
 
@@ -161,7 +210,7 @@ public final class AskUserTool extends InfrastructureTool {
         });
 
         try {
-            String answer = response.get(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            String answer = response.get(RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
             if (answer.isEmpty()) {
                 return "Error: user cancelled";
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -121,10 +121,17 @@ class ChatConsolePanel(
     private var htmlPageFuture: java.util.concurrent.CompletableFuture<String>? = null
     private val pendingPermissionCallbacks =
         java.util.concurrent.ConcurrentHashMap<String, (PermissionResponse) -> Unit>()
-    private val pendingAskUserCallbacks = java.util.concurrent.ConcurrentHashMap<String, (String) -> Unit>()
+
+    private data class ActiveAskUser(
+        val reqId: String,
+        val onRespond: (String) -> Unit,
+        val onExtend: () -> Long,
+        val onSuperseded: () -> Unit,
+    )
 
     @Volatile
-    private var activeAskUserRequestId: String? = null
+    private var activeAskUser: ActiveAskUser? = null
+    private var extendAskUserBridgeJs = ""
 
     // CEF windowless frame rate — high during streaming and active user scroll, moderate when idle.
     // 10fps was too aggressive — caused stale-frame tearing during manual scroll.
@@ -279,6 +286,11 @@ class ChatConsolePanel(
             scrollEndedQuery.addHandler { endScrollFrameRateBoost(); null }
             Disposer.register(this, scrollEndedQuery)
             scrollEndedBridgeJs = scrollEndedQuery.inject("''")
+
+            val extendAskUserQuery = JBCefJSQuery.create(browser as com.intellij.ui.jcef.JBCefBrowserBase)
+            extendAskUserQuery.addHandler { reqId -> handleExtendAskUser(reqId); null }
+            Disposer.register(this, extendAskUserQuery)
+            extendAskUserBridgeJs = extendAskUserQuery.inject("reqId")
 
             setFrameRate(IDLE_FRAME_RATE)
 
@@ -1560,42 +1572,62 @@ class ChatConsolePanel(
         reqId: String,
         question: String,
         options: List<String>,
-        onRespond: (String) -> Unit
+        deadlineEpochMs: Long,
+        onRespond: (String) -> Unit,
+        onExtend: () -> Long,
+        onSuperseded: () -> Unit,
     ) {
-        clearPendingAskUserRequest(null)
-        pendingAskUserCallbacks[reqId] = onRespond
-        activeAskUserRequestId = reqId
+        // If a previous ask is still open, supersede it cleanly so its waiter unblocks.
+        activeAskUser?.let { prev ->
+            activeAskUser = null
+            disableQuickReplies()
+            // Fire callback off-EDT — onSuperseded typically completes a CompletableFuture;
+            // we don't want to do that under invokeLater chains that might re-enter the panel.
+            ApplicationManager.getApplication().executeOnPooledThread { prev.onSuperseded() }
+        }
+        activeAskUser = ActiveAskUser(reqId, onRespond, onExtend, onSuperseded)
 
         val safeId = escJs(reqId)
         val safeQuestion = escJs(question)
         val optionJson = options.joinToString(",") { "'${escJs(it)}'" }
         val turnId = currentTurnId.ifEmpty { "t${turnCounter++}".also { currentTurnId = it } }
-        executeJs("window.showAskUserRequest('$turnId','main','$safeId','$safeQuestion',[$optionJson]);")
+        executeJs(
+            "window.showAskUserRequest('$turnId','main','$safeId','$safeQuestion',[$optionJson],$deadlineEpochMs);"
+        )
         ChatWebServer.getInstance(project)?.pushNotification("Agent needs your input", question.take(100))
     }
 
-    override fun hasPendingAskUserRequest(): Boolean = activeAskUserRequestId != null
+    override fun hasPendingAskUserRequest(): Boolean = activeAskUser != null
 
     override fun consumePendingAskUserResponse(response: String): Boolean {
-        val reqId = activeAskUserRequestId ?: return false
         if (response.isBlank()) return false
-
-        val callback = pendingAskUserCallbacks.remove(reqId) ?: return false
-        activeAskUserRequestId = null
+        val active = activeAskUser ?: return false
+        activeAskUser = null
         disableQuickReplies()
+        // Tell JS to retire the countdown / extension button for this request.
+        executeJs("window.closeAskUserRequest && window.closeAskUserRequest('${escJs(active.reqId)}','answered');")
         addPromptEntry(response, null)
-        callback.invoke(response)
+        active.onRespond(response)
         return true
     }
 
     override fun clearPendingAskUserRequest(reqId: String?) {
-        val activeId = activeAskUserRequestId
-        if (reqId != null && activeId != null && reqId != activeId) return
-        if (activeId != null) {
-            pendingAskUserCallbacks.remove(activeId)
-        }
-        activeAskUserRequestId = null
+        val active = activeAskUser ?: return
+        if (reqId != null && reqId != active.reqId) return
+        activeAskUser = null
         disableQuickReplies()
+        executeJs("window.closeAskUserRequest && window.closeAskUserRequest('${escJs(active.reqId)}','cancelled');")
+        ApplicationManager.getApplication().executeOnPooledThread { active.onSuperseded() }
+    }
+
+    /** Called from the JS "I need more time" button via the [extendAskUserBridgeJs] bridge. */
+    private fun handleExtendAskUser(reqId: String) {
+        val active = activeAskUser ?: return
+        if (reqId != active.reqId) return
+        val newDeadline = active.onExtend()
+        executeJs(
+            "window.updateAskUserDeadline && window.updateAskUserDeadline('${escJs(active.reqId)}',$newDeadline);"
+        )
     }
 
     override fun showNudgeBubble(id: String, text: String) {
@@ -1906,7 +1938,8 @@ class ChatConsolePanel(
                 autoScrollDisabled: function() { $autoScrollDisabledBridgeJs },
                 autoScrollEnabled: function() { $autoScrollEnabledBridgeJs },
                 scrollStarted: function() { $scrollStartedBridgeJs },
-                scrollEnded: function() { $scrollEndedBridgeJs }
+                scrollEnded: function() { $scrollEndedBridgeJs },
+                extendAskUser: function(reqId) { $extendAskUserBridgeJs }
             };
         """.trimIndent()
         val css = loadResource("/chat/chat.css")

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatPanelApi.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatPanelApi.kt
@@ -152,12 +152,22 @@ interface ChatPanelApi : Disposable {
 
     /**
      * Show an ask-user bubble with quick-reply options. The user can also type a free-form response.
+     *
+     * The bubble renders a live countdown (driven by [deadlineEpochMs]) and an
+     * "I need more time" button. When the user clicks that button, [onExtend] is invoked;
+     * the new deadline it returns is pushed back to the JS countdown.
+     *
+     * If a previous ask-user request is still open, its [onSuperseded] is invoked so the
+     * tool that issued it can complete its waiter (typically with a "cancelled" terminal state).
      */
     fun showAskUserRequest(
         reqId: String,
         question: String,
         options: List<String>,
-        onRespond: (String) -> Unit
+        deadlineEpochMs: Long,
+        onRespond: (String) -> Unit,
+        onExtend: () -> Long,
+        onSuperseded: () -> Unit,
     )
 
     fun hasPendingAskUserRequest(): Boolean


### PR DESCRIPTION
The MCP `ask_user` tool previously blocked silently for 120s and gave the
user no feedback about how long they had left. If they took too long
thinking about their answer, the question would silently time out.

## Changes

**UI** — Visible countdown row inside the question bubble:
- Shows remaining time (mm:ss), updated every second from a JS interval reading `data-deadline-ms` (no drift if browser pauses).
- Turns amber under 30s, red under 10s.
- "I need more time" button extends deadline by another 120s via a new `extendAskUserBridgeJs` JCEF query.
- When answered/superseded/timed-out the countdown switches to a closed terminal-state and the extend button is hidden.

**Backend** — `AskUserTool.execute()`:
- Replaces fixed `future.get(120s)` with a deadline-loop that re-reads a shared `long[] deadlineMs` cell each iteration.
- Extracted helper `awaitWithExtensibleDeadline` keeps cognitive complexity ≤ 15.
- Deadline is absolute epoch ms so JS and Java agree on one scalar.
- A new ask-user request supersedes any prior open one — the prior future completes with `__cancelled__` sentinel and the tool returns \`Error: ask-user request cancelled (superseded by another request)\`.

**Panel** — `ChatPanelApi.showAskUserRequest` gains `deadlineEpochMs`, `onRespond`, `onExtend: () -> Long`, `onSuperseded: () -> Unit` callbacks. This avoids creating a new \`ui → psi.tools\` dependency. \`ChatConsolePanel\` tracks the active request in a private \`ActiveAskUser\` data class. The \`onSuperseded\` callback is invoked off-EDT via \`executeOnPooledThread\` so completing the future doesn't reenter the panel under \`invokeLater\`.

**JS** (`ChatController.ts`, `index.ts`) — New globals \`updateAskUserDeadline(reqId, ms)\` and \`closeAskUserRequest(reqId, terminalText)\` exposed for Kotlin. \`_startAskUserCountdown\` self-clears on \`--closed\` class.

**CSS** — Adds \`.ask-countdown\`, \`.ask-countdown-label\`, \`.ask-remaining\`, \`.ask-extend\`, \`.ask-countdown--warn\`, \`.ask-countdown--danger\`, \`.ask-countdown--closed\` using existing theme vars (\`--fg-muted\`, \`--user\`, \`--user-a16\`, \`--think-a08\`).

## Verification
- `agentbridge-build_project` → 0 errors, 0 warnings.
- `npm run build` in chat-ui regenerates `chat-components.js` — passes.
- JS tests fail locally only due to a pre-existing Node 20 vs Node 22 \`styleText\` import issue in the bundled rolldown — unrelated to this change; CI uses a newer Node.