### PR TITLE
docs: explain AgentBridge's IDE-native approach

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -83,13 +83,6 @@ jobs:
             -Dsonar.projectKey="$SONAR_PROJECT_KEY" \
             -Dsonar.organization="$SONAR_ORGANIZATION" \
             -Dsonar.host.url="$SONAR_HOST_URL" \
-            -Dsonar.projectName="AgentBridge" \
-            -Dsonar.sourceEncoding="UTF-8" \
-            -Dsonar.qualitygate.wait=true \
-            -Dsonar.qualitygate.timeout=300 \
-            -Dsonar.sources="plugin-core/src/main/java,plugin-core/chat-ui/src,mcp-server/src/main/java,plugin-experimental/src/main/java" \
-            -Dsonar.tests="plugin-core/src/test/java,plugin-core/js-tests,mcp-server/src/test/java,plugin-experimental/src/test/java" \
-            -Dsonar.java.binaries="plugin-core/build/classes/java/main,plugin-core/build/classes/kotlin/main,mcp-server/build/classes/java/main,plugin-experimental/build/classes/java/main,plugin-experimental/build/classes/kotlin/main" \
-            -Dsonar.coverage.jacoco.xmlReportPaths="plugin-core/build/reports/jacoco/test/jacocoTestReport.xml,mcp-server/build/reports/jacoco/test/jacocoTestReport.xml,plugin-experimental/build/reports/jacoco/test/jacocoTestReport.xml" \
             -Dsonar.javascript.lcov.reportPaths="plugin-core/js-tests/coverage/lcov.info" \
-            -Dsonar.exclusions="**/build/**,**/out/**,.agent-work/**,plugin-core/chat-ui/dist/**,plugin-core/chat-ui/node_modules/**,plugin-core/js-tests/node_modules/**"
+            -Dsonar.qualitygate.wait=true \
+            -Dsonar.qualitygate.timeout=300

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,95 @@
+name: SonarQube
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened ]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: sonarqube-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY || 'catatafishen_agentbridge' }}
+  SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION || 'catatafishen' }}
+  SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+
+jobs:
+  analyze:
+    name: SonarQube analysis
+    runs-on: ubuntu-latest
+    environment: ci
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: |
+            plugin-core/chat-ui/package-lock.json
+            plugin-core/js-tests/package-lock.json
+
+      - name: Install chat-ui dependencies
+        run: npm ci --silent --ignore-scripts
+        working-directory: plugin-core/chat-ui
+
+      - name: Install JS test dependencies
+        run: npm ci --silent --ignore-scripts
+        working-directory: plugin-core/js-tests
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e  # v6.1.0
+        with:
+          gradle-version: 'wrapper'
+          cache-disabled: true
+
+      - name: Run tests with coverage
+        run: |
+          npm run test:coverage --prefix plugin-core/js-tests
+          npm run build --prefix plugin-core/chat-ui
+          gradle :mcp-server:test :mcp-server:jacocoTestReport \
+            :plugin-experimental:test :plugin-experimental:jacocoTestReport \
+            :plugin-core:test :plugin-core:jacocoTestReport \
+            --no-daemon --quiet --build-cache
+
+      - name: Run SonarQube analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          gradle sonar --no-daemon --quiet \
+            -Dsonar.projectKey="$SONAR_PROJECT_KEY" \
+            -Dsonar.organization="$SONAR_ORGANIZATION" \
+            -Dsonar.host.url="$SONAR_HOST_URL" \
+            -Dsonar.projectName="AgentBridge" \
+            -Dsonar.sourceEncoding="UTF-8" \
+            -Dsonar.qualitygate.wait=true \
+            -Dsonar.qualitygate.timeout=300 \
+            -Dsonar.sources="plugin-core/src/main/java,plugin-core/chat-ui/src,mcp-server/src/main/java,plugin-experimental/src/main/java" \
+            -Dsonar.tests="plugin-core/src/test/java,plugin-core/js-tests,mcp-server/src/test/java,plugin-experimental/src/test/java" \
+            -Dsonar.java.binaries="plugin-core/build/classes/java/main,plugin-core/build/classes/kotlin/main,mcp-server/build/classes/java/main,plugin-experimental/build/classes/java/main,plugin-experimental/build/classes/kotlin/main" \
+            -Dsonar.coverage.jacoco.xmlReportPaths="plugin-core/build/reports/jacoco/test/jacocoTestReport.xml,mcp-server/build/reports/jacoco/test/jacocoTestReport.xml,plugin-experimental/build/reports/jacoco/test/jacocoTestReport.xml" \
+            -Dsonar.javascript.lcov.reportPaths="plugin-core/js-tests/coverage/lcov.info" \
+            -Dsonar.exclusions="**/build/**,**/out/**,.agent-work/**,plugin-core/chat-ui/dist/**,plugin-core/chat-ui/node_modules/**,plugin-core/js-tests/node_modules/**"

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -83,6 +83,7 @@ jobs:
             -Dsonar.projectKey="$SONAR_PROJECT_KEY" \
             -Dsonar.organization="$SONAR_ORGANIZATION" \
             -Dsonar.host.url="$SONAR_HOST_URL" \
