### PR TITLE
fix: prevent follow-agent tool focus steals

### DIFF
--- a/docs/BRANCH-USAGE-STATS.md
+++ b/docs/BRANCH-USAGE-STATS.md
@@ -1,0 +1,21 @@
+# Branch usage statistics
+
+The Usage Statistics panel can group turn costs by Git branch to give a rough "cost of a feature" view. This is intended for comparing feature branches against each other, not for exact accounting.
+
+## How branch attribution works
+
+For each completed turn, AgentBridge records these values in the local usage-statistics database:
+
+- `git_branch_start`: the branch checked out when the turn began.
+- `git_branch_end`: the branch checked out when the turn completed.
+- `git_branch`: the branch used for the branch chart.
+
+The chart attribution prefers the end branch because agents often start on a default branch, create or checkout a feature branch during the turn, and finish there. If the end branch is missing or is a default branch (`main` or `master`), AgentBridge falls back to the start branch. If neither branch is available, the turn is counted as unattributed and excluded from branch totals.
+
+## Why this is approximate
+
+Branch tracking is sampled at turn start and turn end. AgentBridge does not currently record every intermediate checkout that may happen during a turn, because that would require additional VCS event tracking or parsing Git reflog messages. The start/end model keeps recording lightweight while avoiding the most misleading case: work that starts on `master` but ends on a feature branch.
+
+## What the chart includes
+
+Branch totals include turns recorded after branch tracking is available. Older turns, detached HEAD states, non-Git projects, or failed Git branch detection can appear as unattributed. The UI shows the number of unattributed turns so totals can be interpreted in context.

--- a/docs/bugs/FOCUS-STEALING-BUG.md
+++ b/docs/bugs/FOCUS-STEALING-BUG.md
@@ -508,9 +508,35 @@ flag **and** a *request focus / autoFocusContent* flag — they must be gated **
 
 ---
 
+### Attempt 14: Fix FocusGuard chat-boundary fallback
+
+**Problem**: User reported that `git`, `run_command`, and `run_in_terminal` still stole focus
+while typing in the chat prompt with Follow Agent enabled, even after the per-tool `show()` /
+`activate()` and focus-flag guards above.
+
+**Root cause**: `FocusGuard.isInsideChatToolWindow()` had a fallback for JCEF edge cases that
+treated any component in the same IDE main frame as "inside chat":
+
+```java
+ownerWindow == twWindow && SwingUtilities.isDescendingFrom(twRoot, ownerWindow)
+```
+
+Because the AgentBridge tool window root is itself a descendant of the IDE frame, this condition
+was true for sibling tool-window/editor components too. As a result, the veto path allowed focus
+changes into VCS, Terminal, and Run content as if they were chat-internal focus changes.
+
+**Fix**: Restrict chat-boundary detection to the actual AgentBridge component hierarchy
+(`comp == chatRoot || SwingUtilities.isDescendingFrom(comp, chatRoot)`) and remove the same-frame
+fallback. This restores the guard's intended behavior: programmatic focus moves to sibling tool
+windows in the IDE frame are vetoed, while focus moves within the chat UI are allowed.
+
+**Files**: `FocusGuard.java`, `FocusGuardTest.java`.
+
+---
+
 ## Remaining Root Causes
 
-_All previously documented root causes (RC1–RC4) have been fixed. See Attempts 1–10 below._
+_All previously documented root causes (RC1–RC4) have been fixed. See Attempts 1–14 above._
 
 ---
 
@@ -533,7 +559,7 @@ _All previously documented root causes (RC1–RC4) have been fixed. See Attempts
 | `PsiBridgeService.java`    | 321  | ✅ `chatWasActive` captured at start, completion re-checks                                                                                                    |
 | `PsiBridgeService.java`    | 469  | ✅ Focus restore requires both start+end active                                                                                                               |
 | `ChatToolWindowContent.kt` | 165  | ✅ 150ms alarm checks chat-active before firing                                                                                                               |
-| `FocusGuard.java`          | all  | ✅ `VetoableChangeListener` vetoes programmatic focus steals; targeted to same-Window only; circuit breaker at 20 vetoes; synchronous EDT uninstall via latch |
+| `FocusGuard.java`          | all  | ✅ `VetoableChangeListener` vetoes programmatic focus steals to sibling editor/tool-window components; targeted to same-Window only; circuit breaker at 20 vetoes; synchronous EDT uninstall via latch |
 | `FileTool.java`            | 257  | ✅ `navigate(focus)` check is inside `invokeLater`                                                                                                            |
 | `FileTool.java`            | 286  | ✅ `selectInProjectView` skips if chat active; only scrolls if already open                                                                                   |
 | `GitTool.java`             | 400  | ✅ VCS `show()`/`activate()` check is inside `invokeLater`                                                                                                    |

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/FocusGuard.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/FocusGuard.java
@@ -256,16 +256,13 @@ final class FocusGuard implements java.beans.VetoableChangeListener {
             // tw.getComponent() is @NotNull but we keep the defensive check — runtime ≠ compile-time.
             //noinspection ConstantValue
             if (twRoot == null) return false;
-            if (SwingUtilities.isDescendingFrom(comp, twRoot)) return true;
-
-            // JCEF browser components live in a separate heavyweight window; fall back to
-            // comparing the root window of the focus owner with the tool window's window.
-            Window ownerWindow = SwingUtilities.getWindowAncestor(comp);
-            Window twWindow = SwingUtilities.getWindowAncestor(twRoot);
-            return ownerWindow != null && ownerWindow == twWindow
-                && SwingUtilities.isDescendingFrom(twRoot, ownerWindow);
+            return isInsideChatComponent(comp, twRoot);
         } catch (Exception e) {
             return false;
         }
