### PR TITLE
fix(sonar): real bug fixes (S2184, S899) + S3077 suppressions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,7 +105,21 @@ sonar {
             IgnoredIssue("ts_s3776_render", "typescript:S3776", "**/chat-ui/src/renderMarkdown.ts"),
             IgnoredIssue("ts_s3776_batch", "typescript:S3776", "**/chat-ui/src/BatchRenderer.ts"),
             IgnoredIssue("ts_s2004_app", "typescript:S2004", "**/chat-ui/src/web-app.ts")
-        )
+        ) + listOf(
+            // java:S3077 (volatile non-primitive). All these fields hold either an immutable
+            // value (String, Path) or a snapshot reference that is only ever wholesale
+            // reassigned — never mutated through the reference. volatile is the correct and
+            // minimal mechanism for safe publication; AtomicReference would add overhead
+            // without changing semantics.
+            "**/services/ChatWebServer.java",
+            "**/memory/MemoryService.java",
+            "**/memory/embedding/EmbeddingService.java",
+            "**/acp/client/AcpClient.java",
+            "**/acp/client/AcpTerminalHandler.java",
+            "**/services/ActiveAgentManager.java",
+            "**/session/SessionSwitchService.java",
+            "**/settings/ShellEnvironment.java"
+        ).mapIndexed { i, path -> IgnoredIssue("s3077_$i", "java:S3077", path) }
 
         property("sonar.issue.ignore.multicriteria", ignoredIssues.joinToString(",") { it.key })
         ignoredIssues.forEach {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
@@ -1734,7 +1734,10 @@ public final class ChatWebServer implements Disposable {
         void close() {
             // Best-effort: if the queue is full the consumer is already lagging or closed;
             // dropping the signal is acceptable since the connection is being torn down anyway.
-            queue.offer(CLOSE_SIGNAL);
+            boolean accepted = queue.offer(CLOSE_SIGNAL);
+            if (!accepted) {
+                LOG.debug("SSE close signal dropped — queue full, consumer already lagging");
+            }
         }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -491,7 +491,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         turnToolsValue.setText(String.valueOf(turnTools));
         // Hide zero-value rows to reduce visual noise — a row of "0"s conveys no signal.
         turnToolsRow.setVisible(turnTools > 0);
-        long turnLines = snap.getTurnLinesAdded() + snap.getTurnLinesRemoved();
+        long turnLines = (long) snap.getTurnLinesAdded() + snap.getTurnLinesRemoved();
         turnLinesRow.setVisible(turnLines > 0);
 
         if (snap.getMultiplierMode()) {
@@ -500,7 +500,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
             turnTokensRow.setVisible(true);
             turnCostRow.setVisible(false);
         } else {
-            long turnTok = snap.getTurnInputTokens() + snap.getTurnOutputTokens();
+            long turnTok = (long) snap.getTurnInputTokens() + snap.getTurnOutputTokens();
             Double turnCost = snap.getTurnCostUsd();
             boolean hasTurnUsage = turnTok > 0 || (turnCost != null && turnCost > 0.0);
             if (hasTurnUsage) {
@@ -529,7 +529,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         int sessionTools = snap.getSessionToolCalls();
         toolsValue.setText(String.valueOf(sessionTools));
         sessionToolsRow.setVisible(sessionTools > 0);
-        long sessionLines = snap.getSessionLinesAdded() + snap.getSessionLinesRemoved();
+        long sessionLines = (long) snap.getSessionLinesAdded() + snap.getSessionLinesRemoved();
         linesRow.setVisible(sessionLines > 0);
 
         if (snap.getMultiplierMode()) {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpServerConfigTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpServerConfigTest.java
@@ -36,7 +36,7 @@ class CustomMcpServerConfigTest {
         config.setId("abcd1234-efgh");
         config.setName("");
         assertTrue(config.toolPrefix().startsWith("cmcp_"), "prefix should always start with cmcp_");
-        assertFalse(config.toolPrefix().equals("cmcp_"), "prefix should have non-empty suffix");
+        assertNotEquals("cmcp_", config.toolPrefix(), "prefix should have non-empty suffix");
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/InfrastructureToolsExtendedTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/InfrastructureToolsExtendedTest.java
@@ -7,6 +7,8 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 
+import static org.junit.Assert.assertNotEquals;
+
 /**
  * Platform tests for infrastructure tools: {@link ListRunTabsTool},
  * {@link GetNotificationsTool}, {@link ReadBuildOutputTool}, and {@link ReadRunOutputTool}.
@@ -154,7 +156,7 @@ public class InfrastructureToolsExtendedTest extends BasePlatformTestCase {
 
         assertNotNull(result);
         assertFalse("Result must not be a raw Java exception", result.startsWith("java."));
-        assertFalse("Result must not be the 'null' string", "null".equals(result));
+        assertNotEquals("Result must not be the 'null' string", "null", result);
     }
 
     // ── ReadBuildOutputTool ───────────────────────────────────────────────────
@@ -212,7 +214,7 @@ public class InfrastructureToolsExtendedTest extends BasePlatformTestCase {
 
         assertNotNull(result);
         assertFalse("Result must not be a raw Java exception", result.startsWith("java."));
-        assertFalse("Result must not be the 'null' string", "null".equals(result));
+        assertNotEquals("Result must not be the 'null' string", "null", result);
     }
 
     // ── ReadRunOutputTool ─────────────────────────────────────────────────────
@@ -259,7 +261,7 @@ public class InfrastructureToolsExtendedTest extends BasePlatformTestCase {
 
         assertNotNull(result);
         assertFalse("Result must not be blank", result.isBlank());
-        assertFalse("Result must not be the 'null' string", "null".equals(result));
+        assertNotEquals("Result must not be the 'null' string", "null", result);
         assertFalse("Result must not be a raw Java exception", result.startsWith("java."));
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextToolStaticMethodsTest.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -198,7 +199,7 @@ class SearchTextToolStaticMethodsTest {
         void literalFlagSet() throws ReflectiveOperationException {
             Pattern p = compile("test", false, true);
             assertNotNull(p);
-            assertTrue((p.flags() & Pattern.LITERAL) != 0,
+            assertNotEquals(0, p.flags() & Pattern.LITERAL,
                 "LITERAL flag should be set when isRegex=false");
         }
 
@@ -216,9 +217,9 @@ class SearchTextToolStaticMethodsTest {
         void literalCaseInsensitiveBothFlags() throws ReflectiveOperationException {
             Pattern p = compile("test", false, false);
             assertNotNull(p);
-            assertTrue((p.flags() & Pattern.LITERAL) != 0,
+            assertNotEquals(0, p.flags() & Pattern.LITERAL,
                 "LITERAL flag should be set");
-            assertTrue((p.flags() & Pattern.CASE_INSENSITIVE) != 0,
+            assertNotEquals(0, p.flags() & Pattern.CASE_INSENSITIVE,
                 "CASE_INSENSITIVE flag should be set");
         }
     }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/AnthropicClientRoundTripTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/AnthropicClientRoundTripTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -412,8 +413,8 @@ class AnthropicClientRoundTripTest {
         for (EntryData entry : imported) {
             if (entry instanceof EntryData.ToolCall) {
                 toolCount++;
-                assertNotNull("Each tool call should have a result after round-trip",
-                    ((EntryData.ToolCall) entry).getResult());
+                assertNotNull(((EntryData.ToolCall) entry).getResult(),
+                    "Each tool call should have a result after round-trip");
             }
         }
         assertEquals(3, toolCount, "All 3 tool results should round-trip");

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/AnthropicClientRoundTripTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/AnthropicClientRoundTripTest.java
@@ -412,8 +412,8 @@ class AnthropicClientRoundTripTest {
         for (EntryData entry : imported) {
             if (entry instanceof EntryData.ToolCall) {
                 toolCount++;
-                assertTrue(((EntryData.ToolCall) entry).getResult() != null,
-                    "Each tool call should have a result after round-trip");
+                assertNotNull("Each tool call should have a result after round-trip",
+                    ((EntryData.ToolCall) entry).getResult());
             }
         }
         assertEquals(3, toolCount, "All 3 tool results should round-trip");

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/OpenCodeClientRoundTripTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/OpenCodeClientRoundTripTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/OpenCodeClientRoundTripTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/OpenCodeClientRoundTripTest.java
@@ -332,7 +332,7 @@ class OpenCodeClientRoundTripTest {
                 while (rs.next()) {
                     JsonObject partData = GSON.fromJson(rs.getString("data"), JsonObject.class);
                     String type = partData.get("type").getAsString();
-                    assertNotEquals("subagent type must not be written to DB", "subagent", type);
+                    assertNotEquals("subagent", type, "subagent type must not be written to DB");
                     if ("text".equals(type)) {
                         String text = partData.get("text").getAsString();
                         if (text.contains("Exploring codebase")) {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/OpenCodeClientRoundTripTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/OpenCodeClientRoundTripTest.java
@@ -332,7 +332,7 @@ class OpenCodeClientRoundTripTest {
                 while (rs.next()) {
                     JsonObject partData = GSON.fromJson(rs.getString("data"), JsonObject.class);
                     String type = partData.get("type").getAsString();
-                    assertFalse("subagent".equals(type), "subagent type must not be written to DB");
+                    assertNotEquals("subagent type must not be written to DB", "subagent", type);
                     if ("text".equals(type)) {
                         String text = partData.get("text").getAsString();
                         if (text.contains("Exploring codebase")) {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/SessionSwitchServiceStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/SessionSwitchServiceStaticMethodsTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -656,7 +657,7 @@ class SessionSwitchServiceStaticMethodsTest {
         void differentSessionIds_produceDifferentPaths() {
             Path dir1 = SessionSwitchService.copilotSessionDir("id-1");
             Path dir2 = SessionSwitchService.copilotSessionDir("id-2");
-            assertFalse(dir1.equals(dir2),
+            assertNotEquals(dir2, dir1,
                 "Different session IDs should produce different paths");
             assertEquals(dir1.getParent(), dir2.getParent(),
                 "Parent directories should be the same");


### PR DESCRIPTION
Continuing the SonarCloud sweep on master.

## Real bugs fixed
- **S2184** (×3, SessionStatsPanel.java): `int + int` arithmetic assigned to `long` could overflow. Cast one operand to `long` before addition.
- **S899** (×1, ChatWebServer.java): `BlockingQueue.offer()` return value was discarded. Now logged at debug level when the SSE close signal can't be enqueued (queue full / consumer torn down).

## Suppressed: S3077 (volatile non-primitive)
All 26 findings are across 8 files where the `volatile` reference holds either:
- an immutable value (`String`, `Path`), or
- a snapshot reference that is only ever wholesale-reassigned (never mutated through the reference).

In these patterns, `volatile` provides correct safe-publication semantics. Switching to `AtomicReference` would add overhead without changing observable behaviour. Files added to the existing `sonar.issue.ignore.multicriteria` block in build.gradle.kts.

Quality gate may flag new-code coverage; admin-merge per project policy once other checks pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>