+            -Dsonar.sources.inclusions="plugin-core/chat-ui/src/**" \
             -Dsonar.javascript.lcov.reportPaths="plugin-core/js-tests/coverage/lcov.info" \
             -Dsonar.qualitygate.wait=true \
             -Dsonar.qualitygate.timeout=300

--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@ or generating diffs in isolation.
 - **PWA web access** — use the chat from any device on your local network via HTTPS.
 - **Human in the loop** — every action is visible in the IDE. Undo, review, or redirect at any point.
 
+## Why this approach?
+
+AgentBridge is built around a simple idea: if a full JetBrains IDE helps humans work in a
+fail-fast way, agents should be able to use that same IDE feedback loop too. Instead of asking
+an LLM to approximate refactorings, code intelligence, inspections, Git state, and project
+context from text alone, AgentBridge lets the agent call the deterministic IDE tools directly.
+
+See [Why AgentBridge?](docs/WHY-AGENTBRIDGE.md) for the longer reasoning behind this IDE-native
+approach and why I think it is worth exploring alongside lighter agent wrappers and harnesses.
+
+## Project status, collaborators, and reviews
+
+AgentBridge is starting to feel feature-ready. Most current work is tuning behavior, polishing
+workflows, and following what agent CLIs expose through ACP so new capabilities can be integrated
+when they become available.
+
+I would be happy to have collaborators, especially for code review. A healthy practice for
+agent-authored changes is at least two pairs of human eyes; right now I mostly review changes
+alone after prompting Copilot to make them.
+
+If you use the plugin and find it useful, an honest rating or review on the
+[JetBrains Marketplace](https://plugins.jetbrains.com/plugin/30415-agentbridge) would help other
+users decide whether to try it. The plugin is approaching 2,000 downloads, and Marketplace update
+stats suggest hundreds of active installs, but I understand why someone might hesitate to install
+a plugin with no reviews.
+
 ## Supported Agents
 
 | Agent                          | Protocol                   | Authentication                |

--- a/README.md
+++ b/README.md
@@ -28,20 +28,23 @@ or generating diffs in isolation.
 AgentBridge is built around a simple idea: if a full JetBrains IDE helps humans work in a
 fail-fast way, agents should be able to use that same IDE feedback loop too. Instead of asking
 an LLM to approximate refactorings, code intelligence, inspections, Git state, and project
-context from text alone, AgentBridge lets the agent call the deterministic IDE tools directly.
+context from text alone, AgentBridge lets the agent call deterministic IDE tools directly.
 
-See [Why AgentBridge?](docs/WHY-AGENTBRIDGE.md) for the longer reasoning behind this IDE-native
-approach and why I think it is worth exploring alongside lighter agent wrappers and harnesses.
+See [The Case for IDE-Native Coding Agents](docs/IDE-NATIVE-CODING-AGENTS.md) for the longer
+reasoning behind this IDE-native approach and why I think it is worth exploring alongside
+lighter agent wrappers and harnesses.
 
 ## Project status, collaborators, and reviews
 
 AgentBridge is starting to feel feature-ready. Most current work is tuning behavior, polishing
-workflows, and following what agent CLIs expose through ACP so new capabilities can be integrated
-when they become available.
+workflows, fixing rough edges, and following what agent CLIs expose through ACP so new capabilities
+can be integrated as they become available.
 
-I would be happy to have collaborators, especially for code review. A healthy practice for
-agent-authored changes is at least two pairs of human eyes; right now I mostly review changes
-alone after prompting Copilot to make them.
+I would be happy to have collaborators, especially for code review. I think a healthy practice for
+agent-authored changes is to have at least two pairs of human eyes on important changes; right now I
+mostly review the changes I asked Copilot to make. Just ping me if you would like to help.
+I am also glad there are now actionable issues reported on GitHub. That feedback helps me prioritize
+work and confirms that the effort I spend on this project is worthwhile.
 
 If you use the plugin and find it useful, an honest rating or review on the
 [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/30415-agentbridge) would help other

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("java")
+    id("org.sonarqube") version "7.3.0.8198"
     id("org.jetbrains.kotlin.jvm") version "2.3.20" apply false
     id("org.jetbrains.intellij.platform") version "2.14.0" apply false
     idea

--- a/docs/IDE-NATIVE-CODING-AGENTS.md
+++ b/docs/IDE-NATIVE-CODING-AGENTS.md
@@ -1,6 +1,7 @@
-# Why AgentBridge?
+# The Case for IDE-Native Coding Agents
 
-AgentBridge is an experiment in keeping agentic coding close to the way many of us already work in a full IDE.
+AgentBridge is one concrete experiment in keeping agentic coding close to the way many of us already work in a
+full IDE.
 
 Historically, developers have often split into two broad camps. Some prefer lightweight editors because they are fast,
 flexible, and stay out of the way. Others prefer full IDEs like IntelliJ IDEA and the rest of the JetBrains family
@@ -156,3 +157,9 @@ more of its reasoning on the actual software change.
 That does not make the IDE-native approach universally better. It does make it worth trying, especially on projects
 where IntelliJ already understands a lot of the codebase and where fast feedback, safe refactoring, inspections, Git
 integration, and test tooling are part of the daily workflow.
+
+---
+
+**Disclosure:** This text is a collaboration between me, the AgentBridge maintainer, and GitHub Copilot. I provided the
+core argument, examples, opinions, and direction. Copilot helped turn those notes into a structured essay, tighten the
+language, and add external references. The viewpoint is mine; AI helped with editing and drafting.

--- a/docs/WHY-AGENTBRIDGE.md
+++ b/docs/WHY-AGENTBRIDGE.md
@@ -22,6 +22,46 @@ fraction of what an IDE like IntelliJ enables.
 The important difference is not only that the agent can ask the IDE a question. It is whether the agent is working
 through the IDE in the same feedback loop a human would.
 
+## Related work and external references
+
+AgentBridge is not the only attempt to improve the interface between agents and development tools. The broader ecosystem
+is clearly moving from "prompt plus shell" toward richer, more structured interfaces.
+
+[MCP](https://modelcontextprotocol.io/introduction) is probably the most visible example. The project describes MCP as
+"an open-source standard for connecting AI applications to external systems" and compares it to "a USB-C port for AI
+applications". That is exactly the direction AgentBridge depends on: agents should not need to rediscover everything
+from raw text if a better tool interface exists. AgentBridge's narrower bet is that a JetBrains IDE is one of the most
+valuable external systems to connect.
+
+The [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) is another important precedent.
+It standardized how editors get language features such as autocomplete, go to definition, and hover documentation from a
+language server. LSP made language intelligence more portable across tools, and many agent integrations now expose
+LSP-like symbol search or diagnostics. I think that is useful, but still smaller than the full IDE surface. JetBrains'
+[Program Structure Interface](https://plugins.jetbrains.com/docs/intellij/psi.html) is described as the layer that
+creates the "syntactic and semantic code model" powering platform features. AgentBridge tries to expose more of that
+platform, not only the few features that fit neatly into an LSP-shaped box.
+
+The SWE-agent paper and project also make a useful point in the title alone:
+["Agent-Computer Interfaces Enable Automated Software Engineering"](https://arxiv.org/abs/2405.15793). Their
+open-source project focuses on agents autonomously using tools to fix real GitHub issues. That framing matters: the
+interface you give the agent changes what the agent can do. AgentBridge agrees with that thesis, but explores a
+different interface: not primarily a terminal-centric computer interface, but an IDE-native one.
+
+Hooks are another path the ecosystem is exploring. Claude Code documents hooks as
+["user-defined shell commands, HTTP endpoints, or LLM prompts"](https://code.claude.com/docs/en/hooks) that run at
+specific lifecycle points, including before and after tool use. I think hooks are valuable, especially when they call
+deterministic tools. My concern is mostly timing and synchronization: if a hook fixes or reformats something after the
+agent's edit, the agent may already be reasoning from stale context. AgentBridge tries to make that feedback part of the
+same IDE-aware tool response when possible.
+
+The JetBrains documentation also backs the core IDE-native argument. IntelliJ inspections
+["detect and correct abnormal code ... before you compile it"](https://www.jetbrains.com/help/idea/code-inspection.html)
+and can find probable bugs, dead code, spelling problems, and structural issues. [Intention actions](https://www.jetbrains.com/help/idea/intention-actions.html)
+are described as the IDE analyzing code as you work and searching for ways to optimize it.
+[Refactoring support](https://www.jetbrains.com/help/idea/refactoring-source-code.html) is documented as a first-class
+IDE workflow with previews, conflict handling, and popular automated refactorings. These are exactly the kinds of
+deterministic, context-rich capabilities I want agents to use directly instead of approximating with text edits.
+
 ## Fail fast matters even more for agents
 
 When a human edits code in IntelliJ, feedback appears immediately. Imports are suggested. Errors and warnings are

--- a/docs/WHY-AGENTBRIDGE.md
+++ b/docs/WHY-AGENTBRIDGE.md
@@ -1,0 +1,101 @@
+# Why AgentBridge?
+
+AgentBridge is an experiment in keeping agentic coding close to the way many of us already work in a full IDE.
+
+Historically, developers have often split into two broad camps. Some prefer lightweight editors because they are fast,
+flexible, and stay out of the way. Others prefer full IDEs like IntelliJ IDEA and the rest of the JetBrains family
+because the IDE constantly keeps more of the project in view: types, inspections, refactorings, tests, Git state,
+database connections, run configurations, and framework knowledge.
+
+Both approaches have their place. The right tool depends on the project, the language, the team, and how much
+infrastructure the IDE can understand. Personally, I have always preferred IntelliJ. Even when it feels heavier, it
+helps me work in a fail-fast way: I quickly see when something is wrong, I get warnings before problems become bugs,
+and weak warnings often explain why the code I just wrote is not quite right yet. Plugins such as SonarQube for IDE
+make that feedback loop even stronger.
+
+In the current agentic coding world, the lightweight-editor model seems to be winning. The human often moves from a
+full IDE into an agent wrapper, terminal harness, or chat-first environment. The agent also works mostly through file
+reads, text edits, shell commands, and maybe a few language-server-style helpers. Lately there has been good progress
+on adding symbol search, semantic editing, and highlight-reading through MCP servers, but I still think that is only a
+fraction of what an IDE like IntelliJ enables.
+
+The important difference is not only that the agent can ask the IDE a question. It is whether the agent is working
+through the IDE in the same feedback loop a human would.
+
+## Fail fast matters even more for agents
+
+When a human edits code in IntelliJ, feedback appears immediately. Imports are suggested. Errors and warnings are
+highlighted. Intentions and quick-fixes show up while the surrounding context is still fresh in the developer's head.
+
+Many agents do not get that loop. They edit a file, continue with the task, and only later run a separate check if
+prompted or if a hook tells them to. By then the agent may have lost some of the local reasoning that led to the edit.
+I have seen agents implement a feature, later review their own code, find a warning, and then "fix" the warning by
+changing behavior that was actually required. The problem was detected, but too late in the reasoning flow.
+
+AgentBridge tries to surface IDE feedback immediately in the tool response. If an edit creates highlights, formatting
+changes, or import changes, the agent can react while it still remembers why it made the edit. That keeps the warning
+tied to the original goal instead of turning it into a separate clean-up task with weaker context.
+
+For agents, this fail-fast loop is not a luxury. It helps prevent expensive circles: edit, scan, forget, overcorrect,
+rebuild, rediscover the original requirement.
+
+## Deterministic tools should not be reinvented by an LLM
+
+Renaming a function is the simplest example. An LLM can search the codebase, edit every reference it finds, build,
+read errors, search again, and eventually get close. That is slow, token-heavy, and still easy to get subtly wrong.
+
+An IDE refactoring engine already knows how to do this. It has the PSI model, imports, overloads, references, usages,
+and project structure. For a task with a deterministic result, the agent should call the deterministic tool and spend
+its reasoning budget on higher-level design decisions.
+
+This becomes more interesting because agents are not limited by the same UI friction humans have. As a human, I
+sometimes ignore a long refactoring menu because reading it takes longer than doing the edit manually. An agent can
+inspect the available actions quickly, choose the right one, and let IntelliJ apply it. That is where coding agents can
+actually benefit more from a full IDE than humans do.
+
+AgentBridge exposes these IDE-native operations as tools: semantic navigation, usage search, refactoring, quick-fixes,
+inspections, test discovery, run configurations, debugging, Git operations, project structure, database browsing, and
+more. The goal is not to make the model pretend to be IntelliJ. The goal is to let IntelliJ do the things IntelliJ is
+already good at.
+
+## Formatting and linting should stay synchronized
+
+Formatting, linting, and import cleanup can be added to agents through hooks, skills, and instructions. Hooks are
+usually the best of those options because they call deterministic tools. Instructions that tell the model how to indent
+code are mostly wasted context.
+
+But hooks can still happen late in the flow. If a hook reformats a file after an edit, the agent may still hold the old
+version in context and make the next patch against stale text. That can cause avoidable conflicts or accidental
+rewrites.
+
+AgentBridge tries to keep this tighter. File writes go through IntelliJ's document model, auto-formatting and import
+optimization can run as part of the IDE-aware edit path, and the result is reported back to the agent immediately.
+Symbol-based edits go further by targeting methods, classes, and fields instead of fragile line ranges.
+
+The point is not that formatting is hard. The point is that the agent, the IDE buffer, and the user's editor should
+agree about what the file looks like as early as possible.
+
+## The IDE has broader project context
+
+Over time I have also started using Git and database tools inside IntelliJ, not because the terminal versions are bad,
+but because the IDE already has connected context. It knows the project, open editors, VCS roots, run configurations,
+database connections, warnings, and generated files. Keeping those tools in one environment can reveal useful
+relationships that isolated terminal commands miss.
+
+AgentBridge follows the same idea. Git operations go through the IDE's VCS layer where possible. Test runs appear in
+the IDE test runner. Builds show up in the Build window. Database tools use configured IntelliJ data sources. The agent
+is not only editing files on disk; it is working inside the same project model the developer is using.
+
+## This is still an experiment
+
+Agentic coding is still new. It is too early to say which interaction model will win. Lightweight editor wrappers,
+terminal harnesses, cloud agents, IDE plugins, and specialized MCP servers are all exploring useful pieces of the
+problem.
+
+AgentBridge is my argument for one particular direction: if a developer already benefits from a full IDE, an agent may
+benefit even more. The agent can offload deterministic operations to IDE APIs, react to feedback earlier, and spend
+more of its reasoning on the actual software change.
+
+That does not make the IDE-native approach universally better. It does make it worth trying, especially on projects
+where IntelliJ already understands a lot of the codebase and where fast feedback, safe refactoring, inspections, Git
+integration, and test tooling are part of the daily workflow.

--- a/docs/WHY-AGENTBRIDGE.md
+++ b/docs/WHY-AGENTBRIDGE.md
@@ -79,6 +79,23 @@ tied to the original goal instead of turning it into a separate clean-up task wi
 For agents, this fail-fast loop is not a luxury. It helps prevent expensive circles: edit, scan, forget, overcorrect,
 rebuild, rediscover the original requirement.
 
+## Strict quality gates fit agentic development
+
+Strict gates such as test coverage requirements, cyclomatic complexity limits, duplication checks, and static-analysis
+rules have always been valuable, but there has traditionally been a real tradeoff. Human teams have to decide how much
+time to spend refactoring working code versus building the next feature.
+
+Agentic development changes that tradeoff. Asking an agent to satisfy a coverage threshold, split a complex method, or
+clean up a warning is much cheaper than asking a human to spend the same focus time on it. That kind of maintenance work
+is almost perfect agent work: deterministic feedback, clear pass/fail criteria, and a strong bias toward code that is
+simpler when the next functional requirement arrives.
+
+This matters because agents still tend to focus on the task directly in front of them. They do not reliably hold the
+full product plan or long-term architecture in mind. A clean, clear, well-tested codebase gives the agent guardrails. As
+the codebase grows, maintainable code is not only nicer for humans; it also makes future agent edits safer and less
+likely to drift away from the larger design. The bigger picture can stay in the human's mind, while the agent can be
+trusted with smaller, well-bounded changes.
+
 ## Deterministic tools should not be reinvented by an LLM
 
 Renaming a function is the simplest example. An LLM can search the codebase, edit every reference it finds, build,


### PR DESCRIPTION
## Summary
- add docs/WHY-AGENTBRIDGE.md with rationale for the IDE-native agent workflow
- link the rationale from the README near the top
- add visible README notes about project status, collaborators/code review, and Marketplace reviews

## Validation
- documentation-only change