### PR TITLE
fix: prevent follow-agent tool focus steals

### DIFF
--- a/docs/bugs/FOCUS-STEALING-BUG.md
+++ b/docs/bugs/FOCUS-STEALING-BUG.md
@@ -508,9 +508,35 @@ flag **and** a *request focus / autoFocusContent* flag — they must be gated **
 
 ---
 
+### Attempt 14: Fix FocusGuard chat-boundary fallback
+
+**Problem**: User reported that `git`, `run_command`, and `run_in_terminal` still stole focus
+while typing in the chat prompt with Follow Agent enabled, even after the per-tool `show()` /
+`activate()` and focus-flag guards above.
+
+**Root cause**: `FocusGuard.isInsideChatToolWindow()` had a fallback for JCEF edge cases that
+treated any component in the same IDE main frame as "inside chat":
+
+```java
+ownerWindow == twWindow && SwingUtilities.isDescendingFrom(twRoot, ownerWindow)
+```
+
+Because the AgentBridge tool window root is itself a descendant of the IDE frame, this condition
+was true for sibling tool-window/editor components too. As a result, the veto path allowed focus
+changes into VCS, Terminal, and Run content as if they were chat-internal focus changes.
+
+**Fix**: Restrict chat-boundary detection to the actual AgentBridge component hierarchy
+(`comp == chatRoot || SwingUtilities.isDescendingFrom(comp, chatRoot)`) and remove the same-frame
+fallback. This restores the guard's intended behavior: programmatic focus moves to sibling tool
+windows in the IDE frame are vetoed, while focus moves within the chat UI are allowed.
+
+**Files**: `FocusGuard.java`, `FocusGuardTest.java`.
+
+---
+
 ## Remaining Root Causes
 
-_All previously documented root causes (RC1–RC4) have been fixed. See Attempts 1–10 below._
+_All previously documented root causes (RC1–RC4) have been fixed. See Attempts 1–14 above._
 
 ---
 
@@ -533,7 +559,7 @@ _All previously documented root causes (RC1–RC4) have been fixed. See Attempts
 | `PsiBridgeService.java`    | 321  | ✅ `chatWasActive` captured at start, completion re-checks                                                                                                    |
 | `PsiBridgeService.java`    | 469  | ✅ Focus restore requires both start+end active                                                                                                               |
 | `ChatToolWindowContent.kt` | 165  | ✅ 150ms alarm checks chat-active before firing                                                                                                               |
-| `FocusGuard.java`          | all  | ✅ `VetoableChangeListener` vetoes programmatic focus steals; targeted to same-Window only; circuit breaker at 20 vetoes; synchronous EDT uninstall via latch |
+| `FocusGuard.java`          | all  | ✅ `VetoableChangeListener` vetoes programmatic focus steals to sibling editor/tool-window components; targeted to same-Window only; circuit breaker at 20 vetoes; synchronous EDT uninstall via latch |
 | `FileTool.java`            | 257  | ✅ `navigate(focus)` check is inside `invokeLater`                                                                                                            |
 | `FileTool.java`            | 286  | ✅ `selectInProjectView` skips if chat active; only scrolls if already open                                                                                   |
 | `GitTool.java`             | 400  | ✅ VCS `show()`/`activate()` check is inside `invokeLater`                                                                                                    |

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/FocusGuard.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/FocusGuard.java
@@ -256,16 +256,13 @@ final class FocusGuard implements java.beans.VetoableChangeListener {
             // tw.getComponent() is @NotNull but we keep the defensive check — runtime ≠ compile-time.
             //noinspection ConstantValue
             if (twRoot == null) return false;
-            if (SwingUtilities.isDescendingFrom(comp, twRoot)) return true;
-
-            // JCEF browser components live in a separate heavyweight window; fall back to
-            // comparing the root window of the focus owner with the tool window's window.
-            Window ownerWindow = SwingUtilities.getWindowAncestor(comp);
-            Window twWindow = SwingUtilities.getWindowAncestor(twRoot);
-            return ownerWindow != null && ownerWindow == twWindow
-                && SwingUtilities.isDescendingFrom(twRoot, ownerWindow);
+            return isInsideChatComponent(comp, twRoot);
         } catch (Exception e) {
             return false;
         }
+    }
+
+    static boolean isInsideChatComponent(Component comp, JComponent chatRoot) {
+        return comp == chatRoot || SwingUtilities.isDescendingFrom(comp, chatRoot);
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/FocusGuardTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/FocusGuardTest.java
@@ -11,6 +11,7 @@ import java.beans.PropertyChangeEvent;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -105,6 +106,26 @@ class FocusGuardTest {
         // The 21st should NOT throw — circuit breaker tripped, guard is uninstalled
         guard.vetoableChange(outsideEvent());
         assertTrue(guard.uninstalled, "Guard should be uninstalled after circuit breaker trips");
+    }
+
+    @Test
+    void chatComponentDetectionDoesNotTreatMainWindowSiblingsAsChat() {
+        JPanel ideFrameRoot = new JPanel(new BorderLayout());
+        JPanel chatRoot = new JPanel();
+        JPanel chatChild = new JPanel();
+        JPanel vcsToolWindow = new JPanel();
+        JPanel runToolWindow = new JPanel();
+
+        chatRoot.add(chatChild);
+        ideFrameRoot.add(chatRoot, BorderLayout.CENTER);
+        ideFrameRoot.add(vcsToolWindow, BorderLayout.WEST);
+        ideFrameRoot.add(runToolWindow, BorderLayout.SOUTH);
+
+        assertTrue(FocusGuard.isInsideChatComponent(chatRoot, chatRoot));
+        assertTrue(FocusGuard.isInsideChatComponent(chatChild, chatRoot));
+        assertFalse(FocusGuard.isInsideChatComponent(vcsToolWindow, chatRoot));
+        assertFalse(FocusGuard.isInsideChatComponent(runToolWindow, chatRoot));
+        assertFalse(FocusGuard.isInsideChatComponent(ideFrameRoot, chatRoot));
     }
 
     // ── Pass-through cases (no veto expected) ────────────────────────────────────────────────────


### PR DESCRIPTION
Restrict FocusGuard chat-boundary detection to the actual AgentBridge component hierarchy so sibling tool windows in the IDE frame are no longer treated as chat-internal targets. This lets the veto guard block programmatic focus moves into VCS, Terminal, and Run content while the user is typing in chat.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
