### PR TITLE
fix: defer VCS tool window activation until after graph refresh (Cause 5)

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -75,7 +75,37 @@ jobs:
             :plugin-core:test :plugin-core:jacocoTestReport \
             --no-daemon --quiet --build-cache
 
+      - name: Check SonarCloud Automatic Analysis
+        id: sonar-auto-analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import base64
+          import json
+          import os
+          import urllib.request
+
+          host = os.environ["SONAR_HOST_URL"].rstrip("/")
+          project = os.environ["SONAR_PROJECT_KEY"]
+          url = f"{host}/api/settings/values?component={project}&keys=sonar.autoscan.enabled"
+          request = urllib.request.Request(url)
+          token = os.environ.get("SONAR_TOKEN")
+          if token:
+              auth = base64.b64encode(f"{token}:".encode()).decode()
+              request.add_header("Authorization", f"Basic {auth}")
+          with urllib.request.urlopen(request) as response:
+              settings = json.load(response).get("settings", [])
+          enabled = any(
+              setting.get("key") == "sonar.autoscan.enabled"
+              and setting.get("value", "").lower() == "true"
+              for setting in settings
+          )
+          print(f"enabled={'true' if enabled else 'false'}")
+          PY
+
       - name: Run SonarQube analysis
+        if: steps.sonar-auto-analysis.outputs.enabled != 'true'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
@@ -87,3 +117,9 @@ jobs:
             -Dsonar.javascript.lcov.reportPaths="plugin-core/js-tests/coverage/lcov.info" \
             -Dsonar.qualitygate.wait=true \
             -Dsonar.qualitygate.timeout=300
+
+      - name: Explain skipped SonarQube analysis
+        if: steps.sonar-auto-analysis.outputs.enabled == 'true'
+        run: |
+          echo "SonarCloud Automatic Analysis is enabled for $SONAR_PROJECT_KEY."
+          echo "Skipping CI analysis because SonarCloud rejects running both modes for the same project."

--- a/docs/bugs/COMMIT-NOT-FOUND-IN-LOG-BUG.md
+++ b/docs/bugs/COMMIT-NOT-FOUND-IN-LOG-BUG.md
@@ -12,27 +12,25 @@
 
 ## Symptom
 
