### PR TITLE
refactor(sonar): remove dead code (unused methods, constants, redundant null checks)

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemoryService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemoryService.java
@@ -110,7 +110,7 @@ public final class MemoryService implements Disposable {
      */
     public @NotNull String getEffectiveWing() {
         String wing = MemorySettings.getInstance(project).getPalaceWing();
-        if (wing == null || wing.isEmpty()) {
+        if (wing.isEmpty()) {
             wing = project.getName()
                 .toLowerCase()
                 .replaceAll("[^a-z0-9_-]", "-")

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/SessionSwitchService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/SessionSwitchService.java
@@ -83,8 +83,6 @@ public final class SessionSwitchService implements Disposable {
     private static final String SESSIONS_DIR = "sessions";
     private static final String CLAUDE_HOME = ".claude";
     private static final String CLAUDE_PROJECTS_DIR = "projects";
-    private static final String KIRO_HOME = ".kiro";
-    private static final String KIRO_SESSIONS_DIR = "sessions";
     private static final String JUNIE_HOME = ".junie";
     private static final String JUNIE_SESSIONS_DIR = "sessions";
     private static final String USER_HOME_PROPERTY = "user.home";
@@ -188,7 +186,7 @@ public final class SessionSwitchService implements Disposable {
         // on every conversation save. No need to re-import from the previous client's
         // native format; that would introduce round-trip conversion bugs.
         List<EntryData> entries = loadCurrentV2Session(basePath);
-        if (entries == null || entries.isEmpty()) {
+        if (entries.isEmpty()) {
             LOG.info("No v2 session found to migrate from " + fromProfileId + " to " + toProfileId);
             return;
         }
@@ -620,7 +618,7 @@ public final class SessionSwitchService implements Disposable {
 
     // ── v2 session reading ────────────────────────────────────────────────────
 
-    @Nullable
+    @NotNull
     private List<EntryData> loadCurrentV2Session(@Nullable String basePath) {
         return SessionStoreV2.getInstance(project).loadRecentEntries(basePath).entries();
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/OpenCodeClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/OpenCodeClientExporter.java
@@ -275,26 +275,6 @@ public final class OpenCodeClientExporter {
         return EntryBudgetTrimmer.trimEntriesToBudget(entries, maxTotalChars);
     }
 
-    private static int countEntryChars(@NotNull EntryData e) {
-        return EntryBudgetTrimmer.countEntryChars(e);
-    }
-
-    private static int countTotalChars(@NotNull List<EntryData> entries) {
-        return EntryBudgetTrimmer.countTotalChars(entries);
-    }
-
-    private static int findSecondPromptIndex(@NotNull List<EntryData> entries) {
-        return EntryBudgetTrimmer.findSecondPromptIndex(entries);
-    }
-
-    /**
-     * Drops the oldest non-Prompt entry after the initial Prompt.
-     * Returns the number of characters freed, or -1 if nothing could be dropped.
-     */
-    private static int dropOldestNonPrompt(@NotNull List<EntryData> result) {
-        return EntryBudgetTrimmer.dropOldestNonPrompt(result);
-    }
-
     /**
      * Generates an OpenCode-style prefixed ID (e.g. {@code ses_abc123...}).
      * Uses a UUID as the random component, encoded as base-36 alphanumeric.


### PR DESCRIPTION
Clean up Sonar code-smell findings:

- **S1144** – `OpenCodeClientExporter`: drop 4 unused `private static` wrapper methods (`countEntryChars`, `countTotalChars`, `findSecondPromptIndex`, `dropOldestNonPrompt`) that thinly delegated to `EntryBudgetTrimmer`. Tests for the underlying behaviour live in `EntryBudgetTrimmerTest`.
- **S1068** – `SessionSwitchService`: drop unused `KIRO_HOME` and `KIRO_SESSIONS_DIR` private constants.
- **S2589** – `SessionSwitchService.loadCurrentV2Session`: declared `@Nullable` but always returns non-null; promote to `@NotNull` and drop the redundant `entries == null` check at the call site.
- **S2589** – `MemoryService.getEffectiveWing`: drop redundant `wing == null` check (`MemorySettings.getPalaceWing()` is declared `@NotNull`).

Build: clean (0 errors, 0 warnings).