### PR TITLE
feat: make move_file semantic

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/MoveFileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/MoveFileTool.java
@@ -11,13 +11,10 @@ import org.jetbrains.annotations.NotNull;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-/**
- * Moves a file to a different directory.
- */
-@SuppressWarnings("java:S112")
 public final class MoveFileTool extends FileTool {
 
     private static final String PARAM_DESTINATION = "destination";
+    private static final int MOVE_TIMEOUT_SECONDS = 30;
 
     public MoveFileTool(Project project) {
         super(project);
@@ -29,14 +26,20 @@ public final class MoveFileTool extends FileTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Move File";
     }
 
     @Override
     public @NotNull String description() {
-        return "Move a file to a different directory. Does NOT update import statements or references — " +
-            "use refactor(operation='rename') for reference-aware moves.";
+        return "Move a file to a different directory using IntelliJ's refactoring engine when PSI is available. " +
+            "Language-aware IDE move handlers update imports, package declarations, and references where supported. " +
+            "Falls back to a plain VFS move only for files/directories the IDE cannot represent as PSI.";
     }
 
     @Override
@@ -46,7 +49,7 @@ public final class MoveFileTool extends FileTool {
 
     @Override
     public @NotNull String permissionTemplate() {
-        return "Move {path} → {destination}";
+        return "Move {path} -> {destination}";
     }
 
     @Override
@@ -77,32 +80,94 @@ public final class MoveFileTool extends FileTool {
 
         CompletableFuture<String> resultFuture = new CompletableFuture<>();
         performMoveOnEdt(vf, destDir, resultFuture);
-        return resultFuture.get(10, TimeUnit.SECONDS);
+        return resultFuture.get(MOVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
     private void performMoveOnEdt(VirtualFile vf, VirtualFile destDir, CompletableFuture<String> resultFuture) {
+        EdtUtil.invokeLater(() -> {
+            try {
+                PsiMoveTarget target = resolvePsiMoveTarget(vf, destDir);
+                String result;
+                if (target.canUseRefactoring()) {
+                    result = performRefactoringMove(target);
+                } else {
+                    result = performPlainVfsMove(vf, destDir);
+                }
+                resultFuture.complete(result);
+            } catch (Exception e) {
+                resultFuture.complete("Error moving file: " + e.getMessage());
+            }
+        });
+    }
+
+    private PsiMoveTarget resolvePsiMoveTarget(VirtualFile vf, VirtualFile destDir) {
+        return ApplicationManager.getApplication().runReadAction(
+            (com.intellij.openapi.util.Computable<PsiMoveTarget>) () -> {
+                var psiManager = com.intellij.psi.PsiManager.getInstance(project);
+                return new PsiMoveTarget(
+                    vf,
+                    destDir,
+                    psiManager.findFile(vf),
+                    psiManager.findDirectory(destDir)
+                );
+            });
+    }
+
+    private String performRefactoringMove(PsiMoveTarget target) {
+        String oldPath = target.sourceFile().getPath();
+        String newPath = target.destinationDirectory().getPath() + "/" + target.sourceFile().getName();
+        var document = com.intellij.openapi.fileEditor.FileDocumentManager.getInstance().getDocument(target.sourceFile());
+        notifyBeforeEdit(project, target.sourceFile(), document);
+        try {
+            var processor = new com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesProcessor(
+                project,
+                new com.intellij.psi.PsiElement[]{target.psiFile()},
+                target.psiDirectory(),
+                true,
+                true,
+                true,
+                null,
+                null
+            );
+            processor.setPreviewUsages(false);
+            processor.run();
+            com.intellij.psi.PsiDocumentManager.getInstance(project).commitAllDocuments();
+            com.intellij.openapi.fileEditor.FileDocumentManager.getInstance().saveAllDocuments();
+            return "Moved " + oldPath + " to " + newPath + " using IntelliJ refactoring engine";
+        } finally {
+            notifyEditComplete();
+        }
+    }
+
+    private String performPlainVfsMove(VirtualFile vf, VirtualFile destDir) {
         String oldPath = vf.getPath();
         MoveFileTool requestor = this;
-        EdtUtil.invokeLater(() ->
-            ApplicationManager.getApplication().runWriteAction(() -> {
-                try {
-                    com.intellij.openapi.command.CommandProcessor.getInstance().executeCommand(
-                        project,
-                        () -> {
-                            try {
-                                vf.move(requestor, destDir);
-                            } catch (java.io.IOException e) {
-                                throw new RuntimeException(e);
-                            }
-                        },
-                        "Move File: " + vf.getName(),
-                        null
-                    );
-                    resultFuture.complete("Moved " + oldPath + " to " + destDir.getPath() + "/" + vf.getName());
-                } catch (Exception e) {
-                    resultFuture.complete("Error moving file: " + e.getMessage());
-                }
-            })
+        ApplicationManager.getApplication().runWriteAction(() ->
+            com.intellij.openapi.command.CommandProcessor.getInstance().executeCommand(
+                project,
+                () -> {
+                    try {
+                        vf.move(requestor, destDir);
+                    } catch (java.io.IOException e) {
+                        throw new IllegalStateException("VFS move failed", e);
+                    }
+                },
+                "Move File: " + vf.getName(),
+                null
+            )
         );
+        return "Moved " + oldPath + " to " + destDir.getPath() + "/" + vf.getName() +
+            " using plain VFS move (no PSI refactoring available)";
+    }
+
+    private record PsiMoveTarget(
+        VirtualFile sourceFile,
+        VirtualFile destinationDirectory,
+        com.intellij.psi.PsiFile psiFile,
+        com.intellij.psi.PsiDirectory psiDirectory) {
+
+        private boolean canUseRefactoring() {
+            return psiFile != null && psiDirectory != null && psiFile.isPhysical() && psiDirectory.isPhysical();
+        }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/MoveFileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/MoveFileTool.java
@@ -26,11 +26,6 @@ public final class MoveFileTool extends FileTool {
     }
 
     @Override
-    public boolean requiresIndex() {
-        return true;
-    }
-
-    @Override
     public @NotNull String displayName() {
         return "Move File";
     }
@@ -115,7 +110,10 @@ public final class MoveFileTool extends FileTool {
 
     private String performRefactoringMove(PsiMoveTarget target) {
         String oldPath = target.sourceFile().getPath();
-        String newPath = target.destinationDirectory().getPath() + "/" + target.sourceFile().getName();
+        String newPath = com.intellij.openapi.util.io.FileUtil.join(
+            target.destinationDirectory().getPath(),
+            target.sourceFile().getName()
+        );
         var document = com.intellij.openapi.fileEditor.FileDocumentManager.getInstance().getDocument(target.sourceFile());
         notifyBeforeEdit(project, target.sourceFile(), document);
         try {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/MoveFileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/MoveFileTool.java
@@ -26,6 +26,11 @@ public final class MoveFileTool extends FileTool {
     }
 
     @Override
+    public @NotNull Kind kind() {
+        return Kind.MOVE;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Move File";
     }
@@ -35,11 +40,6 @@ public final class MoveFileTool extends FileTool {
         return "Move a file to a different directory using IntelliJ's refactoring engine when PSI is available. " +
             "Language-aware IDE move handlers update imports, package declarations, and references where supported. " +
             "Falls back to a plain VFS move only for files/directories the IDE cannot represent as PSI.";
-    }
-
-    @Override
-    public @NotNull Kind kind() {
-        return Kind.MOVE;
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/MoveFileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/MoveFileTool.java
@@ -36,13 +36,6 @@ public final class MoveFileTool extends FileTool {
     }
 
     @Override
-    public @NotNull String description() {
-        return "Move a file to a different directory using IntelliJ's refactoring engine when PSI is available. " +
-            "Language-aware IDE move handlers update imports, package declarations, and references where supported. " +
-            "Falls back to a plain VFS move only for files/directories the IDE cannot represent as PSI.";
-    }
-
-    @Override
     public @NotNull String permissionTemplate() {
         return "Move {path} -> {destination}";
     }
@@ -53,6 +46,13 @@ public final class MoveFileTool extends FileTool {
             Param.required("path", TYPE_STRING, "Path to the file to move (absolute or project-relative)"),
             Param.required(PARAM_DESTINATION, TYPE_STRING, "Destination directory path (absolute or project-relative)")
         );
+    }
+
+    @Override
+    public @NotNull String description() {
+        return "Move a file to a different directory using IntelliJ's refactoring engine when PSI is available. " +
+            "Language-aware IDE move handlers update imports, package declarations, and references where supported. " +
+            "Falls back to a plain VFS move only for files/directories the IDE cannot represent as PSI.";
     }
 
     @Override

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/MoveFileToolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/MoveFileToolTest.java
@@ -30,9 +30,9 @@ import java.util.stream.Stream;
  * can locate both the source file and the destination directory.
  *
  * <p><b>Async execution note:</b> {@code MoveFileTool} uses {@code EdtUtil.invokeLater} to
- * perform the actual {@code VirtualFile#move} inside a write action on the EDT, then blocks on
- * a {@code CompletableFuture}. The {@code executeSync} helper runs {@code execute()} on a pooled
- * thread and pumps the EDT queue until the future resolves.
+ * perform the actual move on the EDT, then blocks on a {@code CompletableFuture}. The
+ * {@code executeSync} helper runs {@code execute()} on a pooled thread and pumps the EDT queue
+ * until the future resolves.
  */
 public class MoveFileToolTest extends BasePlatformTestCase {
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/MoveFileToolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/MoveFileToolTest.java
@@ -170,6 +170,31 @@ public class MoveFileToolTest extends BasePlatformTestCase {
             result.contains("tomove.txt"));
     }
 
+    public void testMoveDirectoryFallsBackToPlainVfs() throws Exception {
+        VirtualFile srcDir = createTestDirectory("source-dir");
+        VirtualFile destDir = createTestDirectory("parent-dest");
+
+        String result = executeSync(
+            args("path", srcDir.getPath(), "destination", destDir.getPath()));
+
+        assertTrue("Expected plain VFS fallback message, got: " + result,
+            result.contains("using plain VFS move"));
+        assertNotNull("Moved directory should exist under destination",
+            destDir.findChild("source-dir"));
+    }
+
+    public void testMoveWithMissingDestination() throws Exception {
+        VirtualFile srcVf = createTestFile("missing-dest-source.txt", "content");
+        String missingDestination = tempDir.resolve("missing-dest").toString();
+
+        String result = tool.execute(args("path", srcVf.getPath(), "destination", missingDestination));
+
+        assertTrue("Expected error prefix, got: " + result,
+            result.startsWith(ToolUtils.ERROR_PREFIX));
+        assertTrue("Expected destination error, got: " + result,
+            result.contains("Destination directory not found"));
+    }
+
     /**
      * Omitting the "path" parameter should return an error about the missing required parameters.
      * The tool returns synchronously before any VFS access, so direct EDT invocation is safe.


### PR DESCRIPTION
## Summary
- route move_file through IntelliJ's refactoring engine when PSI is available
- keep a plain VFS fallback for non-PSI files
- update the tool description to advertise reference-aware behavior

## Tests
- MoveFileToolTest