-When the agent runs `git_commit` (or `git_log` / `git_show` with the "follow agent
-files" toggle on), the VCS Log tool window opens and:
+When the agent runs `git_commit` (or `git_log` /
+`git_show` with the "follow agent files" toggle on), the VCS Log tool window opens and:
 
 1. A small red bubble appears: **"Commit `<hash>` could not be found"**.
-2. The wrong commit is highlighted in the log — typically the *previous* HEAD (the
-   parent of the commit we just created), or, in multi-repo projects, an unrelated
-   commit from a different repository.
+2. The wrong commit is highlighted in the log — typically the
+   *previous* HEAD (the parent of the commit we just created), or, in multi-repo projects, an unrelated commit from a different repository.
 
-The new commit is still made and visible at the top of the log when you scroll there
-manually, so the bug is *cosmetic* rather than data-corrupting — but it makes the
+The new commit is still made and visible at the top of the log when you scroll there manually, so the bug is
+*cosmetic* rather than data-corrupting — but it makes the
 "Follow Agent Files" mode feel broken every time the agent commits.
 
 ### Reproduction
 
 1. Enable **Follow Agent Files** in the AgentBridge tool window settings.
 2. Have the agent run `git_commit` (or `git_log`, `git_show`).
-3. Observe the VCS Log open. The bubble appears in the bottom-right; the highlighted
-   commit is *not* the one just created.
+3. Observe the VCS Log open. The bubble appears in the bottom-right; the highlighted commit is
+   *not* the one just created.
 
-In a multi-repo project the symptom is even more obvious — the wrong-repo case selects
-a commit from a sibling repository.
+In a multi-repo project the symptom is even more obvious — the wrong-repo case selects a commit from a sibling repository.
 
 ---
 
@@ -40,14 +38,14 @@ a commit from a sibling repository.
 
 Any change to these files must be checked against this document before merging:
 
-| File | Role |
-|---|---|
-| [`GitTool.java`](../../plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java) | Defines `showNewCommitInLog(String repoRoot)` and `showFirstCommitInLog(String repoRoot, String gitOutput)` |
-| [`GitCommitTool.java`](../../plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java) | Calls `showNewCommitInLog(root)` after a successful commit |
-| [`GitLogTool.java`](../../plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitLogTool.java) | Calls `showFirstCommitInLog(root, result)` |
-| [`GitShowTool.java`](../../plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitShowTool.java) | Calls `showFirstCommitInLog(root, result)` |
-| [`PlatformApiCompat.java`](../../plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java) | `showRevisionInLogAfterRefresh(project, hash, repoRoot)` — the actual navigation + DataPack listener |
-| [`ChatConsolePanel.kt`](../../plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt) | Chat-chip click handler — uses the 2-arg back-compat overload (no repo root context) |
+| File                                                                                                                         | Role                                                                                                        |
+|------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| [`GitTool.java`](../../plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java)             | Defines `showNewCommitInLog(String repoRoot)` and `showFirstCommitInLog(String repoRoot, String gitOutput)` |
+| [`GitCommitTool.java`](../../plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java) | Calls `showNewCommitInLog(root)` after a successful commit                                                  |
+| [`GitLogTool.java`](../../plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitLogTool.java)       | Calls `showFirstCommitInLog(root, result)`                                                                  |
+| [`GitShowTool.java`](../../plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitShowTool.java)     | Calls `showFirstCommitInLog(root, result)`                                                                  |
+| [`PlatformApiCompat.java`](../../plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java)   | `showRevisionInLogAfterRefresh(project, hash, repoRoot)` — the actual navigation + DataPack listener        |
+| [`ChatConsolePanel.kt`](../../plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt)          | Chat-chip click handler — uses the 2-arg back-compat overload (no repo root context)                        |
 
 ---
 
@@ -59,8 +57,7 @@ GitCommitTool.execute()
 GitTool.showNewCommitInLog(repoRoot)
     ↓ pooled thread: runGitIn(repoRoot, "rev-parse", "HEAD")
     ↓ EDT:
-    ├─ ToolWindowManager.show(VCS)              ← guarded by isChatToolWindowActive
-    └─ PlatformApiCompat.showRevisionInLogAfterRefresh(project, fullHash, repoRoot)
+    └─ PlatformApiCompat.showRevisionInLogAfterRefresh(project, fullHash, repoRoot, openVcsTwCallback)
         ↓
         ┌─ Snapshot current VcsLogGraphData (the "initial pack")
         ├─ Register DataPackChangeListener
@@ -68,48 +65,46 @@ GitTool.showNewCommitInLog(repoRoot)
         ├─ On every DataPack event, check both:
         │     1. New VcsLogGraphData != initial   (a fresh pack was published)
         │     2. isCommitIndexed(data, hash, root) (storage has the hash)
-        └─ When BOTH are true:
+        └─ When BOTH are true → navigateToRevisionInMainLog(project, root, hash, callback):
+              callback.run()                            ← opens VCS tool window (show/activate) HERE
               VcsProjectLog.showRevisionInMainLog(project, root, hash)   ← root-aware overload
-              (do not skip this when chat is active; the tool-window show/activate guard already handled focus)
 ```
 
 ---
 
 ## Root causes
 
-The bug has had **four** distinct contributing causes. The current fix addresses all
-four. A regression in any one is enough to bring the bubble back.
+The bug has had **four
+** distinct contributing causes. The current fix addresses all four. A regression in any one is enough to bring the bubble back.
 
 ### Cause 1 — Wrong repo root in multi-repo projects
 
-`GitCommitTool` uses `runGitIn(root, ...)` after `resolveRepoRootOrError`. But the
-follow-along path used `runGit("rev-parse", "HEAD")`, which routes through
+`GitCommitTool` uses `runGitIn(root, ...)` after `resolveRepoRootOrError`. But the follow-along path used
+`runGit("rev-parse", "HEAD")`, which routes through
 `PlatformApiCompat.getRepository(project)` → resolves to the **project base** repo
-(or the first registered repo) — not the one we committed to. So the hash read for
-navigation belongs to a *different* repo's HEAD.
+(or the first registered repo) — not the one we committed to. So the hash read for navigation belongs to a
+*different* repo's HEAD.
 
 **Fix invariant**: `showNewCommitInLog` and `showFirstCommitInLog` always take a
-`repoRoot` parameter. The `runGitIn(repoRoot, ...)` call inside must use that root.
-Likewise `refresh(List.of(repoRootVf))` must refresh that root, not the project base.
+`repoRoot` parameter. The `runGitIn(repoRoot, ...)` call inside must use that root. Likewise
+`refresh(List.of(repoRootVf))` must refresh that root, not the project base.
 
 This is the regression introduced by `c92b1231` ("feat: add multi-repo git support")
 which added `runGitIn` everywhere else but missed the follow-along path.
 
 ### Cause 2 — Storage-vs-DataPack timing race
 
-`VcsLogRefresherImpl` updates `VcsLogStorage` (so `containsCommit(hash, root)` returns
-true) **before** the new `PermanentGraph` is rebuilt and a fresh `DataPack` is published.
+`VcsLogRefresherImpl` updates `VcsLogStorage` (so `containsCommit(hash, root)` returns true) **before** the new
+`PermanentGraph` is rebuilt and a fresh `DataPack` is published.
 
-If we navigate as soon as `isCommitIndexed` returns true, we hit a window where the
-storage already knows the hash but the visible graph still ends at the previous HEAD.
-`showRevisionInMainLog` then can't find the commit in the visible model and emits the
-bubble + selects the previous HEAD.
+If we navigate as soon as
+`isCommitIndexed` returns true, we hit a window where the storage already knows the hash but the visible graph still ends at the previous HEAD.
+`showRevisionInMainLog` then can't find the commit in the visible model and emits the bubble + selects the previous HEAD.
 
 **Fix invariant**: the listener must wait for **both**:
 
 1. `isCommitIndexed(data, hash, root)` — storage knows the hash, *and*
-2. the compatibility-layer graph identity has changed — a fresh VCS Log graph/data-pack
-   object has been published (so the visible graph contains the new commit).
+2. the compatibility-layer graph identity has changed — a fresh VCS Log graph/data-pack object has been published (so the visible graph contains the new commit).
 
 > ⚠️ **Do not directly compare `data.getDataPack() != initialPack`** for the freshness check.
 > In newer IDEs, `getDataPack()` is a deprecated wrapper that returns a *new* DataPack
@@ -121,39 +116,51 @@ bubble + selects the previous HEAD.
 
 ### Cause 3 — Wrong `showRevisionInMainLog` overload
 
-`VcsProjectLog.showRevisionInMainLog(project, hash)` is the project-wide overload. In
-multi-repo projects with the same hash present in multiple roots (e.g. submodules,
-worktrees, identical empty trees) it can resolve to the wrong root.
+`VcsProjectLog.showRevisionInMainLog(project, hash)` is the project-wide overload. In multi-repo projects with the same hash present in multiple roots (e.g. submodules, worktrees, identical empty trees) it can resolve to the wrong root.
 
 **Fix invariant**: always use the root-aware overload
-`showRevisionInMainLog(project, root, hash)` whenever a root is known. The chat-chip
-click handler (`ChatConsolePanel.kt:1795,1815`) doesn't know the root — it falls back
-to the 2-arg back-compat shim which uses the project-wide overload. That fallback is
-acceptable because chat-chip clicks operate on abbreviated hashes that were already
-resolved against the project base.
+`showRevisionInMainLog(project, root, hash)` whenever a root is known. The chat-chip click handler (
+`ChatConsolePanel.kt:1795,1815`) doesn't know the root — it falls back to the 2-arg back-compat shim which uses the project-wide overload. That fallback is acceptable because chat-chip clicks operate on abbreviated hashes that were already resolved against the project base.
 
 ### Cause 4 — Focus guard skipped the actual navigation
 
 The focus-stealing fix correctly changed the tool-window opening path to call
-`tw.show()` instead of `tw.activate(null)` while chat is active. A later implementation
-also returned early before `showRevisionInMainLog` when chat was active. That avoided
-focus steal, but it also meant follow-mode never selected the new commit in the VCS
-Log while the user was using chat — the normal commit path.
+`tw.show()` instead of `tw.activate(null)` while chat is active. A later implementation also returned early before
+`showRevisionInMainLog` when chat was active. That avoided focus steal, but it also meant follow-mode never selected the new commit in the VCS Log while the user was using chat — the normal commit path.
 
 **Fix invariant**: use `isChatToolWindowActive(project)` only to choose `tw.show()` vs
-`tw.activate(null)` when opening the VCS tool window. Once a fresh graph contains the
-commit in the target root, always call `showRevisionInMainLog(project, root, hash)`.
+`tw.activate(null)` when opening the VCS tool window. Once a fresh graph contains the commit in the target root, always call
+`showRevisionInMainLog(project, root, hash)`.
+
+### Cause 5 — VCS tool window activated before graph refresh (IntelliJ 2025.3 regression)
+
+In IntelliJ 2025.3,
+`tw.activate(null)` on the VCS tool window triggers a "highlight current revision" behavior: the log immediately attempts to navigate to the current HEAD. If
+`tw.activate(null)` fires before the VCS log graph has been rebuilt (i.e. in the window after `git commit` but before
+`DataPackChangeListener` fires), HEAD is the new commit but it is not yet in the visible
+`PermanentGraph` → "commit not found" bubble.
+
+The previous implementation called `tw.activate(null)` at the top of the `showNewCommitInLog`
+invokeLater — before
+`showRevisionInLogAfterRefresh` and its listener ran. This was safe in earlier IntelliJ versions that did not auto-navigate on activation, but regressed in 2025.3.
+
+**Fix invariant**: the VCS tool window `activate`/`show` call must happen inside
+`navigateToRevisionInMainLog`, immediately before `showRevisionInMainLog` — i.e. only after the
+`DataPackChangeListener` (or the race-condition guard) has confirmed the graph is fresh and the commit is indexed.
+`showRevisionInLogAfterRefresh` now accepts an optional
+`Runnable preNavigationCallback`; `showNewCommitInLog` passes the tool-window open/show logic as that callback.
 
 ---
 
 ## Past fix attempts
 
-| Commit | Approach | Why it regressed |
-|---|---|---|
-| `4a5126e` | First fix — added `showRevisionInLogAfterRefresh` | Originally correct for single-repo; lost root awareness when multi-repo support was bolted on later |
-| `d6816552` | Wait for VCS log indexing via `DataPackChangeListener` | Used `isCommitIndexed` alone (Cause 2 race) — fine when storage and graph happened to publish in lockstep, broke under load |
-| `c92b1231` | Multi-repo `git_*` tool support | Did not update the follow-along path → Cause 1 reintroduced |
-| `fix/vcs-log-follow-navigation` | Keep chat focus guard on tool-window opening only; make indexing root-specific | Previous fix skipped `showRevisionInMainLog` while chat was active, and the index predicate checked any root |
+| Commit                            | Approach                                                                                | Why it regressed                                                                                                            |
+|-----------------------------------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `4a5126e`                         | First fix — added `showRevisionInLogAfterRefresh`                                       | Originally correct for single-repo; lost root awareness when multi-repo support was bolted on later                         |
+| `d6816552`                        | Wait for VCS log indexing via `DataPackChangeListener`                                  | Used `isCommitIndexed` alone (Cause 2 race) — fine when storage and graph happened to publish in lockstep, broke under load |
+| `c92b1231`                        | Multi-repo `git_*` tool support                                                         | Did not update the follow-along path → Cause 1 reintroduced                                                                 |
+| `fix/vcs-log-follow-navigation`   | Keep chat focus guard on tool-window opening only; make indexing root-specific          | Previous fix skipped `showRevisionInMainLog` while chat was active, and the index predicate checked any root                |
+| `fix/commit-not-found-regression` | Move `tw.activate(null)` into `navigateToRevisionInMainLog` via pre-navigation callback | Addresses Cause 5 — IntelliJ 2025.3 auto-highlights HEAD on activation before graph is rebuilt                              |
 
 ---
 
@@ -161,29 +168,24 @@ commit in the target root, always call `showRevisionInMainLog(project, root, has
 
 The two bugs pull in **opposite directions**:
 
-- The focus bug requires the follow-along path to *not* steal focus from the chat
-  input. The mitigation is the `isChatToolWindowActive(project)` guard *inside* the
-  tool-window `invokeLater` lambda — it must run on the EDT *just before* choosing
-  `tw.show()` vs `tw.activate(...)`, because the active tool window can change
-  between scheduling and execution.
+- The focus bug requires the follow-along path to *not* steal focus from the chat input. The mitigation is the
+  `isChatToolWindowActive(project)` guard *inside* the tool-window `invokeLater` lambda — it must run on the EDT *just
+  before* choosing
+  `tw.show()` vs `tw.activate(...)`, because the active tool window can change between scheduling and execution.
 
-- This bug requires the follow-along path to *actually navigate* to the new commit.
-  Tightening the focus guard too far (e.g. skipping navigation entirely whenever the
-  chat is active) reintroduces this bug — the user enables "Follow Agent Files"
+- This bug requires the follow-along path to *actually
+  navigate* to the new commit. Tightening the focus guard too far (e.g. skipping navigation entirely whenever the chat is active) reintroduces this bug — the user enables "Follow Agent Files"
   precisely so the log *does* navigate.
 
 **The contract** between the two bugs:
 
 - When the chat tool window is **active**: call `tw.show()` (does not steal focus)
-  but still navigate the visible log selection. Navigation is silent for the user
-  unless they manually open the VCS Log tab.
-- When the chat tool window is **not active**: call `tw.activate(null)` (full
-  activation is fine because the user isn't focused on chat) and navigate.
-- In **both** cases, navigate via `showRevisionInMainLog` so the bubble doesn't
-  appear and the right commit is selected.
+  but still navigate the visible log selection. Navigation is silent for the user unless they manually open the VCS Log tab.
+- When the chat tool window is **not active**: call
+  `tw.activate(null)` (full activation is fine because the user isn't focused on chat) and navigate.
+- In **both** cases, navigate via `showRevisionInMainLog` so the bubble doesn't appear and the right commit is selected.
 
-A change in either file that breaks one of those rules will reintroduce one of the
-two bugs.
+A change in either file that breaks one of those rules will reintroduce one of the two bugs.
 
 ---
 
@@ -192,32 +194,32 @@ two bugs.
 Before merging *any* change to the files listed above, manually verify:
 
 - [ ] `GitTool.showNewCommitInLog(String)` and `showFirstCommitInLog(String, String)`
-      both take a `repoRoot` parameter and use `runGitIn(repoRoot, ...)`.
+  both take a `repoRoot` parameter and use `runGitIn(repoRoot, ...)`.
 - [ ] All callers (`GitCommitTool`, `GitLogTool`, `GitShowTool`) pass the resolved
-      `root` from `resolveRepoRootOrError` — *not* `getProject().getBasePath()`.
+  `root` from `resolveRepoRootOrError` — *not* `getProject().getBasePath()`.
 - [ ] `GitCommitTool.execute()` calls `showNewCommitInLog(root)` **after** the
-      `if (result.startsWith("Error")) return result;` check. Calling it before opens
-      the log on a failed commit and looks identical to this bug.
-- [ ] `PlatformApiCompat.showRevisionInLogAfterRefresh` snapshots the current graph
-      identity through the compatibility helper — **not** a direct `data.getDataPack()`
-      wrapper comparison.
-- [ ] The DataPackChangeListener navigation predicate requires both a changed graph
-      identity AND `isCommitIndexed(data, hash, root)` for the *target* root, not any root.
-- [ ] The `refresh(...)` call passes the *commit's repo root* as a `VirtualFile`,
-      not the project base.
+  `if (result.startsWith("Error")) return result;` check. Calling it before opens the log on a failed commit and looks identical to this bug.
+- [ ] 
+  `PlatformApiCompat.showRevisionInLogAfterRefresh` snapshots the current graph identity through the compatibility helper —
+  **not** a direct `data.getDataPack()`
+  wrapper comparison.
+- [ ] The DataPackChangeListener navigation predicate requires both a changed graph identity AND
+  `isCommitIndexed(data, hash, root)` for the *target* root, not any root.
+- [ ] The `refresh(...)` call passes the *commit's repo root* as a `VirtualFile`, not the project base.
 - [ ] `VcsProjectLog.showRevisionInMainLog` is called with the 3-arg
-      `(project, root, hash)` overload whenever a root is known.
-- [ ] `isChatToolWindowActive(project)` is checked *inside* the tool-window
-      `invokeLater` lambda right before choosing `tw.show()` vs `tw.activate(null)`.
-      It must not guard or skip `showRevisionInMainLog`; skipping navigation
-      reintroduces this bug.
+  `(project, root, hash)` overload whenever a root is known.
+- [ ] `isChatToolWindowActive(project)` is checked *inside* the pre-navigation callback passed to
+  `showRevisionInLogAfterRefresh`, right before choosing `tw.show()` vs
+  `tw.activate(null)`. The callback runs inside
+  `navigateToRevisionInMainLog` — after graph freshness is confirmed — not before
+  `showRevisionInLogAfterRefresh` is called. It must not guard or skip
+  `showRevisionInMainLog`; skipping navigation reintroduces this bug.
 - [ ] The regression test
-      `GitCommitFollowAlongRepoRootTest.testShowNewCommitInLogReadsHeadFromSuppliedRoot`
-      still passes.
-- [ ] Manual smoke test: with Follow Agent Files **on**, ask the agent to make a
-      commit; verify the VCS Log opens, no bubble appears, and the topmost commit is
-      selected. Repeat in a multi-repo project (e.g. add a submodule or sibling repo)
-      and verify selection happens in the *correct* repo.
+  `GitCommitFollowAlongRepoRootTest.testShowNewCommitInLogReadsHeadFromSuppliedRoot`
+  still passes.
+- [ ] Manual smoke test: with Follow Agent Files **on
+  **, ask the agent to make a commit; verify the VCS Log opens, no bubble appears, and the topmost commit is selected. Repeat in a multi-repo project (e.g. add a submodule or sibling repo)
+  and verify selection happens in the *correct* repo.
 
 ---
 
@@ -229,18 +231,16 @@ If the bubble reappears after a future change, in order:
    That's Cause 1 — multi-repo regression. Revert and route the root through.
 
 2. **Is `data.getDataPack()` being compared directly to a snapshot somewhere?**
-   That's the Cause 2 trap on newer SDKs — the comparison always returns "different".
-   Route freshness checks through `PlatformApiCompat`'s graph-identity helper instead.
+   That's the Cause 2 trap on newer SDKs — the comparison always returns "different". Route freshness checks through
+   `PlatformApiCompat`'s graph-identity helper instead.
 
 3. **Is `showRevisionInMainLog(project, hash)` being called with no root?**
    That's Cause 3 — switch to the 3-arg overload (`project, root, hash`).
 
 4. **Did `getDetectedGitRoots` start returning roots that aren't in
    `data.getLogProviders()`?** This happens for unregistered subfolder repos
-   (e.g. submodules the user hasn't added to project settings). Skip navigation
-   cleanly when `getLogProviders().get(root) == null` — don't blow up, don't navigate
-   to a stale root.
+   (e.g. submodules the user hasn't added to project settings). Skip navigation cleanly when
+   `getLogProviders().get(root) == null` — don't blow up, don't navigate to a stale root.
 
-5. **Does the focus guard return before `showRevisionInMainLog`?** That is Cause 4.
-   Cross-check [`FOCUS-STEALING-BUG.md`](FOCUS-STEALING-BUG.md): the guard belongs on
-   VCS tool-window show/activate, not on the log-selection navigation.
+5. **Does the focus guard return before `showRevisionInMainLog`?** That is Cause 4. Cross-check [
+   `FOCUS-STEALING-BUG.md`](FOCUS-STEALING-BUG.md): the guard belongs on VCS tool-window show/activate, not on the log-selection navigation.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
@@ -431,8 +431,27 @@ public final class PlatformApiCompat {
      *                     (only suitable for entry points like chat-chip clicks that
      *                     have no repo context).
      */
+    /**
+     * Overload that accepts a pre-navigation callback invoked on the EDT immediately before
+     * {@code showRevisionInMainLog}. Used to open the VCS tool window only after the graph is
+     * confirmed fresh — avoiding IntelliJ 2025.3's "highlight current revision" auto-navigation
+     * that fires on {@code tw.activate(null)} and emits the "commit not found" bubble when the
+     * graph hasn't been rebuilt yet. See COMMIT-NOT-FOUND-IN-LOG-BUG.md § Cause 5.
+     */
+    public static void showRevisionInLogAfterRefresh(
+        @NotNull Project project, @NotNull String fullHash, @Nullable String repoRootPath,
+        @Nullable Runnable preNavigationCallback) {
+        showRevisionInLogAfterRefreshImpl(project, fullHash, repoRootPath, preNavigationCallback);
+    }
+
     public static void showRevisionInLogAfterRefresh(
         @NotNull Project project, @NotNull String fullHash, @Nullable String repoRootPath) {
+        showRevisionInLogAfterRefreshImpl(project, fullHash, repoRootPath, null);
+    }
+
+    private static void showRevisionInLogAfterRefreshImpl(
+        @NotNull Project project, @NotNull String fullHash, @Nullable String repoRootPath,
+        @Nullable Runnable preNavigationCallback) {
         var hash = com.intellij.vcs.log.impl.HashImpl.build(fullHash);
         var vcsLog = com.intellij.vcs.log.impl.VcsProjectLog.getInstance(project);
         var data = vcsLog.getDataManager();
@@ -462,7 +481,7 @@ public final class PlatformApiCompat {
         var navigated = new java.util.concurrent.atomic.AtomicBoolean(false);
 
         com.intellij.vcs.log.data.DataPackChangeListener listener =
-            buildDataPackListener(project, data, hash, repoRootVf, initialGraph, navigated);
+            buildDataPackListener(project, data, hash, repoRootVf, initialGraph, navigated, preNavigationCallback);
 
         data.addDataPackChangeListener(listener);
         data.refresh(java.util.List.of(repoRootVf));
@@ -477,7 +496,7 @@ public final class PlatformApiCompat {
             && navigated.compareAndSet(false, true)) {
             data.removeDataPackChangeListener(listener);
             com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater(() ->
-                navigateToRevisionInMainLog(project, repoRootVf, hash));
+                navigateToRevisionInMainLog(project, repoRootVf, hash, preNavigationCallback));
             return;
         }
 
@@ -540,7 +559,8 @@ public final class PlatformApiCompat {
         @NotNull com.intellij.vcs.log.Hash hash,
         @NotNull com.intellij.openapi.vfs.VirtualFile repoRootVf,
         @NotNull Object initialGraph,
-        @NotNull java.util.concurrent.atomic.AtomicBoolean navigated) {
+        @NotNull java.util.concurrent.atomic.AtomicBoolean navigated,
+        @Nullable Runnable preNavigationCallback) {
         return (com.intellij.vcs.log.data.DataPackChangeListener) java.lang.reflect.Proxy.newProxyInstance(
             com.intellij.vcs.log.data.DataPackChangeListener.class.getClassLoader(),
             new Class<?>[]{com.intellij.vcs.log.data.DataPackChangeListener.class},
@@ -576,7 +596,7 @@ public final class PlatformApiCompat {
                 data.removeDataPackChangeListener(
                     (com.intellij.vcs.log.data.DataPackChangeListener) proxy);
                 com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater(() ->
-                    navigateToRevisionInMainLog(project, repoRootVf, hash));
+                    navigateToRevisionInMainLog(project, repoRootVf, hash, preNavigationCallback));
                 return null;
             });
     }
@@ -628,9 +648,14 @@ public final class PlatformApiCompat {
     private static void navigateToRevisionInMainLog(
         @NotNull Project project,
         @NotNull com.intellij.openapi.vfs.VirtualFile repoRoot,
-        @NotNull com.intellij.vcs.log.Hash hash) {
-        // Tool-window show/activate is handled before this point. Do not skip selection
-        // when chat is active: follow-mode must still move the VCS Log selection without focus steal.
+        @NotNull com.intellij.vcs.log.Hash hash,
+        @Nullable Runnable preNavigationCallback) {
+        // The pre-navigation callback (if any) opens the VCS tool window here — AFTER the graph
+        // is confirmed fresh. This avoids IntelliJ 2025.3's "highlight current revision" behavior
+        // that fires on tw.activate(null) and tries to navigate to HEAD before the graph is ready.
+        if (preNavigationCallback != null) preNavigationCallback.run();
+        // Do not skip selection when chat is active: follow-mode must still move the VCS Log
+        // selection without stealing focus (that is handled inside the callback itself).
         com.intellij.vcs.log.impl.VcsProjectLog.showRevisionInMainLog(project, repoRoot, hash);
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
@@ -601,7 +601,12 @@ public abstract class GitTool extends Tool {
                 String fullHash = runGitIn(repoRoot, "rev-parse", "HEAD").trim();
                 if (fullHash.length() != 40) return;
 
-                EdtUtil.invokeLater(() -> {
+                // Build the VCS tool window callback separately so it runs only AFTER the
+                // graph is confirmed fresh. tw.activate(null) on a stale graph triggers
+                // IntelliJ 2025.3's "highlight current revision" which tries to navigate to
+                // the new commit before it is in the visible PermanentGraph, emitting the
+                // "commit not found" bubble. See COMMIT-NOT-FOUND-IN-LOG-BUG.md § Cause 5.
+                Runnable openVcsTw = () -> {
                     var twm = com.intellij.openapi.wm.ToolWindowManager.getInstance(project);
                     var tw = twm.getToolWindow(com.intellij.openapi.wm.ToolWindowId.VCS);
                     if (tw != null) {
@@ -611,9 +616,10 @@ public abstract class GitTool extends Tool {
                             tw.activate(null);
                         }
                     }
+                };
 
-                    PlatformApiCompat.showRevisionInLogAfterRefresh(project, fullHash, repoRoot);
-                });
+                EdtUtil.invokeLater(() ->
+                    PlatformApiCompat.showRevisionInLogAfterRefresh(project, fullHash, repoRoot, openVcsTw));
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             } catch (Exception ignored) {


### PR DESCRIPTION
## Problem

The "commit not found" bubble has regressed in IntelliJ 2025.3.

**Root cause (Cause 5)**: IntelliJ 2025.3 added a "highlight current revision" behaviour on `tw.activate(null)`. When the VCS tool window was activated in `showNewCommitInLog`'s `invokeLater` — before the `DataPackChangeListener` confirmed the graph was fresh — IntelliJ tried to navigate to the new commit immediately, but it wasn't in the `PermanentGraph` yet → bubble.

## Fix

Move `tw.activate(null)`/`tw.show()` from `showNewCommitInLog`'s `invokeLater` to inside `navigateToRevisionInMainLog`, which only runs after graph freshness and commit indexing are both confirmed.

`showRevisionInLogAfterRefresh` now accepts an optional `Runnable preNavigationCallback` that is threaded through `buildDataPackListener` and `navigateToRevisionInMainLog`. `showNewCommitInLog` passes the open/show logic as that callback. `showFirstCommitInLog` and chat-chip clicks pass `null` (no behaviour change).

## Testing

- ✅ `GitCommitFollowAlongRepoRootTest` passes
- ✅ Gradle build passes (0 errors)
- Docs: `COMMIT-NOT-FOUND-IN-LOG-BUG.md` updated with Cause 5, new architecture diagram, updated pre-merge checklist, and fix-history row

See also: `FOCUS-STEALING-BUG.md` — the activation callback still respects `isChatToolWindowActive()` for the `show` vs `activate` choice.