### PR TITLE
feat: add find super methods tool

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/FindSuperMethodsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/FindSuperMethodsTool.java
@@ -1,0 +1,200 @@
+package com.github.catatafishen.agentbridge.psi.tools.refactoring;
+
+import com.github.catatafishen.agentbridge.psi.ToolUtils;
+import com.github.catatafishen.agentbridge.ui.renderers.SearchResultRenderer;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiParameter;
+import com.intellij.psi.search.searches.SuperMethodsSearch;
+import com.intellij.psi.util.MethodSignatureBackedByPsiMethod;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public final class FindSuperMethodsTool extends RefactoringTool {
+
+    private static final String PARAM_FILE = "file";
+    private static final String PARAM_LINE = "line";
+    private static final String PARAM_COLUMN = "column";
+
+    private final boolean hasJava;
+
+    public FindSuperMethodsTool(Project project, boolean hasJava) {
+        super(project);
+        this.hasJava = hasJava;
+    }
+
+    @Override
+    public @NotNull String id() {
+        return "find_super_methods";
+    }
+
+    @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
+    public @NotNull String displayName() {
+        return "Find Super Methods";
+    }
+
+    @Override
+    public @NotNull String description() {
+        return "Find parent methods that the method at a file position overrides or implements. " +
+            "Java-aware lookup returns the inheritance chain with file locations and containing class details.";
+    }
+
+    @Override
+    public @NotNull Kind kind() {
+        return Kind.READ;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
+    public @NotNull JsonObject inputSchema() {
+        return schema(
+            Param.required(PARAM_FILE, TYPE_STRING, "File path containing the overriding method"),
+            Param.required(PARAM_LINE, TYPE_INTEGER, "1-based line number inside the method declaration or body"),
+            Param.optional(PARAM_COLUMN, TYPE_INTEGER, "1-based column number. Defaults to the first non-whitespace character on the line", 1)
+        );
+    }
+
+    @Override
+    public @NotNull Object resultRenderer() {
+        return SearchResultRenderer.INSTANCE;
+    }
+
+    @Override
+    public @NotNull String execute(@NotNull JsonObject args) {
+        if (!hasJava) return ToolUtils.ERROR_PREFIX + "find_super_methods requires Java PSI support";
+        if (!args.has(PARAM_FILE) || !args.has(PARAM_LINE)) {
+            return ToolUtils.ERROR_PREFIX + "'file' and 'line' parameters are required";
+        }
+
+        String filePath = args.get(PARAM_FILE).getAsString();
+        int line = args.get(PARAM_LINE).getAsInt();
+        int column = args.has(PARAM_COLUMN) ? args.get(PARAM_COLUMN).getAsInt() : 1;
+        VirtualFile vf = resolveVirtualFile(filePath);
+        if (vf == null) vf = refreshAndFindVirtualFile(filePath);
+        VirtualFile resolvedFile = vf;
+
+        Computable<String> computation = () -> {
+            VirtualFile targetFile = resolvedFile != null ? resolvedFile : findProjectContentFile(filePath);
+            if (targetFile == null) return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_FILE_NOT_FOUND + filePath;
+            return findSuperMethods(targetFile, line, column);
+        };
+        return ApplicationManager.getApplication().runReadAction(computation);
+    }
+
+    private VirtualFile findProjectContentFile(String filePath) {
+        String normalizedPath = filePath.replace('\\', '/');
+        String basePath = project.getBasePath();
+        VirtualFile[] match = {null};
+        ProjectFileIndex.getInstance(project).iterateContent(vf -> {
+            if (vf.isDirectory()) return true;
+            if (!matchesPath(vf, normalizedPath, basePath)) return true;
+            match[0] = vf;
+            return false;
+        });
+        return match[0];
+    }
+
+    private boolean matchesPath(VirtualFile vf, String normalizedPath, String basePath) {
+        String virtualPath = vf.getPath().replace('\\', '/');
+        if (virtualPath.equals(normalizedPath)) return true;
+        if (basePath == null) return false;
+        return relativize(basePath, virtualPath).equals(stripLeadingSlash(normalizedPath));
+    }
+
+    private static String stripLeadingSlash(String path) {
+        return path.startsWith("/") ? path.substring(1) : path;
+    }
+
+    private String findSuperMethods(VirtualFile vf, int line, int column) {
+        PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
+        if (psiFile == null) return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_CANNOT_PARSE + vf.getPath();
+        Document document = FileDocumentManager.getInstance().getDocument(vf);
+        if (document == null) return ToolUtils.ERROR_PREFIX + "Cannot read document: " + vf.getPath();
+        if (line < 1 || line > document.getLineCount()) return ToolUtils.ERROR_PREFIX + "Line out of range: " + line;
+
+        PsiMethod method = findMethodAt(psiFile, document, line, column);
+        if (method == null) return ToolUtils.ERROR_PREFIX + "No method found at position";
+
+        List<PsiMethod> superMethods = SuperMethodsSearch.search(method, null, true, false).findAll().stream()
+            .map(MethodSignatureBackedByPsiMethod::getMethod)
+            .sorted(Comparator.comparing(this::methodLocation))
+            .toList();
+        if (superMethods.isEmpty()) return "No super methods found for " + method.getName();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Super methods for ").append(formatMethodLabel(method)).append(":\n");
+        for (PsiMethod superMethod : superMethods) {
+            sb.append(formatMethodEntry(superMethod)).append('\n');
+        }
+        return ToolUtils.truncateOutput(sb.toString().stripTrailing());
+    }
+
+    private PsiMethod findMethodAt(PsiFile psiFile, Document document, int line, int column) {
+        int lineIndex = line - 1;
+        int lineStart = document.getLineStartOffset(lineIndex);
+        int lineEnd = document.getLineEndOffset(lineIndex);
+        int requestedOffset = lineStart + Math.max(0, column - 1);
+        int offset = Math.clamp(requestedOffset, lineStart, Math.max(lineStart, lineEnd - 1));
+        PsiElement element = psiFile.findElementAt(offset);
+        return element == null ? null : PsiTreeUtil.getParentOfType(element, PsiMethod.class, false);
+    }
+
+    private String formatMethodEntry(PsiMethod method) {
+        PsiFile file = method.getContainingFile();
+        VirtualFile vf = file == null ? null : file.getVirtualFile();
+        String basePath = project.getBasePath();
+        String path = resolveDeclPath(vf, basePath);
+        int line = methodLine(method, vf);
+        return path + ":" + line + " [" + containingClassLabel(method) + "] " + formatMethodLabel(method);
+    }
+
+    private String formatMethodLabel(PsiMethod method) {
+        List<String> params = new ArrayList<>();
+        for (PsiParameter parameter : method.getParameterList().getParameters()) {
+            params.add(parameter.getType().getPresentableText());
+        }
+        return method.getName() + "(" + String.join(", ", params) + ")";
+    }
+
+    private String containingClassLabel(PsiMethod method) {
+        PsiClass psiClass = method.getContainingClass();
+        if (psiClass == null) return "method";
+        String kind = psiClass.isInterface() ? "interface" : "class";
+        return kind + " " + psiClass.getQualifiedName();
+    }
+
+    private int methodLine(PsiMethod method, VirtualFile vf) {
+        Document doc = vf == null ? null : FileDocumentManager.getInstance().getDocument(vf);
+        return doc == null ? -1 : doc.getLineNumber(method.getTextOffset()) + 1;
+    }
+
+    private String methodLocation(PsiMethod method) {
+        PsiFile file = method.getContainingFile();
+        VirtualFile vf = file == null ? null : file.getVirtualFile();
+        return resolveDeclPath(vf, project.getBasePath()) + ":" + methodLine(method, vf);
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/FindSuperMethodsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/FindSuperMethodsTool.java
@@ -39,34 +39,13 @@ public final class FindSuperMethodsTool extends RefactoringTool {
     }
 
     @Override
-    public @NotNull String id() {
-        return "find_super_methods";
-    }
-
-    @Override
-    public boolean requiresIndex() {
-        return true;
-    }
-
-    @Override
-    public @NotNull String displayName() {
-        return "Find Super Methods";
-    }
-
-    @Override
-    public @NotNull String description() {
-        return "Find parent methods that the method at a file position overrides or implements. " +
-            "Java-aware lookup returns the inheritance chain with file locations and containing class details.";
-    }
-
-    @Override
     public @NotNull Kind kind() {
         return Kind.READ;
     }
 
     @Override
-    public boolean isReadOnly() {
-        return true;
+    public @NotNull Object resultRenderer() {
+        return SearchResultRenderer.INSTANCE;
     }
 
     @Override
@@ -79,8 +58,29 @@ public final class FindSuperMethodsTool extends RefactoringTool {
     }
 
     @Override
-    public @NotNull Object resultRenderer() {
-        return SearchResultRenderer.INSTANCE;
+    public @NotNull String displayName() {
+        return "Find Super Methods";
+    }
+
+    @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
+    public @NotNull String id() {
+        return "find_super_methods";
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
+    public @NotNull String description() {
+        return "Find parent methods that the method at a file position overrides or implements. " +
+            "Java-aware lookup returns the inheritance chain with file locations and containing class details.";
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolFactory.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolFactory.java
@@ -23,6 +23,7 @@ public final class RefactoringToolFactory {
         tools.add(new GoToDeclarationTool(project));
         tools.add(new GetTypeHierarchyTool(project, hasJava));
         tools.add(new FindImplementationsTool(project, hasJava));
+        tools.add(new FindSuperMethodsTool(project, hasJava));
         tools.add(new GetCallHierarchyTool(project));
         tools.add(new GetDocumentationTool(project));
         tools.add(new GetSymbolInfoTool(project));

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/ToolDefinitionContractTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/ToolDefinitionContractTest.java
@@ -105,6 +105,7 @@ import com.github.catatafishen.agentbridge.psi.tools.quality.OptimizeImportsTool
 import com.github.catatafishen.agentbridge.psi.tools.quality.RunSonarQubeAnalysisTool;
 import com.github.catatafishen.agentbridge.psi.tools.quality.SuppressInspectionTool;
 import com.github.catatafishen.agentbridge.psi.tools.refactoring.FindImplementationsTool;
+import com.github.catatafishen.agentbridge.psi.tools.refactoring.FindSuperMethodsTool;
 import com.github.catatafishen.agentbridge.psi.tools.refactoring.GetCallHierarchyTool;
 import com.github.catatafishen.agentbridge.psi.tools.refactoring.GetDocumentationTool;
 import com.github.catatafishen.agentbridge.psi.tools.refactoring.GetSymbolInfoTool;
@@ -304,6 +305,7 @@ class ToolDefinitionContractTest {
             new GoToDeclarationTool(null),
             new GetTypeHierarchyTool(null, true),
             new FindImplementationsTool(null, true),
+            new FindSuperMethodsTool(null, true),
             new GetCallHierarchyTool(null),
             new GetDocumentationTool(null),
             new GetSymbolInfoTool(null)

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/FindSuperMethodsToolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/FindSuperMethodsToolTest.java
@@ -1,0 +1,80 @@
+package com.github.catatafishen.agentbridge.psi.tools.refactoring;
+
+import com.github.catatafishen.agentbridge.psi.ToolUtils;
+import com.google.gson.JsonObject;
+import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+public class FindSuperMethodsToolTest extends BasePlatformTestCase {
+
+    private FindSuperMethodsTool tool;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        tool = new FindSuperMethodsTool(getProject(), true);
+    }
+
+    public void testFindsImplementedInterfaceMethod() {
+        myFixture.addFileToProject("demo/SuperContract.java", """
+                package demo;
+                public interface SuperContract {
+                    String load(String id);
+                }
+                """);
+        PsiFile implementation = myFixture.addFileToProject("demo/SuperImpl.java", """
+                package demo;
+                public class SuperImpl implements SuperContract {
+                    @Override
+                    public String load(String id) {
+                        return id;
+                    }
+                }
+                """);
+
+        String result = tool.execute(args(
+                "file", implementation.getVirtualFile().getPath(),
+                "line", "4",
+                "column", "25"));
+
+        assertTrue("Expected super method header, got: " + result,
+                result.contains("Super methods for load(String):"));
+        assertTrue("Expected interface method location, got: " + result,
+                result.contains("SuperContract.java:3"));
+        assertTrue("Expected interface label, got: " + result,
+                result.contains("interface demo.SuperContract"));
+    }
+
+    public void testNoSuperMethodsForStandaloneMethod() {
+        PsiFile standalone = myFixture.addFileToProject("demo/StandaloneSuperMethod.java", """
+                package demo;
+                public class StandaloneSuperMethod {
+                    public void localOnly() {}
+                }
+                """);
+
+        String result = tool.execute(args(
+                "file", standalone.getVirtualFile().getPath(),
+                "line", "3",
+                "column", "25"));
+
+        assertEquals("No super methods found for localOnly", result);
+    }
+
+    public void testMissingPositionReturnsError() {
+        String result = tool.execute(new JsonObject());
+
+        assertTrue("Expected error prefix, got: " + result,
+                result.startsWith(ToolUtils.ERROR_PREFIX));
+        assertTrue("Expected required params message, got: " + result,
+                result.contains("'file' and 'line' parameters are required"));
+    }
+
+    private static JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/FindSuperMethodsToolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/FindSuperMethodsToolTest.java
@@ -17,46 +17,46 @@ public class FindSuperMethodsToolTest extends BasePlatformTestCase {
 
     public void testFindsImplementedInterfaceMethod() {
         myFixture.addFileToProject("demo/SuperContract.java", """
-                package demo;
-                public interface SuperContract {
-                    String load(String id);
-                }
-                """);
+            package demo;
+            public interface SuperContract {
+                String load(String id);
+            }
+            """);
         PsiFile implementation = myFixture.addFileToProject("demo/SuperImpl.java", """
-                package demo;
-                public class SuperImpl implements SuperContract {
-                    @Override
-                    public String load(String id) {
-                        return id;
-                    }
+            package demo;
+            public class SuperImpl implements SuperContract {
+                @Override
+                public String load(String id) {
+                    return id;
                 }
-                """);
+            }
+            """);
 
         String result = tool.execute(args(
-                "file", implementation.getVirtualFile().getPath(),
-                "line", "4",
-                "column", "25"));
+            "file", implementation.getVirtualFile().getPath(),
+            "line", "4",
+            "column", "25"));
 
         assertTrue("Expected super method header, got: " + result,
-                result.contains("Super methods for load(String):"));
+            result.contains("Super methods for load(String):"));
         assertTrue("Expected interface method location, got: " + result,
-                result.contains("SuperContract.java:3"));
+            result.contains("SuperContract.java:3"));
         assertTrue("Expected interface label, got: " + result,
-                result.contains("interface demo.SuperContract"));
+            result.contains("interface demo.SuperContract"));
     }
 
     public void testNoSuperMethodsForStandaloneMethod() {
         PsiFile standalone = myFixture.addFileToProject("demo/StandaloneSuperMethod.java", """
-                package demo;
-                public class StandaloneSuperMethod {
-                    public void localOnly() {}
-                }
-                """);
+            package demo;
+            public class StandaloneSuperMethod {
+                public void localOnly() {}
+            }
+            """);
 
         String result = tool.execute(args(
-                "file", standalone.getVirtualFile().getPath(),
-                "line", "3",
-                "column", "25"));
+            "file", standalone.getVirtualFile().getPath(),
+            "line", "3",
+            "column", "25"));
 
         assertEquals("No super methods found for localOnly", result);
     }
@@ -65,9 +65,57 @@ public class FindSuperMethodsToolTest extends BasePlatformTestCase {
         String result = tool.execute(new JsonObject());
 
         assertTrue("Expected error prefix, got: " + result,
-                result.startsWith(ToolUtils.ERROR_PREFIX));
+            result.startsWith(ToolUtils.ERROR_PREFIX));
         assertTrue("Expected required params message, got: " + result,
-                result.contains("'file' and 'line' parameters are required"));
+            result.contains("'file' and 'line' parameters are required"));
+    }
+
+    public void testRequiresJavaPsiSupport() {
+        FindSuperMethodsTool nonJavaTool = new FindSuperMethodsTool(getProject(), false);
+        String result = nonJavaTool.execute(args(
+            "file", "demo/Any.java",
+            "line", "1"));
+
+        assertTrue("Expected error prefix, got: " + result,
+            result.startsWith(ToolUtils.ERROR_PREFIX));
+        assertTrue("Expected Java PSI support message, got: " + result,
+            result.contains("requires Java PSI support"));
+    }
+
+    public void testLineOutOfRangeReturnsError() {
+        PsiFile file = myFixture.addFileToProject("demo/ShortSuperMethod.java", """
+            package demo;
+            public class ShortSuperMethod {
+                public void localOnly() {}
+            }
+            """);
+
+        String result = tool.execute(args(
+            "file", file.getVirtualFile().getPath(),
+            "line", "99"));
+
+        assertTrue("Expected error prefix, got: " + result,
+            result.startsWith(ToolUtils.ERROR_PREFIX));
+        assertTrue("Expected line range error, got: " + result,
+            result.contains("Line out of range"));
+    }
+
+    public void testNoMethodAtPositionReturnsError() {
+        PsiFile file = myFixture.addFileToProject("demo/NoMethodAtPosition.java", """
+            package demo;
+            public class NoMethodAtPosition {
+                private String value;
+            }
+            """);
+
+        String result = tool.execute(args(
+            "file", file.getVirtualFile().getPath(),
+            "line", "1"));
+
+        assertTrue("Expected error prefix, got: " + result,
+            result.startsWith(ToolUtils.ERROR_PREFIX));
+        assertTrue("Expected no method message, got: " + result,
+            result.contains("No method found at position"));
     }
 
     private static JsonObject args(String... pairs) {


### PR DESCRIPTION
## Summary
- add a Java-aware find_super_methods MCP tool for overridden/implemented method lookup
- register the tool and include it in tool definition contract coverage
- add platform tests for implemented interface methods, no-super-method cases, and required parameters

## Tests
- FindSuperMethodsToolTest
- ToolDefinitionContractTest