### PR TITLE
feat: enrich file outline structure

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
@@ -8,9 +8,16 @@ import com.github.catatafishen.agentbridge.services.ToolRegistry;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiModifierList;
+import com.intellij.psi.PsiModifierListOwner;
 import com.intellij.psi.PsiNamedElement;
+import com.intellij.psi.PsiParameter;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.PsiSearchHelper;
 import com.intellij.psi.search.UsageSearchContext;
@@ -158,7 +165,9 @@ public abstract class NavigationTool extends Tool {
                         String type = ToolUtils.classifyElement(element);
                         if (type != null) {
                             int line = document.getLineNumber(element.getTextOffset()) + 1;
-                            outline.add(String.format("  %d: %s %s", line, type, name));
+                            int depth = structuralAncestorDepth(element);
+                            outline.add(String.format("  %s%d: %s %s",
+                                "  ".repeat(depth), line, type, outlineLabel(named)));
                         }
                     }
                 }
@@ -166,6 +175,67 @@ public abstract class NavigationTool extends Tool {
             }
         });
         return outline;
+    }
+
+    private int structuralAncestorDepth(PsiElement element) {
+        int depth = 0;
+        PsiElement parent = element.getParent();
+        while (parent != null) {
+            if (parent instanceof PsiNamedElement && ToolUtils.classifyElement(parent) != null) {
+                depth++;
+            }
+            parent = parent.getParent();
+        }
+        return depth;
+    }
+
+    private String outlineLabel(PsiNamedElement element) {
+        String name = element.getName();
+        StringBuilder label = new StringBuilder(name == null ? "<anonymous>" : name);
+        if (element instanceof PsiMethod method) {
+            appendMethodSignature(label, method);
+        } else if (element instanceof PsiField field) {
+            label.append(": ").append(field.getType().getPresentableText());
+        } else if (element instanceof PsiClass psiClass) {
+            String qualifiedName = psiClass.getQualifiedName();
+            if (qualifiedName != null && !qualifiedName.equals(name)) {
+                label.append(" [").append(qualifiedName).append(']');
+            }
+        }
+        return prefixModifiers(element, label.toString());
+    }
+
+    private static void appendMethodSignature(StringBuilder label, PsiMethod method) {
+        label.append('(');
+        java.util.List<String> parameters = new java.util.ArrayList<>();
+        for (PsiParameter parameter : method.getParameterList().getParameters()) {
+            parameters.add(parameter.getType().getPresentableText());
+        }
+        label.append(String.join(", ", parameters)).append(')');
+        if (!method.isConstructor() && method.getReturnType() != null) {
+            label.append(": ").append(method.getReturnType().getPresentableText());
+        }
+    }
+
+    private static String prefixModifiers(PsiNamedElement element, String label) {
+        if (!(element instanceof PsiModifierListOwner owner)) return label;
+        PsiModifierList modifierList = owner.getModifierList();
+        if (modifierList == null) return label;
+        java.util.List<String> modifiers = new java.util.ArrayList<>();
+        addModifier(modifierList, modifiers, PsiModifier.PUBLIC, "public");
+        addModifier(modifierList, modifiers, PsiModifier.PROTECTED, "protected");
+        addModifier(modifierList, modifiers, PsiModifier.PRIVATE, "private");
+        addModifier(modifierList, modifiers, PsiModifier.STATIC, "static");
+        addModifier(modifierList, modifiers, PsiModifier.ABSTRACT, "abstract");
+        addModifier(modifierList, modifiers, PsiModifier.FINAL, "final");
+        return modifiers.isEmpty() ? label : String.join(" ", modifiers) + " " + label;
+    }
+
+    private static void addModifier(PsiModifierList modifierList, java.util.List<String> modifiers,
+                                    String modifier, String label) {
+        if (modifierList.hasModifierProperty(modifier)) {
+            modifiers.add(label);
+        }
     }
 
     protected void collectSymbolsFromFile(PsiFile psiFile, Document doc, com.intellij.openapi.vfs.VirtualFile vf,

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/GetFileOutlineToolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/GetFileOutlineToolTest.java
@@ -1,0 +1,96 @@
+package com.github.catatafishen.agentbridge.psi.tools.navigation;
+
+import com.google.gson.JsonObject;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+public class GetFileOutlineToolTest extends BasePlatformTestCase {
+
+    private GetFileOutlineTool tool;
+    private Path tempDir;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        tool = new GetFileOutlineTool(getProject());
+        tempDir = Files.createTempDirectory("get-file-outline-tool-test");
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            deleteDir(tempDir);
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    public void testIncludesHierarchyModifiersAndSignatures() {
+        VirtualFile file = createTestFile("OutlineSample.java", """
+            public class OutlineSample {
+                private final String id;
+
+                public OutlineSample(String id) {
+                    this.id = id;
+                }
+
+                public String load(int count) {
+                    return id + count;
+                }
+            }
+            """);
+
+        String result = tool.execute(args("path", file.getPath()));
+
+        assertTrue("Expected class outline, got: " + result,
+            result.contains("1: class public OutlineSample"));
+        assertTrue("Expected field with modifiers and type, got: " + result,
+            result.contains("  2: field private final id: String"));
+        assertTrue("Expected constructor signature, got: " + result,
+            result.contains("  4: method public OutlineSample(String)"));
+        assertTrue("Expected method signature and return type, got: " + result,
+            result.contains("  8: method public load(int): String"));
+    }
+
+    private VirtualFile createTestFile(String name, String content) {
+        try {
+            Path file = tempDir.resolve(name);
+            Files.writeString(file, content);
+            VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByPath(file.toString());
+            assertNotNull("Failed to register test file in VFS: " + file, vf);
+            return vf;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create test file: " + name, e);
+        }
+    }
+
+    private static JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    private static void deleteDir(Path dir) {
+        if (dir == null || !Files.exists(dir)) return;
+        try (Stream<Path> walk = Files.walk(dir)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ignored) {
+                    // best-effort cleanup
+                }
+            });
+        } catch (IOException ignored) {
+            // best-effort cleanup
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make get_file_outline output hierarchical instead of flat
- include Java modifiers, field types, constructor signatures, method parameters, and return types
- add focused platform coverage for richer outline output

## Tests
- GetFileOutlineToolTest