### PR TITLE
feat: allow grep/rg via run_command when targeting paths outside source roots

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
@@ -576,6 +576,139 @@ public final class ToolUtils {
         return null;
     }
 
+    public static boolean grepTargetsOnlyOutsideSourceRoots(@Nullable Project project, @NotNull String command) {
+        if (project == null) return false;
+        java.util.List<String> paths = extractGrepPaths(command);
+        if (paths.isEmpty()) return false;
+
+        String basePath = project.getBasePath();
+        java.nio.file.Path base = basePath != null ? java.nio.file.Path.of(basePath) : null;
+        com.intellij.openapi.roots.ProjectFileIndex index =
+            com.intellij.openapi.roots.ProjectFileIndex.getInstance(project);
+
+        for (String pathStr : paths) {
+            if (!isPathOutsideSourceRoots(pathStr, base, index)) return false;
+        }
+        return true;
+    }
+
+    private static boolean isPathOutsideSourceRoots(
+        @NotNull String pathStr,
+        @Nullable java.nio.file.Path base,
+        @NotNull com.intellij.openapi.roots.ProjectFileIndex index
+    ) {
+        java.nio.file.Path resolved = resolveCommandPath(pathStr, base);
+        if (resolved == null) return false;
+
+        VirtualFile vf = LocalFileSystem.getInstance().findFileByNioFile(resolved);
+        if (vf == null) {
+            // File doesn't exist (yet?). Allow only when clearly outside the project root.
+            return base == null || !resolved.startsWith(base);
+        }
+        return com.intellij.openapi.application.ReadAction.compute(() ->
+            !index.isInSource(vf) || index.isInGeneratedSources(vf));
+    }
+
+    @Nullable
+    private static java.nio.file.Path resolveCommandPath(@NotNull String pathStr, @Nullable java.nio.file.Path base) {
+        try {
+            String expanded = pathStr.startsWith("~")
+                ? System.getProperty("user.home") + pathStr.substring(1)
+                : pathStr;
+            java.nio.file.Path p = java.nio.file.Path.of(expanded);
+            java.nio.file.Path candidate = p.isAbsolute() || base == null ? p : base.resolve(p);
+            return candidate.normalize();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    static java.util.List<String> extractGrepPaths(@NotNull String command) {
+        java.util.List<String> tokens = tokenizeShellCommand(command);
+        int idx = findGrepCommandIndex(tokens);
+        if (idx < 0) return java.util.List.of();
+        return collectPathArgs(tokens, idx + 1);
+    }
+
+    private static int findGrepCommandIndex(@NotNull java.util.List<String> tokens) {
+        for (int i = 0; i < tokens.size(); i++) {
+            String t = tokens.get(i);
+            if (t.equalsIgnoreCase("grep") || t.equalsIgnoreCase("rg")) return i;
+        }
+        return -1;
+    }
+
+    private static final java.util.Set<String> GREP_TWO_ARG_FLAGS = java.util.Set.of(
+        "-e", "-f", "--regexp", "--file",
+        "--include", "--exclude", "--exclude-dir", "--include-dir",
+        "-A", "-B", "-C", "--after-context", "--before-context", "--context",
+        "-m", "--max-count", "--max-depth", "-t", "-T", "--type", "--type-not",
+        "-g", "--glob", "--iglob"
+    );
+
+    private static final java.util.Set<String> GREP_PATTERN_FLAGS = java.util.Set.of(
+        "-e", "-f", "--regexp", "--file"
+    );
+
+    private static java.util.List<String> collectPathArgs(@NotNull java.util.List<String> tokens, int from) {
+        boolean patternConsumed = false;
+        boolean skipNext = false;
+        java.util.List<String> paths = new java.util.ArrayList<>();
+        for (int i = from; i < tokens.size(); i++) {
+            String t = tokens.get(i);
+            if (skipNext) {
+                skipNext = false;
+                continue;
+            }
+            if (t.startsWith("-") && !t.equals("-")) {
+                if (GREP_TWO_ARG_FLAGS.contains(t)) {
+                    if (GREP_PATTERN_FLAGS.contains(t)) patternConsumed = true;
+                    skipNext = true;
+                }
+            } else if (!patternConsumed) {
+                patternConsumed = true;
+            } else if (containsGlob(t)) {
+                return java.util.List.of();
+            } else {
+                paths.add(t);
+            }
+        }
+        return paths;
+    }
+
+    private static boolean containsGlob(@NotNull String s) {
+        return s.indexOf('*') >= 0 || s.indexOf('?') >= 0 || s.indexOf('[') >= 0;
+    }
+
+    /**
+     * Tokenize a shell command string respecting single and double quotes.
+     * Backslash escapes inside quotes are NOT handled — adequate for the simple paths we care about.
+     */
+    @NotNull
+    static java.util.List<String> tokenizeShellCommand(@NotNull String command) {
+        java.util.List<String> out = new java.util.ArrayList<>();
+        StringBuilder cur = new StringBuilder();
+        char quote = 0;
+        for (int i = 0; i < command.length(); i++) {
+            char c = command.charAt(i);
+            if (quote != 0) {
+                if (c == quote) quote = 0;
+                else cur.append(c);
+            } else if (c == '\'' || c == '"') {
+                quote = c;
+            } else if (Character.isWhitespace(c)) {
+                if (!cur.isEmpty()) {
+                    out.add(cur.toString());
+                    cur.setLength(0);
+                }
+            } else {
+                cur.append(c);
+            }
+        }
+        if (!cur.isEmpty()) out.add(cur.toString());
+        return out;
+    }
+
     private static boolean isGradleCompileCommand(String cmd) {
         boolean isGradleCmd = cmd.contains("gradlew") || cmd.matches(".*\\bgradle\\s.*");
         boolean hasCompileTask = cmd.matches(".*compile(test)?(kotlin|java).*");
@@ -685,8 +818,10 @@ public final class ToolUtils {
                     + "Use intellij_read_file to read live editor buffers instead.";
             case "sed" -> "Error: sed is not allowed via " + toolName + " (bypasses IntelliJ editor buffers). "
                 + "Use edit_text with old_str/new_str for file editing instead.";
-            case "grep" -> "Error: grep/rg commands are not allowed via " + toolName + " (searches stale disk files). "
-                + "Use search_text or search_symbols to search live editor buffers instead.";
+            case "grep" -> "Error: grep/rg on project source files is not allowed via " + toolName + " (searches "
+                + "stale disk files). Use search_text or search_symbols to search live editor buffers. "
+                + "Note: grep IS allowed when targeting paths outside source roots (e.g. log files, downloaded "
+                + "CI artifacts, build/ output) — pass an explicit file/dir argument to use it.";
             case "find" -> "Error: find commands are not allowed via " + toolName + ". "
                 + "Use list_project_files to find files instead.";
             case "compile" -> "Error: Gradle compile tasks are not allowed via " + toolName + ". "

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/RunCommandTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/RunCommandTool.java
@@ -84,7 +84,11 @@ public final class RunCommandTool extends InfrastructureTool {
         if (!(toolCall instanceof com.google.gson.JsonObject jsonToolCall)) return null;
         String command = extractCommandFromToolCall(jsonToolCall);
         if (command == null) return null;
-        return ToolUtils.detectCommandAbuseType(command);
+        String abuse = ToolUtils.detectCommandAbuseType(command);
+        if ("grep".equals(abuse) && ToolUtils.grepTargetsOnlyOutsideSourceRoots(project, command)) {
+            return null;
+        }
+        return abuse;
     }
 
     private static @Nullable String extractCommandFromToolCall(com.google.gson.JsonObject toolCall) {
@@ -114,6 +118,9 @@ public final class RunCommandTool extends InfrastructureTool {
         String abuseType = ToolUtils.detectCommandAbuseType(command);
         if ("test".equals(abuseType)) {
             return new RunTestsTool(project).executeFromCommand(command);
+        }
+        if ("grep".equals(abuseType) && ToolUtils.grepTargetsOnlyOutsideSourceRoots(project, command)) {
+            abuseType = null;
         }
         if (abuseType != null) return ToolUtils.getCommandAbuseMessage(abuseType);
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/ToolUtilsAbuseDetectionTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/ToolUtilsAbuseDetectionTest.java
@@ -283,4 +283,106 @@ class ToolUtilsAbuseDetectionTest {
             assertEquals("test", ToolUtils.detectCommandAbuseType("NPX Jest"));
         }
     }
+
+    // ── Grep path extraction ─────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("grep path extraction")
+    class GrepPathExtraction {
+        @Test
+        void extractsSinglePath() {
+            assertEquals(
+                java.util.List.of("file.log"),
+                ToolUtils.extractGrepPaths("grep ERROR file.log"));
+        }
+
+        @Test
+        void extractsMultiplePaths() {
+            assertEquals(
+                java.util.List.of("a.log", "b.log"),
+                ToolUtils.extractGrepPaths("grep TODO a.log b.log"));
+        }
+
+        @Test
+        void skipsSingleArgFlags() {
+            assertEquals(
+                java.util.List.of("notes.md"),
+                ToolUtils.extractGrepPaths("grep -i -n PATTERN notes.md"));
+        }
+
+        @Test
+        void skipsTwoArgFlags() {
+            assertEquals(
+                java.util.List.of("file.txt"),
+                ToolUtils.extractGrepPaths("grep -A 3 -B 2 -e foo file.txt"));
+        }
+
+        @Test
+        void respectsQuotedPattern() {
+            assertEquals(
+                java.util.List.of("ci.log"),
+                ToolUtils.extractGrepPaths("grep \"some thing\" ci.log"));
+        }
+
+        @Test
+        void emptyWhenNoPaths() {
+            assertEquals(java.util.List.of(), ToolUtils.extractGrepPaths("grep -r PATTERN"));
+        }
+
+        @Test
+        void emptyWhenGlob() {
+            assertEquals(java.util.List.of(), ToolUtils.extractGrepPaths("grep PATTERN *.java"));
+        }
+
+        @Test
+        void emptyWhenNotGrep() {
+            assertEquals(java.util.List.of(), ToolUtils.extractGrepPaths("cat file.txt"));
+        }
+
+        @Test
+        void handlesRipgrep() {
+            assertEquals(
+                java.util.List.of("logs/build.log"),
+                ToolUtils.extractGrepPaths("rg --no-heading TODO logs/build.log"));
+        }
+
+        @Test
+        void handlesCommandPrefix() {
+            assertEquals(
+                java.util.List.of("file.log"),
+                ToolUtils.extractGrepPaths("sudo grep PATTERN file.log"));
+        }
+    }
+
+    // ── Shell tokenizer ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("shell tokenizer")
+    class ShellTokenizer {
+        @Test
+        void splitsOnWhitespace() {
+            assertEquals(
+                java.util.List.of("a", "b", "c"),
+                ToolUtils.tokenizeShellCommand("a  b\tc"));
+        }
+
+        @Test
+        void preservesDoubleQuoted() {
+            assertEquals(
+                java.util.List.of("grep", "hello world", "f"),
+                ToolUtils.tokenizeShellCommand("grep \"hello world\" f"));
+        }
+
+        @Test
+        void preservesSingleQuoted() {
+            assertEquals(
+                java.util.List.of("grep", "a b", "f"),
+                ToolUtils.tokenizeShellCommand("grep 'a b' f"));
+        }
+
+        @Test
+        void handlesEmpty() {
+            assertEquals(java.util.List.of(), ToolUtils.tokenizeShellCommand(""));
+        }
+    }
 }


### PR DESCRIPTION
Closes the feature request from the maintainer:

> We have this auto-deny on grep that should be more nuanced: scanning log files
> or downloaded CI failures has no "stale buffer" risk and should be allowed.

## Changes

- **ToolUtils.grepTargetsOnlyOutsideSourceRoots(project, command)**: new helper that parses
  the grep/rg command, resolves each path argument against the project base path, and
  consults `ProjectFileIndex.isInSource` / `isInGeneratedSources`. Returns true only when
  EVERY targeted path is outside source content.
- **RunCommandTool.detectPermissionAbuse / execute**: bypass the "grep" deny verdict when
  the new helper returns true.
- **Updated error message** to explain the new bypass.
- **Tests**: 14 new unit tests covering the parser (extractGrepPaths, tokenizeShellCommand)
  including single/multi paths, single-arg flags, two-arg flags (`-A 3`, `-e PATTERN`),
  quoted patterns, ripgrep, command prefix (`sudo grep`), glob rejection, no-paths case.

## Behaviour matrix

| Command | Verdict |
|---|---|
| `grep TODO src/main/foo.java` | DENY (in source) |
| `grep ERROR build/output.log` | ALLOW (build/ excluded) |
| `grep TODO .agent-work/notes.md` | ALLOW (outside content) |
| `grep "x" /tmp/ci-failure.log` | ALLOW (outside project) |
| `grep PATTERN` (no path) | DENY (conservative — defaults to cwd) |
| `grep PATTERN *.java` (glob) | DENY (conservative — ambiguous) |

Conservative throughout: when in doubt, keep the original deny.
