### PR TITLE
fix: address SonarCloud workflow vulnerabilities and Java code smells

### DIFF
--- a/.github/workflows/await-marketplace-approval.yml
+++ b/.github/workflows/await-marketplace-approval.yml
@@ -18,7 +18,8 @@ on:
     - cron: '0 * * * *'
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -5,7 +5,8 @@ on:
     - cron: '17 */6 * * *'  # Every 6 hours, offset to avoid runner contention
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -20,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address]
+        sanitizer: [ address ]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -2,7 +2,7 @@ name: ClusterFuzzLite continuous build
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
     paths:
       - '**/*.java'
       - '**/*.kt'
@@ -11,7 +11,8 @@ on:
       - 'oss-fuzz/build.sh'
       - '.github/workflows/cflite_build.yml'
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -28,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address]
+        sanitizer: [ address ]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -5,7 +5,8 @@ on:
     - cron: '23 3 * * *'  # Daily at 03:23 UTC
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -10,7 +10,8 @@ on:
       - 'oss-fuzz/build.sh'
       - '.github/workflows/cflite_pr.yml'
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,8 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analyze:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,7 +10,8 @@ on:
         required: false
         default: '120'
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -18,7 +18,8 @@ on:
           - beta
         default: stable
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ master ]
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   # Only one release job runs at a time. cancel-in-progress: false means a second

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,7 +6,8 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [ master ]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   zizmor:

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
@@ -1527,7 +1527,10 @@ public abstract class AcpClient extends AbstractAgentClient {
         switch (request.method()) {
             case "session/request_permission" -> handlePermissionRequest(id, request.params());
             case "fs/read_text_file" -> handleFsRequest(id, () -> fsHandler.readTextFile(request.params()));
-            case "fs/write_text_file" -> handleFsRequest(id, () -> fsHandler.writeTextFile(request.params()));
+            case "fs/write_text_file" -> handleFsRequest(id, () -> {
+                fsHandler.writeTextFile(request.params());
+                return null;
+            });
             case "terminal/create" -> handleTerminalRequest(id, () -> terminalHandler.create(request.params()));
             case "terminal/output" -> handleTerminalRequest(id, () -> terminalHandler.output(request.params()));
             case "terminal/wait_for_exit" ->

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpFileSystemHandler.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpFileSystemHandler.java
@@ -79,7 +79,7 @@ final class AcpFileSystemHandler {
         return result;
     }
 
-    JsonObject writeTextFile(@NotNull JsonObject params) {
+    void writeTextFile(@NotNull JsonObject params) {
         String path = getRequiredString(params, "path");
         String content = getRequiredString(params, "content");
 
@@ -93,7 +93,7 @@ final class AcpFileSystemHandler {
         if (isNewFile) {
             // Disk I/O on the current (background) thread
             createNewFile(absolutePath, content);
-            return null;
+            return;
         }
 
         // EdtUtil.invokeAndWait adds a 30-second backstop + modal-dialog detection,
@@ -127,7 +127,6 @@ final class AcpFileSystemHandler {
         });
 
         LOG.info("Wrote " + content.length() + " chars to " + absolutePath);
-        return null;
     }
 
     private void createNewFile(String absolutePath, String content) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupRespondTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupRespondTool.java
@@ -140,7 +140,7 @@ public final class PopupRespondTool extends QualityTool {
         if (chosen == null) {
             return "Error: could not resolve a choice from the provided value_id/index. "
                 + "Available value_ids: " + pending.snapshot().choices().stream()
-                    .map(c -> "'" + c.valueId() + "'").toList();
+                .map(c -> "'" + c.valueId() + "'").toList();
         }
         if (!chosen.selectable()) {
             return "Error: choice '" + chosen.text() + "' is marked non-selectable in the popup.";
@@ -250,6 +250,9 @@ public final class PopupRespondTool extends QualityTool {
         EdtUtil.invokeLater(() -> {
             try {
                 f.complete(replayable.replay(args, handler));
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                f.completeExceptionally(ie);
             } catch (Exception e) {
                 f.completeExceptionally(e);
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
@@ -1732,6 +1732,8 @@ public final class ChatWebServer implements Disposable {
         }
 
         void close() {
+            // Best-effort: if the queue is full the consumer is already lagging or closed;
+            // dropping the signal is acceptable since the connection is being torn down anyway.
             queue.offer(CLOSE_SIGNAL);
         }
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/CopilotClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/CopilotClientExporter.java
@@ -233,7 +233,7 @@ public final class CopilotClientExporter {
         data.addProperty(CONTENT_KEY, content);
         data.addProperty(INTERACTION_ID_KEY, interactionId);
         String model = text.getModel();
-        if (model != null && !model.isEmpty()) {
+        if (!model.isEmpty()) {
             data.addProperty("model", model);
         }
         sb.append(chain.emit("assistant.message", data, text.getTimestamp())).append('\n');
@@ -247,7 +247,7 @@ public final class CopilotClientExporter {
 
         String toolCallId = UUID.randomUUID().toString();
         String toolName = toolCall.getTitle();
-        if (toolName == null || toolName.isEmpty()) toolName = "unknown";
+        if (toolName.isEmpty()) toolName = "unknown";
         String argsStr = toolCall.getArguments();
 
         JsonObject toolReq = new JsonObject();
@@ -289,10 +289,8 @@ public final class CopilotClientExporter {
 
         JsonObject startData = new JsonObject();
         startData.addProperty(TOOL_CALL_ID_KEY, toolCallId);
-        String agentType = subAgent.getAgentType();
-        startData.addProperty("agentName", agentType != null ? agentType : "general-purpose");
-        String description = subAgent.getDescription();
-        startData.addProperty("agentDisplayName", description != null ? description : "");
+        startData.addProperty("agentName", subAgent.getAgentType());
+        startData.addProperty("agentDisplayName", subAgent.getDescription());
         sb.append(chain.emit("subagent.started", startData, subAgent.getTimestamp())).append('\n');
 
         if ("done".equals(subAgent.getStatus())) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/OpenCodeClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/OpenCodeClientExporter.java
@@ -599,8 +599,8 @@ public final class OpenCodeClientExporter {
     private static JsonObject buildToolInvocationPart(@NotNull EntryData.ToolCall toolCall, long timeMs) {
         JsonObject result = new JsonObject();
         result.addProperty("type", "tool");
-        result.addProperty("callID", toolCall.getEntryId() != null ? toolCall.getEntryId() : "");
-        result.addProperty("tool", toolCall.getTitle() != null ? toolCall.getTitle() : "unknown");
+        result.addProperty("callID", toolCall.getEntryId());
+        result.addProperty("tool", toolCall.getTitle());
 
         boolean completed = toolCall.getResult() != null;
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/claude/ClaudeCliClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/claude/ClaudeCliClientTest.java
@@ -450,7 +450,8 @@ class ClaudeCliClientTest {
             };
 
             // Should not throw — IOException is caught and logged
-            ClaudeCliClient.respondToControlRequest(event, failingStream);
+            org.junit.jupiter.api.Assertions.assertDoesNotThrow(() ->
+                ClaudeCliClient.respondToControlRequest(event, failingStream));
         }
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/validation/MemoryRefactorListenerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/validation/MemoryRefactorListenerTest.java
@@ -134,7 +134,8 @@ class MemoryRefactorListenerTest {
             Project project = mock(Project.class);
             MemoryRefactorListener listener = new MemoryRefactorListener(project);
             // undoRefactoring takes only a String — no RefactoringEventData class loading
-            listener.undoRefactoring("refactoring.rename");
+            org.junit.jupiter.api.Assertions.assertDoesNotThrow(() ->
+                listener.undoRefactoring("refactoring.rename"));
         }
 
         @Test
@@ -143,7 +144,7 @@ class MemoryRefactorListenerTest {
             Project project = mock(Project.class);
             MemoryRefactorListener listener = new MemoryRefactorListener(project);
             // dispose() sets pendingOldFqn = null — no side effects
-            listener.dispose();
+            org.junit.jupiter.api.Assertions.assertDoesNotThrow(listener::dispose);
         }
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/FocusGuardTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/FocusGuardTest.java
@@ -135,33 +135,32 @@ class FocusGuardTest {
     class NoVeto {
 
         @Test
-        void whenNewOwnerIsChatComponent() throws java.beans.PropertyVetoException {
+        void whenNewOwnerIsChatComponent() {
             // Focus returns to the guarded component — no steal, no veto.
             PropertyChangeEvent evt = new PropertyChangeEvent(new Object(), "focusOwner", null, chatOwner);
-            guard.vetoableChange(evt);
-            // No exception = pass-through
+            org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> guard.vetoableChange(evt));
         }
 
         @Test
-        void whenNewOwnerIsNull() throws java.beans.PropertyVetoException {
+        void whenNewOwnerIsNull() {
             // Null focus (e.g., window deactivated) — not instanceof Component, ignored.
             PropertyChangeEvent evt = new PropertyChangeEvent(new Object(), "focusOwner", chatOwner, null);
-            guard.vetoableChange(evt);
+            org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> guard.vetoableChange(evt));
         }
 
         @Test
-        void whenGuardIsUninstalled() throws java.beans.PropertyVetoException {
+        void whenGuardIsUninstalled() {
             // After uninstall the guard is logically off — any lingering focus events must be no-ops.
             guard.uninstalled = true;
-            guard.vetoableChange(outsideEvent());
+            org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> guard.vetoableChange(outsideEvent()));
         }
 
         @Test
-        void whenTargetIsInDifferentWindow() throws java.beans.PropertyVetoException {
+        void whenTargetIsInDifferentWindow() {
             // Focus to a component in a different Window (dialog, popup) — allowed through.
             PropertyChangeEvent evt = new PropertyChangeEvent(
                 new Object(), "focusOwner", chatOwner, differentWindowTarget);
-            guard.vetoableChange(evt);
+            org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> guard.vetoableChange(evt));
         }
     }
 }


### PR DESCRIPTION
Cleanup pass on the highest-impact SonarCloud findings.

## Workflows (rule githubactions:S8234, ×11)
Replaced top-level `permissions: read-all` with explicit `permissions:\n  contents: read` in all 11 workflow files. Each workflow already had job-level `permissions:` blocks granting any extra scopes (`security-events: write`, `id-token: write`, `contents: write`), so this change is safe and follows GitHub's least-privilege guidance.

## Java BLOCKERs / High-impact bugs
- **AcpFileSystemHandler.writeTextFile** (S3516): always returned `null`. Changed return type to `void` and adapted the dispatch in AcpClient.
- **CopilotClientExporter** (S2583, ×3): dropped always-true null checks against `@NotNull` Kotlin fields (`agentType`, `description`, `model`) and a redundant null check on `toolName`.
- **OpenCodeClientExporter** (S2583, ×2): dropped always-true null checks on `@NotNull` `entryId` and `title`.
- **PopupRespondTool** (S2142): re-interrupt the EDT thread when `InterruptedException` is caught inside the `CompletableFuture` wrapper.
- **ChatWebServer.SseClient.close** (S899): documented why the `queue.offer` boolean is intentionally ignored (best-effort close signal).

## Test BLOCKERs (rule java:S2699, ×8)
Wrapped the call under test in `assertDoesNotThrow(...)` for tests whose intent is "this method should not throw":
- ClaudeCliClientTest.respondToControlRequest_ioException_doesNotPropagate
- MemoryRefactorListenerTest.{undoRefactoring,dispose}_doesNotThrow
- FocusGuardTest.NoVeto.{whenNewOwnerIsChatComponent,whenNewOwnerIsNull,whenGuardIsUninstalled,whenTargetIsInDifferentWindow}

## Verification
- `FocusGuardTest`, `MemoryRefactorListenerTest`, `ClaudeCliClientTest` — all PASS locally.
- No new compilation errors in changed files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>