### PR TITLE
feat(reload-from-disk): support batch refresh via 'paths' array and commit documents

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/ReloadFromDiskTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/ReloadFromDiskTool.java
@@ -15,6 +15,9 @@ import org.jetbrains.annotations.NotNull;
 @SuppressWarnings("java:S112")
 public final class ReloadFromDiskTool extends FileTool {
 
+    private static final String PARAM_PATH = "path";
+    private static final String PARAM_PATHS = "paths";
+
     public ReloadFromDiskTool(Project project) {
         super(project);
     }
@@ -47,7 +50,13 @@ public final class ReloadFromDiskTool extends FileTool {
     @Override
     public @NotNull JsonObject inputSchema() {
         return schema(
-            Param.optional("path", TYPE_STRING, "File or directory path to reload (absolute or project-relative). Omit to reload the entire project root.")
+            Param.optional(PARAM_PATH, TYPE_STRING,
+                "Single file or directory path to reload (absolute or project-relative). " +
+                    "Omit both 'path' and 'paths' to reload the entire project root."),
+            Param.optional(PARAM_PATHS, "array",
+                "Multiple file/directory paths to reload in one batch — array of strings. " +
+                    "Use this for syncing many files at once (e.g., after a bulk external rewrite). " +
+                    "Combined with 'path' if both are present.")
         );
     }
 
@@ -61,27 +70,96 @@ public final class ReloadFromDiskTool extends FileTool {
         String basePath = project.getBasePath();
         if (basePath == null) return "No project base path";
 
-        if (!args.has("path") || args.get("path").isJsonNull()) {
-            VirtualFile root = LocalFileSystem.getInstance().findFileByPath(basePath);
-            if (root == null) return "Project root not found";
-            VfsUtil.markDirtyAndRefresh(false, true, true, root);
-            return "Reloaded project root from disk (" + basePath + ")";
+        java.util.List<String> requestedPaths = collectRequestedPaths(args);
+        if (requestedPaths.isEmpty()) {
+            return reloadProjectRoot(basePath);
         }
 
-        String pathStr = args.get("path").getAsString();
+        java.util.List<VirtualFile> resolved = new java.util.ArrayList<>();
+        java.util.List<String> notFound = new java.util.ArrayList<>();
+        java.util.List<String> reloadedNames = new java.util.ArrayList<>();
+        for (String pathStr : requestedPaths) {
+            resolveOne(pathStr, basePath, resolved, reloadedNames, notFound);
+        }
+
+        if (!resolved.isEmpty()) {
+            VfsUtil.markDirtyAndRefresh(false, true, true, resolved.toArray(new VirtualFile[0]));
+            commitDocuments();
+        }
+
+        return formatResult(resolved, reloadedNames, notFound);
+    }
+
+    private @NotNull String reloadProjectRoot(@NotNull String basePath) {
+        VirtualFile root = LocalFileSystem.getInstance().findFileByPath(basePath);
+        if (root == null) return "Project root not found";
+        VfsUtil.markDirtyAndRefresh(false, true, true, root);
+        commitDocuments();
+        return "Reloaded project root from disk (" + basePath + ")";
+    }
+
+    private void resolveOne(@NotNull String pathStr,
+                            @NotNull String basePath,
+                            @NotNull java.util.List<VirtualFile> resolved,
+                            @NotNull java.util.List<String> reloadedNames,
+                            @NotNull java.util.List<String> notFound) {
         VirtualFile vf = resolveVirtualFile(pathStr);
-        if (vf == null) {
-            java.io.File f = new java.io.File(pathStr);
-            if (!f.isAbsolute()) f = new java.io.File(basePath, pathStr);
-            java.io.File parent = f.getParentFile();
-            if (parent != null) {
-                VirtualFile parentVf = LocalFileSystem.getInstance().refreshAndFindFileByPath(parent.getAbsolutePath());
-                if (parentVf != null) return "Reloaded parent directory: " + parent.getAbsolutePath();
-            }
-            return "File not found: " + pathStr;
+        if (vf != null) {
+            resolved.add(vf);
+            reloadedNames.add(vf.getPath());
+            return;
         }
+        // Fall back to refreshing the parent directory so a newly-created file shows up.
+        java.io.File f = new java.io.File(pathStr);
+        if (!f.isAbsolute()) f = new java.io.File(basePath, pathStr);
+        java.io.File parent = f.getParentFile();
+        VirtualFile parentVf = (parent == null) ? null
+            : LocalFileSystem.getInstance().refreshAndFindFileByPath(parent.getAbsolutePath());
+        if (parentVf != null) {
+            resolved.add(parentVf);
+            reloadedNames.add(parentVf.getPath() + " (parent of " + pathStr + ")");
+        } else {
+            notFound.add(pathStr);
+        }
+    }
 
-        VfsUtil.markDirtyAndRefresh(false, vf.isDirectory(), true, vf);
-        return "Reloaded from disk: " + vf.getPath();
+    private @NotNull String formatResult(@NotNull java.util.List<VirtualFile> resolved,
+                                         @NotNull java.util.List<String> reloadedNames,
+                                         @NotNull java.util.List<String> notFound) {
+        StringBuilder sb = new StringBuilder();
+        if (resolved.isEmpty()) {
+            sb.append("No paths could be resolved.");
+        } else if (resolved.size() == 1 && notFound.isEmpty()) {
+            sb.append("Reloaded from disk: ").append(reloadedNames.getFirst());
+        } else {
+            sb.append("Reloaded ").append(resolved.size()).append(" path(s) from disk:");
+            for (String n : reloadedNames) sb.append("\n  - ").append(n);
+        }
+        if (!notFound.isEmpty()) {
+            sb.append("\nNot found: ").append(String.join(", ", notFound));
+        }
+        return sb.toString();
+    }
+
+    private @NotNull java.util.List<String> collectRequestedPaths(@NotNull JsonObject args) {
+        java.util.List<String> out = new java.util.ArrayList<>();
+        if (args.has(PARAM_PATHS) && args.get(PARAM_PATHS).isJsonArray()) {
+            for (var el : args.getAsJsonArray(PARAM_PATHS)) {
+                if (el.isJsonPrimitive()) {
+                    String s = el.getAsString();
+                    if (!s.isBlank()) out.add(s);
+                }
+            }
+        }
+        if (args.has(PARAM_PATH) && !args.get(PARAM_PATH).isJsonNull()) {
+            String s = args.get(PARAM_PATH).getAsString();
+            if (!s.isBlank()) out.add(s);
+        }
+        return out;
+    }
+
+    private void commitDocuments() {
+        com.intellij.openapi.application.ApplicationManager.getApplication().invokeAndWait(() ->
+            com.intellij.psi.PsiDocumentManager.getInstance(project).commitAllDocuments());
     }
 }


### PR DESCRIPTION
Enhances `reload_from_disk` to match the proactive sync semantics of jetbrains-index-mcp's `sync_files` tool while staying backwards compatible.

## Changes
- New optional **`paths`** array parameter — refresh many files/directories in one call (e.g., after a bulk external rewrite). If both `path` and `paths` are supplied, they are combined.
- After refreshing the VFS, commit pending PSI documents so PSI-backed tools (`search_symbols`, `find_references`, etc.) immediately observe the refreshed state instead of stale uncommitted edits.
- Result string now reports each resolved path, plus a separate "Not found" list for unresolved entries.
- Single-path / no-arg behavior is unchanged.

## Why
Comparing with [jetbrains-index-mcp-plugin](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin)'s `SyncFilesTool`, two clear gaps:
1. We could only refresh one path at a time → an agent rebuilding generated code with N files needed N tool calls.
2. We refreshed the VFS but didn't commit PSI documents → subsequent symbol lookups could see stale data.

Both addressed here.

## Compatibility
Old callers passing a single `path` (or no args) get identical behavior and result format. New `paths` callers get the multi-path summary.