+    }
+
+    static boolean isInsideChatComponent(Component comp, JComponent chatRoot) {
+        return comp == chatRoot || SwingUtilities.isDescendingFrom(comp, chatRoot);
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/AskUserTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/AskUserTool.java
@@ -2,11 +2,11 @@ package com.github.catatafishen.agentbridge.psi.tools.infrastructure;
 
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
 import com.github.catatafishen.agentbridge.ui.ChatConsolePanel;
-import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationType;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.wm.WindowManager;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/AskUserTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/AskUserTool.java
@@ -2,13 +2,13 @@ package com.github.catatafishen.agentbridge.psi.tools.infrastructure;
 
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
 import com.github.catatafishen.agentbridge.ui.ChatConsolePanel;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.MessageType;
 import com.intellij.openapi.ui.Messages;
-import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.WindowManager;
 import com.intellij.ui.AppIcon;
 import com.intellij.ui.SystemNotifications;
@@ -30,6 +30,7 @@ public final class AskUserTool extends InfrastructureTool {
     private static final String PARAM_QUESTION = "question";
     private static final String PARAM_OPTIONS = "options";
     private static final long RESPONSE_TIMEOUT_MS = 120_000L;
+    private static final String NOTIFICATION_GROUP_ID = "AgentBridge Notifications";
 
     public AskUserTool(Project project) {
         super(project);
@@ -96,31 +97,7 @@ public final class AskUserTool extends InfrastructureTool {
         final long[] deadlineMs = {System.currentTimeMillis() + RESPONSE_TIMEOUT_MS};
         String reqId = UUID.randomUUID().toString();
 
-        EdtUtil.invokeLater(() ->
-            panel.showAskUserRequest(
-                reqId,
-                question,
-                options,
-                deadlineMs[0],
-                response -> {
-                    responseFuture.complete(response);
-                    return kotlin.Unit.INSTANCE;
-                },
-                () -> {
-                    // Backend always controls the extension amount — never trust the client.
-                    long newDeadline = System.currentTimeMillis() + RESPONSE_TIMEOUT_MS;
-                    deadlineMs[0] = newDeadline;
-                    return newDeadline;
-                },
-                () -> {
-                    // Superseded (a newer ask_user replaced this one) or panel cleared.
-                    if (!responseFuture.isDone()) {
-                        responseFuture.complete("__cancelled__");
-                    }
-                    return kotlin.Unit.INSTANCE;
-                }
-            )
-        );
+        EdtUtil.invokeLater(() -> showAskUserRequestCompat(panel, reqId, question, options, deadlineMs, responseFuture));
 
         try {
             return awaitWithExtensibleDeadline(responseFuture, deadlineMs);
@@ -131,6 +108,71 @@ public final class AskUserTool extends InfrastructureTool {
             return "Error: failed to read user response";
         } finally {
             EdtUtil.invokeLater(() -> panel.clearPendingAskUserRequest(reqId));
+        }
+    }
+
+    /**
+     * Calls the ask-user panel API through reflection so Java compilation does not depend on
+     * javac understanding the Kotlin function-type signature. This has been observed to drift
+     * between the source model and the Java compiler stub view during incremental builds.
+     *
+     * <p>We prefer the new 7-argument API (deadline + extend + supersede callbacks). If the
+     * runtime class only exposes the older 4-argument ABI, we still show the prompt and keep
+     * the backend waiter functional, but deadline extension/supersede notifications are not
+     * available from that older contract.
+     */
+    private static void showAskUserRequestCompat(
+        @NotNull ChatConsolePanel panel,
+        @NotNull String reqId,
+        @NotNull String question,
+        @NotNull List<String> options,
+        long @NotNull [] deadlineMs,
+        @NotNull CompletableFuture<String> responseFuture
+    ) {
+        kotlin.jvm.functions.Function1<String, kotlin.Unit> onRespond = response -> {
+            responseFuture.complete(response);
+            return kotlin.Unit.INSTANCE;
+        };
+        kotlin.jvm.functions.Function0<Long> onExtend = () -> {
+            long newDeadline = System.currentTimeMillis() + RESPONSE_TIMEOUT_MS;
+            deadlineMs[0] = newDeadline;
+            return newDeadline;
+        };
+        kotlin.jvm.functions.Function0<kotlin.Unit> onSuperseded = () -> {
+            if (!responseFuture.isDone()) {
+                responseFuture.complete("__cancelled__");
+            }
+            return kotlin.Unit.INSTANCE;
+        };
+
+        try {
+            panel.getClass().getMethod(
+                "showAskUserRequest",
+                String.class,
+                String.class,
+                List.class,
+                long.class,
+                kotlin.jvm.functions.Function1.class,
+                kotlin.jvm.functions.Function0.class,
+                kotlin.jvm.functions.Function0.class
+            ).invoke(panel, reqId, question, options, deadlineMs[0], onRespond, onExtend, onSuperseded);
+            return;
+        } catch (NoSuchMethodException ignored) {
+            // Fall through to the older ABI below.
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to invoke ask-user panel API", e);
+        }
+
+        try {
+            panel.getClass().getMethod(
+                "showAskUserRequest",
+                String.class,
+                String.class,
+                List.class,
+                kotlin.jvm.functions.Function1.class
+            ).invoke(panel, reqId, question, options, onRespond);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to invoke legacy ask-user panel API", e);
         }
     }
 
@@ -182,9 +224,9 @@ public final class AskUserTool extends InfrastructureTool {
         if (frame == null || frame.isActive()) return;
         String title = "Agent Needs Your Input";
         String content = question.length() > 80 ? question.substring(0, 80) + "…" : question;
-        ToolWindowManager.getInstance(project)
-            .notifyByBalloon("AgentBridge", MessageType.INFO, "<b>" + title + "</b><br>" + content);
-        SystemNotifications.getInstance().notify("AgentBridge Notifications", title, content);
+        new Notification(NOTIFICATION_GROUP_ID, title, content, NotificationType.INFORMATION)
+            .notify(project);
+        SystemNotifications.getInstance().notify(NOTIFICATION_GROUP_ID, title, content);
         AppIcon.getInstance().requestAttention(project, false);
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -46,6 +46,7 @@ public final class ToolCallStatisticsService implements Disposable {
 
     private static final Logger LOG = Logger.getInstance(ToolCallStatisticsService.class);
     private static final String DB_FILENAME = "tool-stats.db";
+    private static final Set<String> DEFAULT_BRANCH_NAMES = Set.of("main", "master");
 
     private final Project project;
     private Connection connection;
@@ -196,6 +197,8 @@ public final class ToolCallStatisticsService implements Disposable {
                 "CREATE INDEX IF NOT EXISTS idx_turn_stats_session ON turn_stats(session_id)");
             migrateAddCommitHashesColumn(stmt);
             migrateAddGitBranchColumn(stmt);
+            migrateAddGitBranchStartColumn(stmt);
+            migrateAddGitBranchEndColumn(stmt);
         }
     }
 
@@ -242,6 +245,30 @@ public final class ToolCallStatisticsService implements Disposable {
         } catch (SQLException e) {
             if (e.getMessage() == null || !e.getMessage().contains("duplicate column")) {
                 LOG.warn("Unexpected error migrating turn_stats schema (git_branch column)", e);
+            }
+            // else: duplicate column — expected for databases that have already been migrated
+        }
+    }
+
+    private void migrateAddGitBranchStartColumn(java.sql.Statement stmt) {
+        try {
+            stmt.execute("ALTER TABLE turn_stats ADD COLUMN git_branch_start TEXT");
+            LOG.info("Migrated turn_stats table: added git_branch_start column");
+        } catch (SQLException e) {
+            if (e.getMessage() == null || !e.getMessage().contains("duplicate column")) {
+                LOG.warn("Unexpected error migrating turn_stats schema (git_branch_start column)", e);
+            }
+            // else: duplicate column — expected for databases that have already been migrated
+        }
+    }
+
+    private void migrateAddGitBranchEndColumn(java.sql.Statement stmt) {
+        try {
+            stmt.execute("ALTER TABLE turn_stats ADD COLUMN git_branch_end TEXT");
+            LOG.info("Migrated turn_stats table: added git_branch_end column");
+        } catch (SQLException e) {
+            if (e.getMessage() == null || !e.getMessage().contains("duplicate column")) {
+                LOG.warn("Unexpected error migrating turn_stats schema (git_branch_end column)", e);
             }
             // else: duplicate column — expected for databases that have already been migrated
         }
@@ -551,40 +578,17 @@ public final class ToolCallStatisticsService implements Disposable {
         String sql = """
             INSERT INTO turn_stats (session_id, agent_id, date, input_tokens, output_tokens,
                                     tool_calls, duration_ms, lines_added, lines_removed,
-                                    premium_requests, timestamp, commit_hashes, git_branch)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                    premium_requests, timestamp, commit_hashes, git_branch,
+                                    git_branch_start, git_branch_end)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """;
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
-            stmt.setString(1, statsRecord.sessionId());
-            stmt.setString(2, statsRecord.agentId());
-            stmt.setString(3, statsRecord.date());
-            stmt.setLong(4, statsRecord.inputTokens());
-            stmt.setLong(5, statsRecord.outputTokens());
-            stmt.setInt(6, statsRecord.toolCalls());
-            stmt.setLong(7, statsRecord.durationMs());
-            stmt.setInt(8, statsRecord.linesAdded());
-            stmt.setInt(9, statsRecord.linesRemoved());
-            stmt.setDouble(10, statsRecord.premiumRequests());
-            stmt.setString(11, statsRecord.timestamp());
-            stmt.setString(12, statsRecord.commitHashes());
-            stmt.setString(13, statsRecord.gitBranch());
+            bindTurnStatsRecord(stmt, statsRecord);
             stmt.executeUpdate();
         } catch (SQLException e) {
             if (isDbMoved(e) && tryReconnect()) {
                 try (PreparedStatement stmt = connection.prepareStatement(sql)) {
-                    stmt.setString(1, statsRecord.sessionId());
-                    stmt.setString(2, statsRecord.agentId());
-                    stmt.setString(3, statsRecord.date());
-                    stmt.setLong(4, statsRecord.inputTokens());
-                    stmt.setLong(5, statsRecord.outputTokens());
-                    stmt.setInt(6, statsRecord.toolCalls());
-                    stmt.setLong(7, statsRecord.durationMs());
-                    stmt.setInt(8, statsRecord.linesAdded());
-                    stmt.setInt(9, statsRecord.linesRemoved());
-                    stmt.setDouble(10, statsRecord.premiumRequests());
-                    stmt.setString(11, statsRecord.timestamp());
-                    stmt.setString(12, statsRecord.commitHashes());
-                    stmt.setString(13, statsRecord.gitBranch());
+                    bindTurnStatsRecord(stmt, statsRecord);
                     stmt.executeUpdate();
                 } catch (SQLException retryEx) {
                     LOG.warn("Failed to record turn stats after reconnect", retryEx);
@@ -593,6 +597,55 @@ public final class ToolCallStatisticsService implements Disposable {
                 LOG.warn("Failed to record turn stats", e);
             }
         }
+    }
+
+    private static void bindTurnStatsRecord(@NotNull PreparedStatement stmt,
+                                            @NotNull TurnStatsRecord statsRecord) throws SQLException {
+        stmt.setString(1, statsRecord.sessionId());
+        stmt.setString(2, statsRecord.agentId());
+        stmt.setString(3, statsRecord.date());
+        stmt.setLong(4, statsRecord.inputTokens());
+        stmt.setLong(5, statsRecord.outputTokens());
+        stmt.setInt(6, statsRecord.toolCalls());
+        stmt.setLong(7, statsRecord.durationMs());
+        stmt.setInt(8, statsRecord.linesAdded());
+        stmt.setInt(9, statsRecord.linesRemoved());
+        stmt.setDouble(10, statsRecord.premiumRequests());
+        stmt.setString(11, statsRecord.timestamp());
+        stmt.setString(12, statsRecord.commitHashes());
+        stmt.setString(13, branchForAttribution(statsRecord.gitBranchStart(), statsRecord.gitBranchEnd(),
+            statsRecord.gitBranch()));
+        stmt.setString(14, normalizeBranch(statsRecord.gitBranchStart()));
+        stmt.setString(15, normalizeBranch(statsRecord.gitBranchEnd()));
+    }
+
+    @Nullable
+    static String branchForAttribution(@Nullable String startBranch,
+                                       @Nullable String endBranch,
+                                       @Nullable String explicitBranch) {
+        String normalizedExplicit = normalizeBranch(explicitBranch);
+        if (normalizedExplicit != null) return normalizedExplicit;
+
+        String normalizedEnd = normalizeBranch(endBranch);
+        if (normalizedEnd != null && !isDefaultBranch(normalizedEnd)) {
+            return normalizedEnd;
+        }
+
+        String normalizedStart = normalizeBranch(startBranch);
+        if (normalizedStart != null) return normalizedStart;
+
+        return normalizedEnd;
+    }
+
+    @Nullable
+    private static String normalizeBranch(@Nullable String branch) {
+        if (branch == null) return null;
+        String trimmed = branch.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private static boolean isDefaultBranch(@NotNull String branch) {
+        return DEFAULT_BRANCH_NAMES.contains(branch);
     }
 
     /**
@@ -851,8 +904,26 @@ public final class ToolCallStatisticsService implements Disposable {
         double premiumRequests,
         @NotNull String timestamp,
         @Nullable String commitHashes,
-        @Nullable String gitBranch
+        @Nullable String gitBranch,
+        @Nullable String gitBranchStart,
+        @Nullable String gitBranchEnd
     ) {
+        public TurnStatsRecord(@NotNull String sessionId,
+                               @NotNull String agentId,
+                               @NotNull String date,
+                               long inputTokens,
+                               long outputTokens,
+                               int toolCalls,
+                               long durationMs,
+                               int linesAdded,
+                               int linesRemoved,
+                               double premiumRequests,
+                               @NotNull String timestamp,
+                               @Nullable String commitHashes,
+                               @Nullable String gitBranch) {
+            this(sessionId, agentId, date, inputTokens, outputTokens, toolCalls, durationMs,
+                linesAdded, linesRemoved, premiumRequests, timestamp, commitHashes, gitBranch, null, null);
+        }
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -195,6 +195,7 @@ public final class ToolCallStatisticsService implements Disposable {
             stmt.execute(
                 "CREATE INDEX IF NOT EXISTS idx_turn_stats_session ON turn_stats(session_id)");
             migrateAddCommitHashesColumn(stmt);
+            migrateAddGitBranchColumn(stmt);
         }
     }
 
@@ -229,6 +230,18 @@ public final class ToolCallStatisticsService implements Disposable {
         } catch (SQLException e) {
             if (e.getMessage() == null || !e.getMessage().contains("duplicate column")) {
                 LOG.warn("Unexpected error migrating turn_stats schema (commit_hashes column)", e);
+            }
+            // else: duplicate column — expected for databases that have already been migrated
+        }
+    }
+
+    private void migrateAddGitBranchColumn(java.sql.Statement stmt) {
+        try {
+            stmt.execute("ALTER TABLE turn_stats ADD COLUMN git_branch TEXT");
+            LOG.info("Migrated turn_stats table: added git_branch column");
+        } catch (SQLException e) {
+            if (e.getMessage() == null || !e.getMessage().contains("duplicate column")) {
+                LOG.warn("Unexpected error migrating turn_stats schema (git_branch column)", e);
             }
             // else: duplicate column — expected for databases that have already been migrated
         }
@@ -538,8 +551,8 @@ public final class ToolCallStatisticsService implements Disposable {
         String sql = """
             INSERT INTO turn_stats (session_id, agent_id, date, input_tokens, output_tokens,
                                     tool_calls, duration_ms, lines_added, lines_removed,
-                                    premium_requests, timestamp, commit_hashes)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                    premium_requests, timestamp, commit_hashes, git_branch)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """;
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
             stmt.setString(1, statsRecord.sessionId());
@@ -554,6 +567,7 @@ public final class ToolCallStatisticsService implements Disposable {
             stmt.setDouble(10, statsRecord.premiumRequests());
             stmt.setString(11, statsRecord.timestamp());
             stmt.setString(12, statsRecord.commitHashes());
+            stmt.setString(13, statsRecord.gitBranch());
             stmt.executeUpdate();
         } catch (SQLException e) {
             if (isDbMoved(e) && tryReconnect()) {
@@ -570,6 +584,7 @@ public final class ToolCallStatisticsService implements Disposable {
                     stmt.setDouble(10, statsRecord.premiumRequests());
                     stmt.setString(11, statsRecord.timestamp());
                     stmt.setString(12, statsRecord.commitHashes());
+                    stmt.setString(13, statsRecord.gitBranch());
                     stmt.executeUpdate();
                 } catch (SQLException retryEx) {
                     LOG.warn("Failed to record turn stats after reconnect", retryEx);
@@ -719,6 +734,108 @@ public final class ToolCallStatisticsService implements Disposable {
     }
 
     /**
+     * Aggregated turn statistics for a single git branch over a date range.
+     * Used for the per-branch comparison bar charts in the usage statistics panel.
+     * <p>
+     * Rows with {@code git_branch IS NULL} (pre-feature history or sessions where
+     * git wasn't available) are excluded from the result. Surface that limitation
+     * in the UI rather than dumping unattributed work into a "(no branch)" bucket.
+     */
+    public record BranchAggregate(
+        @NotNull String branch,
+        int turns,
+        long inputTokens,
+        long outputTokens,
+        int toolCalls,
+        long durationMs,
+        int linesAdded,
+        int linesRemoved,
+        double premiumRequests
+    ) {
+    }
+
+    /**
+     * Queries per-branch totals across the date range. One row per distinct
+     * {@code git_branch} value (NULL branches excluded). Sorted by total
+     * premium-request cost descending, so the most expensive branches lead.
+     *
+     * @param startDate inclusive start date (YYYY-MM-DD)
+     * @param endDate   inclusive end date (YYYY-MM-DD)
+     * @return aggregated branch stats; empty list if the table is empty or all
+     * rows in the range have a null branch
+     */
+    public synchronized List<BranchAggregate> queryBranchTotals(
+        @NotNull String startDate, @NotNull String endDate) {
+        if (connection == null) return List.of();
+        String sql = """
+            SELECT git_branch,
+                   COUNT(*)              AS turns,
+                   SUM(input_tokens)     AS input_tokens,
+                   SUM(output_tokens)    AS output_tokens,
+                   SUM(tool_calls)       AS tool_calls,
+                   SUM(duration_ms)      AS duration_ms,
+                   SUM(lines_added)      AS lines_added,
+                   SUM(lines_removed)    AS lines_removed,
+                   SUM(premium_requests) AS premium_requests
+            FROM turn_stats
+            WHERE date BETWEEN ? AND ?
+              AND git_branch IS NOT NULL
+              AND git_branch <> ''
+            GROUP BY git_branch
+            ORDER BY premium_requests DESC, git_branch
+            """;
+        List<BranchAggregate> results = new ArrayList<>();
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, startDate);
+            stmt.setString(2, endDate);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    results.add(new BranchAggregate(
+                        rs.getString("git_branch"),
+                        rs.getInt("turns"),
+                        rs.getLong("input_tokens"),
+                        rs.getLong("output_tokens"),
+                        rs.getInt("tool_calls"),
+                        rs.getLong("duration_ms"),
+                        rs.getInt("lines_added"),
+                        rs.getInt("lines_removed"),
+                        rs.getDouble("premium_requests")
+                    ));
+                }
+            }
+        } catch (SQLException e) {
+            LOG.warn("Failed to query branch totals", e);
+        }
+        return results;
+    }
+
+    /**
+     * Returns the number of {@code turn_stats} rows in the date range whose
+     * {@code git_branch} is NULL or empty. Used by the UI to surface
+     * "N turns are unattributed (recorded before branch tracking was added)".
+     */
+    public synchronized int countUnattributedTurns(
+        @NotNull String startDate, @NotNull String endDate) {
+        if (connection == null) return 0;
+        String sql = """
+            SELECT COUNT(*) AS unattributed
+            FROM turn_stats
+            WHERE date BETWEEN ? AND ?
+              AND (git_branch IS NULL OR git_branch = '')
+            """;
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, startDate);
+            stmt.setString(2, endDate);
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next() ? rs.getInt("unattributed") : 0;
+            }
+        } catch (SQLException e) {
+            LOG.warn("Failed to count unattributed turns", e);
+            return 0;
+        }
+    }
+
+    /**
      * A single turn stats record for insertion.
      */
     public record TurnStatsRecord(
@@ -733,7 +850,8 @@ public final class ToolCallStatisticsService implements Disposable {
         int linesRemoved,
         double premiumRequests,
         @NotNull String timestamp,
-        @Nullable String commitHashes
+        @Nullable String commitHashes,
+        @Nullable String gitBranch
     ) {
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/TurnStatisticsBackfill.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/TurnStatisticsBackfill.java
@@ -216,7 +216,8 @@ public final class TurnStatisticsBackfill {
         return new ToolCallStatisticsService.TurnStatsRecord(
             sessionId, agentId, date,
             inputTokens, outputTokens, toolCalls, durationMs,
-            linesAdded, linesRemoved, premiumRequests, timestamp, commitHashes);
+            linesAdded, linesRemoved, premiumRequests, timestamp, commitHashes,
+            null);
     }
 
     private static double parsePremiumMultiplier(String multiplier) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/TurnStatisticsBackfill.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/TurnStatisticsBackfill.java
@@ -38,6 +38,8 @@ public final class TurnStatisticsBackfill {
     private static final Logger LOG = Logger.getInstance(TurnStatisticsBackfill.class);
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final String KEY_COMMIT_HASHES = "commitHashes";
+    private static final String KEY_GIT_BRANCH_START = "gitBranchStart";
+    private static final String KEY_GIT_BRANCH_END = "gitBranchEnd";
 
     private TurnStatisticsBackfill() {
         throw new IllegalStateException("Utility class");
@@ -213,11 +215,14 @@ public final class TurnStatisticsBackfill {
             }
         }
 
+        String gitBranchStart = nullableStr(obj, KEY_GIT_BRANCH_START);
+        String gitBranchEnd = nullableStr(obj, KEY_GIT_BRANCH_END);
+
         return new ToolCallStatisticsService.TurnStatsRecord(
             sessionId, agentId, date,
             inputTokens, outputTokens, toolCalls, durationMs,
             linesAdded, linesRemoved, premiumRequests, timestamp, commitHashes,
-            null);
+            null, gitBranchStart, gitBranchEnd);
     }
 
     private static double parsePremiumMultiplier(String multiplier) {
@@ -252,5 +257,11 @@ public final class TurnStatisticsBackfill {
             return obj.get(key).getAsInt();
         }
         return 0;
+    }
+
+    @Nullable
+    private static String nullableStr(@NotNull JsonObject obj, @NotNull String key) {
+        String value = getStr(obj, key);
+        return value.isEmpty() ? null : value;
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
@@ -93,6 +93,7 @@ class PromptOrchestrator(
     private var turnCostUsd: Double? = null
     private var turnModelId = ""
     private var turnStartHeadHash: String? = null
+    private var turnStartGitBranch: String? = null
 
     /**
      * Stack of currently active sub-agent call IDs, ordered by start time (oldest first).
@@ -273,6 +274,7 @@ class PromptOrchestrator(
         turnModelId = selectedModelId
         CodeChangeTracker.clear()
         turnStartHeadHash = captureGitHead()
+        turnStartGitBranch = captureGitBranch()
 
         // Register real-time listener so code-change chips update as each tool runs.
         codeChangeListener?.let { CodeChangeTracker.removeListener(it) }
@@ -499,7 +501,8 @@ class PromptOrchestrator(
         recordTurnStatsToSqlite(
             TurnStatsParams(
                 turnDuration, turnInputTokens, turnOutputTokens,
-                turnToolCallCount, codeChanges[0], codeChanges[1], turnMultiplier, commitHashes
+                turnToolCallCount, codeChanges[0], codeChanges[1], turnMultiplier, commitHashes,
+                turnStartGitBranch
             )
         )
 
@@ -861,7 +864,8 @@ class PromptOrchestrator(
     private data class TurnStatsParams(
         val durationMs: Long, val inputTokens: Int, val outputTokens: Int,
         val toolCallCount: Int, val linesAdded: Int, val linesRemoved: Int,
-        val multiplier: String, val commitHashes: List<String>
+        val multiplier: String, val commitHashes: List<String>,
+        val gitBranch: String?
     )
 
     private fun recordTurnStatsToSqlite(params: TurnStatsParams) {
@@ -881,7 +885,7 @@ class PromptOrchestrator(
                         sessionId, agentId, date,
                         params.inputTokens.toLong(), params.outputTokens.toLong(), params.toolCallCount,
                         params.durationMs, params.linesAdded, params.linesRemoved, premiumRequests, timestamp,
-                        commitHashesStr
+                        commitHashesStr, params.gitBranch
                     )
                 )
             } catch (e: Exception) {
@@ -903,6 +907,30 @@ class PromptOrchestrator(
             val output = proc.inputStream.bufferedReader().readText().trim()
             proc.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)
             if (proc.exitValue() == 0 && output.matches(Regex("[0-9a-f]{40}"))) output else null
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Captures the current git branch checked out at turn start. Returns null when the
+     * working directory is not a git repository, git is unavailable, or HEAD is detached
+     * (e.g. mid-rebase, on a tagged commit). The chart UI treats null as "unattributed"
+     * and excludes those turns from the per-branch comparison view.
+     *
+     * Uses {@code symbolic-ref --short -q HEAD} so detached HEAD exits non-zero rather
+     * than returning the literal string "HEAD" (which {@code rev-parse --abbrev-ref}
+     * would return and which would otherwise need to be filtered out as a magic value).
+     */
+    private fun captureGitBranch(): String? {
+        return try {
+            val pb = ProcessBuilder("git", "symbolic-ref", "--short", "-q", "HEAD")
+                .directory(java.io.File(project.basePath ?: return null))
+            pb.environment()["GIT_TERMINAL_PROMPT"] = "0"
+            val proc = pb.start()
+            val output = proc.inputStream.bufferedReader().readText().trim()
+            proc.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)
+            if (proc.exitValue() == 0 && output.isNotEmpty()) output else null
         } catch (_: Exception) {
             null
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
@@ -490,6 +490,7 @@ class PromptOrchestrator(
         val turnDuration = System.currentTimeMillis() - turnStartedAt
         val turnMultiplier = if (client.supportsMultiplier()) getModelMultiplier(turnModelId) ?: "" else ""
         val commitHashes = collectTurnCommits()
+        val turnEndGitBranch = captureGitBranch()
         consolePanel().emitTurnStats(
             TurnStatsData(
                 turnDuration, turnInputTokens, turnOutputTokens, turnCostUsd ?: 0.0,
@@ -502,7 +503,7 @@ class PromptOrchestrator(
             TurnStatsParams(
                 turnDuration, turnInputTokens, turnOutputTokens,
                 turnToolCallCount, codeChanges[0], codeChanges[1], turnMultiplier, commitHashes,
-                turnStartGitBranch
+                turnStartGitBranch, turnEndGitBranch
             )
         )
 
@@ -865,7 +866,7 @@ class PromptOrchestrator(
         val durationMs: Long, val inputTokens: Int, val outputTokens: Int,
         val toolCallCount: Int, val linesAdded: Int, val linesRemoved: Int,
         val multiplier: String, val commitHashes: List<String>,
-        val gitBranch: String?
+        val gitBranchStart: String?, val gitBranchEnd: String?
     )
 
     private fun recordTurnStatsToSqlite(params: TurnStatsParams) {
@@ -885,7 +886,7 @@ class PromptOrchestrator(
                         sessionId, agentId, date,
                         params.inputTokens.toLong(), params.outputTokens.toLong(), params.toolCallCount,
                         params.durationMs, params.linesAdded, params.linesRemoved, premiumRequests, timestamp,
-                        commitHashesStr, params.gitBranch
+                        commitHashesStr, null, params.gitBranchStart, params.gitBranchEnd
                     )
                 )
             } catch (e: Exception) {
@@ -913,7 +914,7 @@ class PromptOrchestrator(
     }
 
     /**
-     * Captures the current git branch checked out at turn start. Returns null when the
+     * Captures the current git branch. Returns null when the
      * working directory is not a git repository, git is unavailable, or HEAD is detached
      * (e.g. mid-rebase, on a tagged commit). The chart UI treats null as "unattributed"
      * and excludes those turns from the per-branch comparison view.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/BranchComparisonChart.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/BranchComparisonChart.java
@@ -1,0 +1,217 @@
+package com.github.catatafishen.agentbridge.ui.statistics;
+
+import com.github.catatafishen.agentbridge.ui.ChatTheme;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBPanel;
+import com.intellij.util.ui.JBUI;
+
+import javax.swing.BorderFactory;
+import javax.swing.JPanel;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.util.List;
+
+/**
+ * Horizontal bar chart that compares one metric across git branches.
+ * One bar per branch, sorted by value descending. Uses the same color palette
+ * as the agent-grouped chart (via {@link ChatTheme#agentColorIndex(String)},
+ * which hashes any string key) so each branch gets a distinctive but stable
+ * color across reloads.
+ *
+ * <p>Layout: title (north), bar canvas (center), empty-state label (centered
+ * over canvas when there are no rows for the selected metric).
+ */
+final class BranchComparisonChart extends JBPanel<BranchComparisonChart> {
+
+    private static final int ROW_HEIGHT = JBUI.scale(22);
+    private static final int ROW_GAP = JBUI.scale(4);
+    private static final int LABEL_WIDTH = JBUI.scale(140);
+    private static final int VALUE_WIDTH = JBUI.scale(70);
+    private static final int CANVAS_PADDING = JBUI.scale(8);
+
+    private static final Color BAR_TRACK_COLOR = new JBColor(
+        new Color(235, 235, 235), new Color(60, 60, 60));
+    private static final Color LABEL_COLOR = new JBColor(
+        new Color(60, 60, 60), new Color(190, 190, 190));
+
+    private final UsageStatisticsData.Metric metric;
+    private final BarCanvas canvas;
+    private final JBLabel emptyLabel;
+
+    BranchComparisonChart(String title, UsageStatisticsData.Metric metric) {
+        super(new BorderLayout());
+        this.metric = metric;
+
+        setPreferredSize(new Dimension(JBUI.scale(350), JBUI.scale(220)));
+
+        JBLabel titleLabel = new JBLabel(title);
+        titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD));
+        add(titleLabel, BorderLayout.NORTH);
+
+        canvas = new BarCanvas();
+        add(canvas, BorderLayout.CENTER);
+
+        emptyLabel = new JBLabel("No branch data");
+        emptyLabel.setHorizontalAlignment(JBLabel.CENTER);
+        emptyLabel.setVisible(false);
+    }
+
+    void update(UsageStatisticsData.BranchSnapshot snapshot) {
+        if (snapshot == null || snapshot.branches().isEmpty()) {
+            remove(canvas);
+            emptyLabel.setVisible(true);
+            add(emptyLabel, BorderLayout.CENTER);
+            revalidate();
+            repaint();
+            return;
+        }
+
+        emptyLabel.setVisible(false);
+        remove(emptyLabel);
+        add(canvas, BorderLayout.CENTER);
+
+        canvas.setData(snapshot.branches());
+        revalidate();
+        repaint();
+    }
+
+    /**
+     * Extracts the metric value for a branch. Values are returned as {@code double}
+     * to keep the bar-length math uniform across all metric types.
+     */
+    private double valueFor(UsageStatisticsData.BranchStats branch) {
+        return switch (metric) {
+            case PREMIUM_REQUESTS -> branch.premiumRequests();
+            case TURNS -> branch.turns();
+            case TOKENS -> (double) (branch.inputTokens() + branch.outputTokens());
+            case TOOL_CALLS -> branch.toolCalls();
+            case CODE_CHANGES -> (double) (branch.linesAdded() + branch.linesRemoved());
+            case AGENT_TIME -> branch.durationMs();
+        };
+    }
+
+    private String formatValue(double value) {
+        return switch (metric) {
+            case AGENT_TIME -> formatDuration((long) value);
+            case TOKENS, TOOL_CALLS, CODE_CHANGES, TURNS -> formatLargeNumber((long) value);
+            case PREMIUM_REQUESTS -> formatPremium(value);
+        };
+    }
+
+    private static String formatDuration(long ms) {
+        if (ms < 60_000) return (ms / 1000) + "s";
+        long minutes = ms / 60_000;
+        if (minutes < 60) return minutes + "m";
+        long hours = minutes / 60;
+        long remMin = minutes % 60;
+        if (remMin == 0) return hours + "h";
+        return hours + "h " + remMin + "m";
+    }
+
+    private static String formatLargeNumber(long value) {
+        if (value < 1_000) return Long.toString(value);
+        if (value < 1_000_000) return String.format("%.1fK", value / 1_000.0);
+        return String.format("%.1fM", value / 1_000_000.0);
+    }
+
+    private static String formatPremium(double value) {
+        if (value < 100) return String.format("%.1f", value);
+        return String.format("%.0f", value);
+    }
+
+    private final class BarCanvas extends JPanel {
+        private List<UsageStatisticsData.BranchStats> branches = List.of();
+
+        BarCanvas() {
+            setOpaque(false);
+            setBorder(BorderFactory.createEmptyBorder(
+                CANVAS_PADDING, CANVAS_PADDING, CANVAS_PADDING, CANVAS_PADDING));
+        }
+
+        void setData(List<UsageStatisticsData.BranchStats> branches) {
+            this.branches = branches;
+            int rowsHeight = branches.size() * (ROW_HEIGHT + ROW_GAP);
+            setPreferredSize(new Dimension(getWidth(), rowsHeight + 2 * CANVAS_PADDING));
+            revalidate();
+        }
+
+        @Override
+        protected void paintComponent(Graphics g) {
+            super.paintComponent(g);
+            if (branches.isEmpty()) return;
+
+            Graphics2D g2 = (Graphics2D) g.create();
+            try {
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+                g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                    RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
+                int width = getWidth();
+                int barAreaX = CANVAS_PADDING + LABEL_WIDTH;
+                int barAreaWidth = width - barAreaX - VALUE_WIDTH - CANVAS_PADDING;
+                if (barAreaWidth < JBUI.scale(20)) return;
+
+                // Find max for bar scaling. All bars are scaled to the largest value
+                // so the leader stretches the full width.
+                double maxValue = branches.stream()
+                    .mapToDouble(BranchComparisonChart.this::valueFor)
+                    .max().orElse(0);
+                if (maxValue <= 0) return;
+
+                FontMetrics fm = g2.getFontMetrics();
+                int textBaselineOffset = (ROW_HEIGHT + fm.getAscent()) / 2 - JBUI.scale(2);
+
+                int y = CANVAS_PADDING;
+                for (UsageStatisticsData.BranchStats branch : branches) {
+                    double value = valueFor(branch);
+
+                    // Branch label (left), truncated with ellipsis if too long
+                    g2.setColor(LABEL_COLOR);
+                    String label = truncate(g2, branch.branch(), LABEL_WIDTH - JBUI.scale(8));
+                    g2.drawString(label, CANVAS_PADDING, y + textBaselineOffset);
+
+                    // Bar
+                    int barWidth = (int) (barAreaWidth * (value / maxValue));
+                    g2.setColor(BAR_TRACK_COLOR);
+                    g2.fillRect(barAreaX, y + JBUI.scale(4), barAreaWidth, ROW_HEIGHT - JBUI.scale(8));
+
+                    int colorIndex = ChatTheme.INSTANCE.agentColorIndex(branch.branch());
+                    JBColor barColor = ChatTheme.INSTANCE.getSA_COLORS()[colorIndex];
+                    g2.setColor(barColor);
+                    g2.fillRect(barAreaX, y + JBUI.scale(4), barWidth, ROW_HEIGHT - JBUI.scale(8));
+
+                    // Value (right)
+                    g2.setColor(LABEL_COLOR);
+                    String valueStr = formatValue(value);
+                    int valueX = barAreaX + barAreaWidth + JBUI.scale(4);
+                    g2.drawString(valueStr, valueX, y + textBaselineOffset);
+
+                    y += ROW_HEIGHT + ROW_GAP;
+                }
+            } finally {
+                g2.dispose();
+            }
+        }
+
+        private String truncate(Graphics2D g2, String text, int maxWidth) {
+            FontMetrics fm = g2.getFontMetrics();
+            if (fm.stringWidth(text) <= maxWidth) return text;
+            String ellipsis = "…";
+            int ellipsisWidth = fm.stringWidth(ellipsis);
+            for (int i = text.length() - 1; i > 0; i--) {
+                String candidate = text.substring(0, i);
+                if (fm.stringWidth(candidate) + ellipsisWidth <= maxWidth) {
+                    return candidate + ellipsis;
+                }
+            }
+            return ellipsis;
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsData.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsData.java
@@ -109,4 +109,58 @@ final class UsageStatisticsData {
             return displayName;
         }
     }
+
+    /**
+     * Grouping dimension for the usage statistics charts. Driven by the
+     * "Group by" combo box in {@link UsageStatisticsPanel}.
+     */
+    enum GroupBy {
+        AGENT("Agent"),
+        GIT_BRANCH("Git Branch");
+
+        private final String label;
+
+        GroupBy(String label) {
+            this.label = label;
+        }
+
+        String label() {
+            return label;
+        }
+    }
+
+    /**
+     * Aggregated metrics for a single git branch over the selected date range.
+     * Used by the branch-comparison bar charts; one entry per distinct branch.
+     */
+    record BranchStats(
+        String branch,
+        int turns,
+        long inputTokens,
+        long outputTokens,
+        int toolCalls,
+        long durationMs,
+        int linesAdded,
+        int linesRemoved,
+        double premiumRequests
+    ) {
+    }
+
+    /**
+     * Snapshot for branch-grouped view. Populated only when the user picks
+     * "Git Branch" in the Group by combo.
+     *
+     * @param branches      one entry per branch, sorted by premium-request cost desc
+     * @param unattributed  count of turns in the date range with NULL/empty git_branch
+     *                      (recorded before branch tracking was added, or when git
+     *                      was unavailable). Surfaced as a warning in the panel so
+     *                      users understand why the totals differ from the agent view.
+     */
+    record BranchSnapshot(
+        List<BranchStats> branches,
+        LocalDate startDate,
+        LocalDate endDate,
+        int unattributed
+    ) {
+    }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
@@ -57,6 +57,50 @@ final class UsageStatisticsLoader {
     }
 
     /**
+     * Loads per-branch totals for the branch-comparison view. Always reads from
+     * SQLite — JSONL has no branch info, so a JSONL fallback would always be
+     * empty and would just confuse the user.
+     *
+     * @return branch snapshot. {@link UsageStatisticsData.BranchSnapshot#branches()}
+     * is empty when no rows in the range have a git branch attached.
+     */
+    static UsageStatisticsData.BranchSnapshot loadBranches(@NotNull Project project,
+                                                           @NotNull UsageStatisticsData.TimeRange range) {
+        LocalDate startDate = range.startDate();
+        LocalDate endDate = LocalDate.now();
+
+        ToolCallStatisticsService service = ToolCallStatisticsService.getInstance(project);
+        String startStr = startDate.toString();
+        String endStr = endDate.toString();
+
+        List<ToolCallStatisticsService.BranchAggregate> aggregates =
+            service.queryBranchTotals(startStr, endStr);
+        int unattributed = service.countUnattributedTurns(startStr, endStr);
+
+        List<UsageStatisticsData.BranchStats> branches = new ArrayList<>();
+        for (ToolCallStatisticsService.BranchAggregate agg : aggregates) {
+            branches.add(new UsageStatisticsData.BranchStats(
+                agg.branch(), agg.turns(), agg.inputTokens(), agg.outputTokens(),
+                agg.toolCalls(), agg.durationMs(),
+                agg.linesAdded(), agg.linesRemoved(), agg.premiumRequests()
+            ));
+        }
+
+        // For "all time", narrow start to earliest data date if available
+        if (range == UsageStatisticsData.TimeRange.ALL) {
+            LocalDate earliest = service.getEarliestTurnDate();
+            if (earliest != null) {
+                startDate = earliest;
+            }
+        }
+
+        LOG.info("Statistics (branches): " + branches.size() + " branches, "
+            + unattributed + " unattributed turns");
+
+        return new UsageStatisticsData.BranchSnapshot(branches, startDate, endDate, unattributed);
+    }
+
+    /**
      * Loads statistics from the SQLite turn_stats table. Returns null if the
      * table is empty (triggers JSONL fallback with backfill).
      */

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsPanel.java
@@ -17,31 +17,55 @@ import java.util.EnumMap;
 import java.util.Map;
 
 /**
- * Main panel displaying usage statistics with a time-range selector, a legend,
- * and six metric charts arranged in a 2×3 grid.
+ * Main panel displaying usage statistics with a time-range selector, a
+ * Group-by selector (Agent / Git Branch), and metric charts.
+ *
+ * <p>Two views, switched via {@link CardLayout}:
+ * <ul>
+ *   <li>{@code AGENT}: 2×3 grid of {@link UsageStatisticsChart} time-series
+ *       (one per metric). Legend shows agents.</li>
+ *   <li>{@code GIT_BRANCH}: 2×3 grid of {@link BranchComparisonChart} bar
+ *       charts (one per metric) so users can compare per-feature spend.
+ *       Bar charts are used instead of time-series because branches are
+ *       discrete categories — a stacked or multi-line time chart over many
+ *       branches becomes unreadable and "total spend per branch" is the
+ *       actual question being answered.</li>
+ * </ul>
  */
 class UsageStatisticsPanel extends JBPanel<UsageStatisticsPanel> {
 
     private static final Logger LOG = Logger.getInstance(UsageStatisticsPanel.class);
 
+    private static final String CARD_AGENT = "agent";
+    private static final String CARD_BRANCH = "branch";
+
     private final Project project;
     private final ComboBox<UsageStatisticsData.TimeRange> rangeCombo;
-    private final Map<UsageStatisticsData.Metric, UsageStatisticsChart> charts = new EnumMap<>(UsageStatisticsData.Metric.class);
+    private final ComboBox<UsageStatisticsData.GroupBy> groupByCombo;
+
+    private final Map<UsageStatisticsData.Metric, UsageStatisticsChart> agentCharts =
+        new EnumMap<>(UsageStatisticsData.Metric.class);
+    private final Map<UsageStatisticsData.Metric, BranchComparisonChart> branchCharts =
+        new EnumMap<>(UsageStatisticsData.Metric.class);
+
     private final JPanel legendContainer;
+    private final JPanel cardPanel;
+    private final CardLayout cardLayout;
+    private final JBLabel branchHintLabel;
 
     UsageStatisticsPanel(Project project) {
         super(new BorderLayout());
         this.project = project;
         setBorder(JBUI.Borders.empty(12));
 
-        // --- NORTH: toolbar with time-range selector + legend ---
+        // --- NORTH: toolbar with Period + Group-by selectors + legend ---
         JPanel toolbar = new JPanel(new BorderLayout());
 
         JPanel selectorPanel = new JPanel();
         selectorPanel.setLayout(new BoxLayout(selectorPanel, BoxLayout.X_AXIS));
+
         selectorPanel.add(new JBLabel("Period:"));
         selectorPanel.add(Box.createHorizontalStrut(JBUI.scale(6)));
-
         rangeCombo = new ComboBox<>(UsageStatisticsData.TimeRange.values());
         rangeCombo.setSelectedItem(UsageStatisticsData.TimeRange.MONTH_30);
         rangeCombo.setRenderer(new DefaultListCellRenderer() {
@@ -55,13 +79,28 @@ class UsageStatisticsPanel extends JBPanel<UsageStatisticsPanel> {
                 return this;
             }
         });
-        rangeCombo.addActionListener(e -> {
-            UsageStatisticsData.TimeRange selected = (UsageStatisticsData.TimeRange) rangeCombo.getSelectedItem();
-            if (selected != null) {
-                loadData(selected);
+        rangeCombo.addActionListener(e -> reload());
+        selectorPanel.add(rangeCombo);
+
+        selectorPanel.add(Box.createHorizontalStrut(JBUI.scale(16)));
+        selectorPanel.add(new JBLabel("Group by:"));
+        selectorPanel.add(Box.createHorizontalStrut(JBUI.scale(6)));
+        groupByCombo = new ComboBox<>(UsageStatisticsData.GroupBy.values());
+        groupByCombo.setSelectedItem(UsageStatisticsData.GroupBy.AGENT);
+        groupByCombo.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index,
+                                                          boolean isSelected, boolean cellHasFocus) {
+                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                if (value instanceof UsageStatisticsData.GroupBy groupBy) {
+                    setText(groupBy.label());
+                }
+                return this;
             }
         });
-        selectorPanel.add(rangeCombo);
+        groupByCombo.addActionListener(e -> reload());
+        selectorPanel.add(groupByCombo);
+
         toolbar.add(selectorPanel, BorderLayout.WEST);
 
         legendContainer = new JPanel();
@@ -70,49 +109,123 @@ class UsageStatisticsPanel extends JBPanel<UsageStatisticsPanel> {
 
         add(toolbar, BorderLayout.NORTH);
 
-        // --- CENTER: 2×3 grid of charts ---
-        JPanel chartGrid = new JPanel(new GridLayout(2, 3, JBUI.scale(12), JBUI.scale(12)));
+        // --- CENTER: card layout switching between agent grid and branch grid ---
+        cardLayout = new CardLayout();
+        cardPanel = new JPanel(cardLayout);
+
+        // Agent view: existing 2×3 time-series grid
+        JPanel agentGrid = new JPanel(new GridLayout(2, 3, JBUI.scale(12), JBUI.scale(12)));
         for (UsageStatisticsData.Metric metric : UsageStatisticsData.Metric.values()) {
             UsageStatisticsChart chart = new UsageStatisticsChart(metric.displayName(), metric);
-            charts.put(metric, chart);
-            chartGrid.add(chart);
+            agentCharts.put(metric, chart);
+            agentGrid.add(chart);
         }
-        add(chartGrid, BorderLayout.CENTER);
+        cardPanel.add(agentGrid, CARD_AGENT);
+
+        // Branch view: 2×3 grid of bar charts + hint label at bottom
+        JPanel branchView = new JPanel(new BorderLayout());
+        JPanel branchGrid = new JPanel(new GridLayout(2, 3, JBUI.scale(12), JBUI.scale(12)));
+        for (UsageStatisticsData.Metric metric : UsageStatisticsData.Metric.values()) {
+            BranchComparisonChart chart = new BranchComparisonChart(metric.displayName(), metric);
+            branchCharts.put(metric, chart);
+            branchGrid.add(chart);
+        }
+        branchView.add(branchGrid, BorderLayout.CENTER);
+
+        branchHintLabel = new JBLabel(" ");
+        branchHintLabel.setBorder(JBUI.Borders.emptyTop(8));
+        branchHintLabel.setForeground(JBColor.GRAY);
+        branchView.add(branchHintLabel, BorderLayout.SOUTH);
+
+        cardPanel.add(branchView, CARD_BRANCH);
+
+        add(cardPanel, BorderLayout.CENTER);
 
         // --- Initial load ---
-        loadData(UsageStatisticsData.TimeRange.MONTH_30);
+        reload();
     }
 
-    private void loadData(UsageStatisticsData.TimeRange range) {
-        // Use ModalityState.any() so the callback runs even inside a modal dialog
+    private void reload() {
+        UsageStatisticsData.TimeRange range =
+            (UsageStatisticsData.TimeRange) rangeCombo.getSelectedItem();
+        UsageStatisticsData.GroupBy groupBy =
+            (UsageStatisticsData.GroupBy) groupByCombo.getSelectedItem();
+        if (range == null || groupBy == null) return;
+
+        if (groupBy == UsageStatisticsData.GroupBy.AGENT) {
+            cardLayout.show(cardPanel, CARD_AGENT);
+            loadAgentData(range);
+        } else {
+            cardLayout.show(cardPanel, CARD_BRANCH);
+            loadBranchData(range);
+        }
+    }
+
+    private void loadAgentData(UsageStatisticsData.TimeRange range) {
         ModalityState modality = ModalityState.any();
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
             try {
-                UsageStatisticsData.StatisticsSnapshot snapshot = UsageStatisticsLoader.load(project, range);
+                UsageStatisticsData.StatisticsSnapshot snapshot =
+                    UsageStatisticsLoader.load(project, range);
                 LOG.info("Statistics panel: loaded " + snapshot.dailyStats().size()
                     + " daily stats, " + snapshot.agentIds().size() + " agents");
                 ApplicationManager.getApplication().invokeLater(() -> {
                     if (project.isDisposed()) return;
-                    updateCharts(snapshot);
+                    updateAgentCharts(snapshot);
                 }, modality);
             } catch (Exception e) {
-                LOG.error("Statistics panel: failed to load data for range " + range, e);
+                LOG.error("Statistics panel: failed to load agent data for range " + range, e);
             }
         });
     }
 
-    private void updateCharts(UsageStatisticsData.StatisticsSnapshot snapshot) {
-        for (UsageStatisticsChart chart : charts.values()) {
+    private void loadBranchData(UsageStatisticsData.TimeRange range) {
+        ModalityState modality = ModalityState.any();
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                UsageStatisticsData.BranchSnapshot snapshot =
+                    UsageStatisticsLoader.loadBranches(project, range);
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    if (project.isDisposed()) return;
+                    updateBranchCharts(snapshot);
+                }, modality);
+            } catch (Exception e) {
+                LOG.error("Statistics panel: failed to load branch data for range " + range, e);
+            }
+        });
+    }
+
+    private void updateAgentCharts(UsageStatisticsData.StatisticsSnapshot snapshot) {
+        for (UsageStatisticsChart chart : agentCharts.values()) {
             chart.update(snapshot);
         }
         legendContainer.removeAll();
-        JPanel legend = buildLegend(snapshot);
-        legendContainer.add(legend);
+        legendContainer.add(buildAgentLegend(snapshot));
         legendContainer.revalidate();
         legendContainer.repaint();
     }
 
-    private JPanel buildLegend(UsageStatisticsData.StatisticsSnapshot snapshot) {
+    private void updateBranchCharts(UsageStatisticsData.BranchSnapshot snapshot) {
+        for (BranchComparisonChart chart : branchCharts.values()) {
+            chart.update(snapshot);
+        }
+        legendContainer.removeAll();
+        legendContainer.revalidate();
+        legendContainer.repaint();
+
+        if (snapshot.unattributed() > 0) {
+            branchHintLabel.setText(snapshot.unattributed()
+                + " turn(s) in this period have no branch attribution"
+                + " (recorded before per-branch tracking, or git was unavailable).");
+        } else if (snapshot.branches().isEmpty()) {
+            branchHintLabel.setText("No branch data yet. Submit a prompt while on a feature"
+                + " branch to start tracking per-branch usage.");
+        } else {
+            branchHintLabel.setText(" ");
+        }
+    }
+
+    private JPanel buildAgentLegend(UsageStatisticsData.StatisticsSnapshot snapshot) {
         JPanel legend = new JPanel();
         legend.setLayout(new BoxLayout(legend, BoxLayout.X_AXIS));
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/FocusGuardTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/FocusGuardTest.java
@@ -11,6 +11,7 @@ import java.beans.PropertyChangeEvent;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -105,6 +106,26 @@ class FocusGuardTest {
         // The 21st should NOT throw — circuit breaker tripped, guard is uninstalled
         guard.vetoableChange(outsideEvent());
         assertTrue(guard.uninstalled, "Guard should be uninstalled after circuit breaker trips");
+    }
+
+    @Test
+    void chatComponentDetectionDoesNotTreatMainWindowSiblingsAsChat() {
+        JPanel ideFrameRoot = new JPanel(new BorderLayout());
+        JPanel chatRoot = new JPanel();
+        JPanel chatChild = new JPanel();
+        JPanel vcsToolWindow = new JPanel();
+        JPanel runToolWindow = new JPanel();
+
+        chatRoot.add(chatChild);
+        ideFrameRoot.add(chatRoot, BorderLayout.CENTER);
+        ideFrameRoot.add(vcsToolWindow, BorderLayout.WEST);
+        ideFrameRoot.add(runToolWindow, BorderLayout.SOUTH);
+
+        assertTrue(FocusGuard.isInsideChatComponent(chatRoot, chatRoot));
+        assertTrue(FocusGuard.isInsideChatComponent(chatChild, chatRoot));
+        assertFalse(FocusGuard.isInsideChatComponent(vcsToolWindow, chatRoot));
+        assertFalse(FocusGuard.isInsideChatComponent(runToolWindow, chatRoot));
+        assertFalse(FocusGuard.isInsideChatComponent(ideFrameRoot, chatRoot));
     }
 
     // ── Pass-through cases (no veto expected) ────────────────────────────────────────────────────

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
@@ -370,7 +370,7 @@ class ToolCallStatisticsServiceTest {
         double premiumRequests, String timestamp) {
         return new ToolCallStatisticsService.TurnStatsRecord(
             sessionId, agentId, date, inputTokens, outputTokens, toolCalls,
-            durationMs, linesAdded, linesRemoved, premiumRequests, timestamp, null);
+            durationMs, linesAdded, linesRemoved, premiumRequests, timestamp, null, null);
     }
 
     @Test
@@ -511,5 +511,85 @@ class ToolCallStatisticsServiceTest {
         assertDoesNotThrow(() -> nullService.recordTurnStats(
             turnRecord("s1", "copilot", "2025-01-15",
                 100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z")));
+    }
+
+    // --- Per-branch query tests ---
+
+    private static ToolCallStatisticsService.TurnStatsRecord turnRecordWithBranch(
+        String sessionId, String agentId, String date,
+        long inputTokens, long outputTokens, int toolCalls,
+        long durationMs, int linesAdded, int linesRemoved,
+        double premiumRequests, String timestamp, String branch) {
+        return new ToolCallStatisticsService.TurnStatsRecord(
+            sessionId, agentId, date, inputTokens, outputTokens, toolCalls,
+            durationMs, linesAdded, linesRemoved, premiumRequests, timestamp, null, branch);
+    }
+
+    @Test
+    @DisplayName("queryBranchTotals aggregates per branch and orders by premium DESC")
+    void queryBranchTotalsAggregatesAndSorts() {
+        service.recordTurnStats(turnRecordWithBranch("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 0.5, "2025-01-15T10:00:00Z", "feat/a"));
+        service.recordTurnStats(turnRecordWithBranch("s2", "copilot", "2025-01-16",
+            100, 200, 3, 5000, 10, 2, 0.5, "2025-01-16T10:00:00Z", "feat/a"));
+        service.recordTurnStats(turnRecordWithBranch("s3", "copilot", "2025-01-15",
+            50, 100, 1, 1000, 1, 0, 0.1, "2025-01-15T11:00:00Z", "feat/b"));
+        // Cross-agent — should still be merged by branch (collapses agent dimension)
+        service.recordTurnStats(turnRecordWithBranch("s4", "claude-cli", "2025-01-15",
+            10, 20, 1, 500, 0, 0, 5.0, "2025-01-15T12:00:00Z", "feat/b"));
+
+        var results = service.queryBranchTotals("2025-01-01", "2025-01-31");
+
+        assertEquals(2, results.size());
+        // feat/b has higher premium total (5.1) than feat/a (1.0) → first
+        assertEquals("feat/b", results.get(0).branch());
+        assertEquals(5.1, results.get(0).premiumRequests(), 0.0001);
+        assertEquals(2, results.get(0).turns());
+        assertEquals("feat/a", results.get(1).branch());
+        assertEquals(1.0, results.get(1).premiumRequests(), 0.0001);
+        assertEquals(2, results.get(1).turns());
+    }
+
+    @Test
+    @DisplayName("queryBranchTotals excludes rows with null/empty git_branch")
+    void queryBranchTotalsExcludesUnattributed() {
+        service.recordTurnStats(turnRecordWithBranch("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z", "feat/a"));
+        service.recordTurnStats(turnRecordWithBranch("s2", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T11:00:00Z", null));
+        service.recordTurnStats(turnRecordWithBranch("s3", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T12:00:00Z", ""));
+
+        var results = service.queryBranchTotals("2025-01-01", "2025-01-31");
+
+        assertEquals(1, results.size());
+        assertEquals("feat/a", results.get(0).branch());
+    }
+
+    @Test
+    @DisplayName("countUnattributedTurns counts only null/empty branches in range")
+    void countUnattributedTurnsCountsCorrectly() {
+        service.recordTurnStats(turnRecordWithBranch("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z", "feat/a"));
+        service.recordTurnStats(turnRecordWithBranch("s2", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T11:00:00Z", null));
+        service.recordTurnStats(turnRecordWithBranch("s3", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T12:00:00Z", ""));
+        // Outside the date range — should not be counted
+        service.recordTurnStats(turnRecordWithBranch("s4", "copilot", "2024-12-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2024-12-15T10:00:00Z", null));
+
+        assertEquals(2, service.countUnattributedTurns("2025-01-01", "2025-01-31"));
+    }
+
+    @Test
+    @DisplayName("recordTurnStats persists git_branch round-trip")
+    void recordTurnStatsPersistsBranch() {
+        service.recordTurnStats(turnRecordWithBranch("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z", "feat/round-trip"));
+
+        var results = service.queryBranchTotals("2025-01-01", "2025-01-31");
+        assertEquals(1, results.size());
+        assertEquals("feat/round-trip", results.get(0).branch());
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
@@ -525,6 +525,16 @@ class ToolCallStatisticsServiceTest {
             durationMs, linesAdded, linesRemoved, premiumRequests, timestamp, null, branch);
     }
 
+    private static ToolCallStatisticsService.TurnStatsRecord turnRecordWithBranches(
+        String sessionId, String agentId, String date,
+        long inputTokens, long outputTokens, int toolCalls,
+        long durationMs, int linesAdded, int linesRemoved,
+        double premiumRequests, String timestamp, String startBranch, String endBranch) {
+        return new ToolCallStatisticsService.TurnStatsRecord(
+            sessionId, agentId, date, inputTokens, outputTokens, toolCalls,
+            durationMs, linesAdded, linesRemoved, premiumRequests, timestamp, null, null, startBranch, endBranch);
+    }
+
     @Test
     @DisplayName("queryBranchTotals aggregates per branch and orders by premium DESC")
     void queryBranchTotalsAggregatesAndSorts() {
@@ -591,5 +601,45 @@ class ToolCallStatisticsServiceTest {
         var results = service.queryBranchTotals("2025-01-01", "2025-01-31");
         assertEquals(1, results.size());
         assertEquals("feat/round-trip", results.get(0).branch());
+    }
+
+    @Test
+    @DisplayName("recordTurnStats attributes branch to turn end when end is feature branch")
+    void recordTurnStatsUsesEndBranchForAttribution() {
+        service.recordTurnStats(turnRecordWithBranches("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z", "master", "feat/end"));
+
+        var results = service.queryBranchTotals("2025-01-01", "2025-01-31");
+        assertEquals(1, results.size());
+        assertEquals("feat/end", results.get(0).branch());
+    }
+
+    @Test
+    @DisplayName("recordTurnStats falls back to start branch when end is master")
+    void recordTurnStatsFallsBackToStartWhenEndIsDefaultBranch() {
+        service.recordTurnStats(turnRecordWithBranches("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z", "feat/start", "master"));
+
+        var results = service.queryBranchTotals("2025-01-01", "2025-01-31");
+        assertEquals(1, results.size());
+        assertEquals("feat/start", results.get(0).branch());
+    }
+
+    @Test
+    @DisplayName("recordTurnStats falls back to start branch when end branch is missing")
+    void recordTurnStatsFallsBackToStartWhenEndMissing() {
+        service.recordTurnStats(turnRecordWithBranches("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z", "feat/start", null));
+
+        var results = service.queryBranchTotals("2025-01-01", "2025-01-31");
+        assertEquals(1, results.size());
+        assertEquals("feat/start", results.get(0).branch());
+    }
+
+    @Test
+    @DisplayName("branchForAttribution treats main like a default branch")
+    void branchForAttributionFallsBackFromMain() {
+        assertEquals("feat/start",
+            ToolCallStatisticsService.branchForAttribution("feat/start", "main", null));
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/TurnStatisticsBackfillTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/TurnStatisticsBackfillTest.java
@@ -13,7 +13,10 @@ import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link TurnStatisticsBackfill} — verifies that turn stats entries
@@ -189,13 +192,29 @@ class TurnStatisticsBackfillTest {
         createSessionIndex(basePath, "session-1", "GitHub Copilot");
         createSessionJsonl(basePath, "session-1",
             "{\"type\":\"assistant\",\"text\":\"Hello\",\"timestamp\":\"2025-01-15T10:00:00Z\"}",
-            turnStatsEntryNoTimestamp(100, 200, 3, 5000, 10, 2, "1x"));
+            turnStatsEntryNoTimestamp());
 
         TurnStatisticsBackfill.BackfillResult result =
             TurnStatisticsBackfill.backfill(service, basePath);
 
         assertEquals(1, result.inserted());
         assertTrue(service.hasTurnStatsAt("2025-01-15T10:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("backfills git branch start/end and applies attribution rules")
+    void backfillsGitBranchStartEnd() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1", turnStatsEntryWithBranches());
+
+        TurnStatisticsBackfill.BackfillResult result =
+            TurnStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(1, result.inserted());
+        var branches = service.queryBranchTotals("2025-01-01", "2025-01-31");
+        assertEquals(1, branches.size());
+        assertEquals("feat/end", branches.getFirst().branch());
     }
 
     @Test
@@ -232,18 +251,30 @@ class TurnStatisticsBackfillTest {
             + "}";
     }
 
-    private static String turnStatsEntryNoTimestamp(long inputTokens, long outputTokens,
-                                                    int toolCalls, long durationMs,
-                                                    int linesAdded, int linesRemoved,
-                                                    String multiplier) {
+    private static String turnStatsEntryWithBranches() {
         return "{\"type\":\"turnStats\""
-            + ",\"inputTokens\":" + inputTokens
-            + ",\"outputTokens\":" + outputTokens
-            + ",\"toolCallCount\":" + toolCalls
-            + ",\"durationMs\":" + durationMs
-            + ",\"linesAdded\":" + linesAdded
-            + ",\"linesRemoved\":" + linesRemoved
-            + ",\"multiplier\":\"" + multiplier + "\""
+            + ",\"timestamp\":\"2025-01-15T10:00:00Z\""
+            + ",\"inputTokens\":100"
+            + ",\"outputTokens\":200"
+            + ",\"toolCallCount\":3"
+            + ",\"durationMs\":5000"
+            + ",\"linesAdded\":10"
+            + ",\"linesRemoved\":2"
+            + ",\"multiplier\":\"1x\""
+            + ",\"gitBranchStart\":\"master\""
+            + ",\"gitBranchEnd\":\"feat/end\""
+            + "}";
+    }
+
+    private static String turnStatsEntryNoTimestamp() {
+        return "{\"type\":\"turnStats\""
+            + ",\"inputTokens\":100"
+            + ",\"outputTokens\":200"
+            + ",\"toolCallCount\":3"
+            + ",\"durationMs\":5000"
+            + ",\"linesAdded\":10"
+            + ",\"linesRemoved\":2"
+            + ",\"multiplier\":\"1x\""
             + "}";
     }
 


### PR DESCRIPTION
## Summary
- restrict FocusGuard chat-boundary checks to the actual AgentBridge component hierarchy
- add a regression test so sibling VCS/Run tool-window components are not treated as chat
- document Attempt 14 in the focus-stealing bug notes

## Validation
- FocusGuardTest
- plugin-core IDE build

Stacked on feat/usage-stats-per-branch because origin/master currently lacks the AskUserTool/ChatConsolePanel signature fix that this active branch already contains.