### PR TITLE
feat(get_problems): analyze closed files via CodeSmellDetector

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetProblemsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetProblemsTool.java
@@ -44,6 +44,8 @@ public final class GetProblemsTool extends QualityTool {
     @Override
     public @NotNull String description() {
         return "Get cached editor problems (errors/warnings) for open files. Returns severity, message, and available quick-fixes per problem. " +
+            "For files NOT open in an editor, falls back to public batch code-smell analysis " +
+            "(weak warnings and intentions are only available when the file is open). " +
             "Use get_compilation_errors for a faster check focused on compile errors only. " +
             "Use get_highlights for richer diagnostics including inspections, typos, and intentions.";
     }
@@ -73,22 +75,48 @@ public final class GetProblemsTool extends QualityTool {
 
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
             try {
-                ApplicationManager.getApplication().runReadAction(() -> collectProblems(pathStr, resultFuture));
+                collectProblems(pathStr, resultFuture);
             } catch (Exception e) {
                 resultFuture.complete("Error getting problems: " + e.getMessage());
             }
         });
 
-        return resultFuture.get(10, TimeUnit.SECONDS);
+        return resultFuture.get(30, TimeUnit.SECONDS);
     }
 
     private void collectProblems(String pathStr, CompletableFuture<String> resultFuture) {
+        // Phase 1 (inside read action): resolve files, partition open vs closed, collect highlights for open ones.
+        ResolvedFiles resolved = com.intellij.openapi.application.ReadAction.compute(
+            () -> resolveAndCollectOpen(pathStr));
+        if (resolved.error != null) {
+            resultFuture.complete(resolved.error);
+            return;
+        }
+
+        // Phase 2 (outside read action): closed-file batch analysis. CodeSmellDetector
+        // must NOT run inside a read action — it manages its own progress and threading.
+        String basePath = project.getBasePath();
+        for (VirtualFile vf : resolved.closedFiles) {
+            String relPath = basePath != null ? relativize(basePath, vf.getPath()) : vf.getName();
+            collectProblemsViaCodeSmellDetector(vf, relPath, resolved.problems);
+        }
+
+        if (resolved.problems.isEmpty()) {
+            resultFuture.complete("No problems found"
+                + (pathStr.isEmpty() ? " in open files" : " in " + pathStr) + ".");
+        } else {
+            resultFuture.complete(resolved.problems.size() + " problems:\n" + String.join("\n", resolved.problems));
+        }
+    }
+
+    private @NotNull ResolvedFiles resolveAndCollectOpen(@NotNull String pathStr) {
+        ResolvedFiles out = new ResolvedFiles();
         List<VirtualFile> filesToCheck = new ArrayList<>();
         if (!pathStr.isEmpty()) {
             VirtualFile vf = resolveVirtualFile(pathStr);
             if (vf == null) {
-                resultFuture.complete(ToolUtils.ERROR_FILE_NOT_FOUND + pathStr);
-                return;
+                out.error = ToolUtils.ERROR_FILE_NOT_FOUND + pathStr;
+                return out;
             }
             filesToCheck.add(vf);
         } else {
@@ -97,27 +125,25 @@ public final class GetProblemsTool extends QualityTool {
         }
 
         String basePath = project.getBasePath();
-        List<String> problems = new ArrayList<>();
+        var fem = FileEditorManager.getInstance(project);
         for (VirtualFile vf : filesToCheck) {
-            collectProblemsForFile(vf, basePath, problems);
+            String relPath = basePath != null ? relativize(basePath, vf.getPath()) : vf.getName();
+            int beforeSize = out.problems.size();
+            collectOpenFileHighlights(vf, relPath, out.problems);
+            // If the file is not open AND we found no cached highlights, defer to closed-file analysis.
+            if (out.problems.size() == beforeSize && !fem.isFileOpen(vf)) {
+                out.closedFiles.add(vf);
+            }
         }
-
-        if (problems.isEmpty()) {
-            resultFuture.complete("No problems found"
-                + (pathStr.isEmpty() ? " in open files" : " in " + pathStr)
-                + ". Analysis is based on IntelliJ's inspections — file must be open in editor for highlights to be available.");
-        } else {
-            resultFuture.complete(problems.size() + " problems:\n" + String.join("\n", problems));
-        }
+        return out;
     }
 
-    private void collectProblemsForFile(VirtualFile vf, String basePath, List<String> problems) {
+    private void collectOpenFileHighlights(VirtualFile vf, String relPath, List<String> problems) {
         PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
         if (psiFile == null) return;
         Document doc = FileDocumentManager.getInstance().getDocument(vf);
         if (doc == null) return;
 
-        String relPath = basePath != null ? relativize(basePath, vf.getPath()) : vf.getName();
         List<com.intellij.codeInsight.daemon.impl.HighlightInfo> highlights = new ArrayList<>();
         com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerEx.processHighlights(
             doc, project,
@@ -125,13 +151,49 @@ public final class GetProblemsTool extends QualityTool {
             0, doc.getTextLength(),
             highlights::add
         );
-
         for (var h : highlights) {
             if (h.getDescription() == null) continue;
             int line = doc.getLineNumber(h.getStartOffset()) + 1;
             String severity = h.getSeverity().getName();
             problems.add(String.format(FORMAT_LOCATION,
                 relPath, line, severity, h.getDescription()));
+        }
+    }
+
+    private static final class ResolvedFiles {
+        final List<VirtualFile> closedFiles = new ArrayList<>();
+        final List<String> problems = new ArrayList<>();
+        String error;
+    }
+
+    /**
+     * Fallback for files not open in any editor: run public batch code-smell analysis
+     * via {@link com.intellij.openapi.vcs.CodeSmellDetector}. This catches errors and
+     * warnings without requiring the daemon to highlight the file first.
+     *
+     * <p>Must NOT be called from inside a read action — the detector manages its own
+     * threading and may dispatch to EDT internally.</p>
+     *
+     * <p>Note: weak warnings and intentions are only available when the file is open.</p>
+     */
+    private void collectProblemsViaCodeSmellDetector(VirtualFile vf,
+                                                     String relPath, List<String> problems) {
+        try {
+            var detector = com.intellij.openapi.vcs.CodeSmellDetector.getInstance(project);
+            var smells = detector.findCodeSmells(java.util.Collections.singletonList(vf));
+            for (var s : smells) {
+                String msg = s.getDescription();
+                if (msg == null || msg.isBlank()) continue;
+                int line = s.getStartLine() >= 0 ? s.getStartLine() + 1 : 1;
+                String severity = s.getSeverity() != null ? s.getSeverity().getName() : "WARNING";
+                problems.add(String.format(FORMAT_LOCATION, relPath, line, severity, msg));
+            }
+        } catch (com.intellij.openapi.progress.ProcessCanceledException pce) {
+            throw pce;
+        } catch (Exception e) {
+            // Closed-file analysis is best-effort; surface the failure but don't blow up the whole call.
+            problems.add(String.format(FORMAT_LOCATION, relPath, 1, "INFO",
+                "Closed-file analysis unavailable: " + e.getMessage()));
         }
     }
 }


### PR DESCRIPTION
Adds batch analysis fallback for files not currently open in the editor, matching the pattern used by jetbrains-index-mcp-plugin.

**Before:** `get_problems` only returned diagnostics for files open in an editor; closed files returned empty even with obvious errors.

**After:** Closed files are analyzed via `CodeSmellDetector.findCodeSmells` (same engine as 'Inspect Code').

**Implementation:**
- Two-phase: read action resolves files + collects open-file highlights; pooled thread (no read action) runs CodeSmellDetector, which manages its own progress/threading.
- Timeout raised from 10s to 30s to accommodate batch analysis.
- `CodeSmellInfo.getStartLine()` is 0-based; converted with +1.

Tests pass (`QualityToolsTest`).