### PR TITLE
fix(sonar): mechanical cleanup — lambda style, unused imports, S125 false positives

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,7 +119,13 @@ sonar {
             "**/services/ActiveAgentManager.java",
             "**/session/SessionSwitchService.java",
             "**/settings/ShellEnvironment.java"
-        ).mapIndexed { i, path -> IgnoredIssue("s3077_$i", "java:S3077", path) }
+        ).mapIndexed { i, path -> IgnoredIssue("s3077_$i", "java:S3077", path) } + listOf(
+            // java:S125 — both occurrences are descriptive comment blocks (close-signal
+            // best-effort note, EDT-freeze rationale) that Sonar's heuristics misclassify
+            // as commented-out code. They are not dead code.
+            IgnoredIssue("s125_chatwebserver", "java:S125", "**/services/ChatWebServer.java"),
+            IgnoredIssue("s125_runinspections", "java:S125", "**/psi/tools/quality/RunInspectionsTool.java")
+        )
 
         property("sonar.issue.ignore.multicriteria", ignoredIssues.joinToString(",") { it.key })
         ignoredIssues.forEach {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editor/ListScratchFilesTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editor/ListScratchFilesTool.java
@@ -11,7 +11,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -43,7 +42,7 @@ public final class ListScratchFilesTool extends EditorTool {
         return "List existing scratch files in the IDE scratch directory";
     }
 
-    
+
 
     @Override
     public @NotNull Kind kind() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/GetNotificationsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/GetNotificationsTool.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import com.github.catatafishen.agentbridge.ui.renderers.IdeInfoRenderer;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Gets recent IntelliJ balloon notifications.
@@ -30,7 +29,7 @@ public final class GetNotificationsTool extends InfrastructureTool {
         return "Get recent IntelliJ balloon notifications";
     }
 
-    
+
 
     @Override
     public @NotNull Kind kind() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/AddToDictionaryTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/AddToDictionaryTool.java
@@ -1,6 +1,5 @@
 package com.github.catatafishen.agentbridge.psi.tools.quality;
 
-import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.ui.renderers.SimpleStatusRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/claude/AbstractClaudeAgentClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/claude/AbstractClaudeAgentClientTest.java
@@ -203,14 +203,14 @@ class AbstractClaudeAgentClientTest {
         @Test
         void throwsWhenNotStarted() {
             client.setStarted(false);
-            AgentException ex = assertThrows(AgentException.class, () -> client.testEnsureStarted());
+            AgentException ex = assertThrows(AgentException.class, client::testEnsureStarted);
             assertTrue(ex.getMessage().contains("not started"));
         }
 
         @Test
         void doesNotThrowWhenStarted() {
             client.setStarted(true);
-            assertDoesNotThrow(() -> client.testEnsureStarted());
+            assertDoesNotThrow(client::testEnsureStarted);
         }
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpClientSessionTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpClientSessionTest.java
@@ -49,7 +49,7 @@ class CustomMcpClientSessionTest {
     @Test
     void initialize_capturesSessionIdFromResponseHeader() throws IOException {
         String sessionId = "test-session-abc123";
-        setupHandler((exchange) -> {
+        setupHandler(exchange -> {
             requests.add(recordRequest(exchange));
             exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, sessionId);
             respondJson(exchange, initializeResult());
@@ -64,7 +64,7 @@ class CustomMcpClientSessionTest {
 
     @Test
     void initialize_noSessionHeader_sessionIdRemainsNull() throws IOException {
-        setupHandler((exchange) -> {
+        setupHandler(exchange -> {
             requests.add(recordRequest(exchange));
             respondJson(exchange, initializeResult());
         });
@@ -81,7 +81,7 @@ class CustomMcpClientSessionTest {
         String sessionId = "session-for-list";
         AtomicInteger callCount = new AtomicInteger();
 
-        setupHandler((exchange) -> {
+        setupHandler(exchange -> {
             RecordedRequest req = recordRequest(exchange);
             requests.add(req);
             int call = callCount.incrementAndGet();
@@ -110,7 +110,7 @@ class CustomMcpClientSessionTest {
         String sessionId = "session-for-call";
         AtomicInteger callCount = new AtomicInteger();
 
-        setupHandler((exchange) -> {
+        setupHandler(exchange -> {
             RecordedRequest req = recordRequest(exchange);
             requests.add(req);
             int call = callCount.incrementAndGet();
@@ -142,7 +142,7 @@ class CustomMcpClientSessionTest {
     void statelessServer_noSessionHeaderSentOnSubsequentRequests() throws IOException {
         AtomicInteger callCount = new AtomicInteger();
 
-        setupHandler((exchange) -> {
+        setupHandler(exchange -> {
             requests.add(recordRequest(exchange));
             int call = callCount.incrementAndGet();
 
@@ -172,7 +172,7 @@ class CustomMcpClientSessionTest {
         String secondSession = "session-new";
         AtomicInteger callCount = new AtomicInteger();
 
-        setupHandler((exchange) -> {
+        setupHandler(exchange -> {
             RecordedRequest req = recordRequest(exchange);
             requests.add(req);
             int call = callCount.incrementAndGet();
@@ -209,7 +209,7 @@ class CustomMcpClientSessionTest {
         String session = "session-doomed";
         AtomicInteger callCount = new AtomicInteger();
 
-        setupHandler((exchange) -> {
+        setupHandler(exchange -> {
             requests.add(recordRequest(exchange));
             int call = callCount.incrementAndGet();
 
@@ -244,7 +244,7 @@ class CustomMcpClientSessionTest {
         String secondSession = "sess-2";
         AtomicInteger callCount = new AtomicInteger();
 
-        setupHandler((exchange) -> {
+        setupHandler(exchange -> {
             requests.add(recordRequest(exchange));
             int call = callCount.incrementAndGet();
 
@@ -280,7 +280,7 @@ class CustomMcpClientSessionTest {
         AtomicReference<String> deleteMethod = new AtomicReference<>();
         AtomicReference<String> deleteSessionHeader = new AtomicReference<>();
 
-        setupHandler((exchange) -> {
+        setupHandler(exchange -> {
             requests.add(recordRequest(exchange));
             if ("DELETE".equals(exchange.getRequestMethod())) {
                 deleteMethod.set(exchange.getRequestMethod());
@@ -307,7 +307,7 @@ class CustomMcpClientSessionTest {
 
     @Test
     void close_noopWhenNoSession() throws IOException {
-        setupHandler((exchange) -> {
+        setupHandler(exchange -> {
             requests.add(recordRequest(exchange));
             respondJson(exchange, initializeResult());
         });
@@ -328,7 +328,7 @@ class CustomMcpClientSessionTest {
     void close_swallows405FromServer() throws IOException {
         String sessionId = "session-405";
 
-        setupHandler((exchange) -> {
+        setupHandler(exchange -> {
             requests.add(recordRequest(exchange));
             if ("DELETE".equals(exchange.getRequestMethod())) {
                 exchange.sendResponseHeaders(405, -1);
@@ -351,7 +351,7 @@ class CustomMcpClientSessionTest {
         String sessionId = "session-idempotent";
         AtomicInteger deleteCount = new AtomicInteger();
 
-        setupHandler((exchange) -> {
+        setupHandler(exchange -> {
             requests.add(recordRequest(exchange));
             if ("DELETE".equals(exchange.getRequestMethod())) {
                 deleteCount.incrementAndGet();

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupGateLogicTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupGateLogicTest.java
@@ -116,7 +116,7 @@ class PopupGateLogicTest {
             PopupGateLogic.evaluate(p, "search_text", OWNING, later);
         // age should mention seconds count
         long expected = PendingPopupService.MAX_AGE.toSeconds() + 42;
-        assertTrue(awcn.note().contains(expected + "s"), () -> awcn.note());
+        assertTrue(awcn.note().contains(expected + "s"), awcn::note);
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ActiveAgentManagerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ActiveAgentManagerTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ActiveAgentManagerTest {
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/MarkdownRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/MarkdownRendererTest.java
@@ -243,7 +243,7 @@ class MarkdownRendererTest {
 
         @Test
         void inlineCodeWithGitShaResolvesToGitShowLink() {
-            String html = renderWithGit("`abc1234`", sha -> "abc1234".equals(sha));
+            String html = renderWithGit("`abc1234`", "abc1234"::equals);
             assertTrue(html.contains("<a href='gitshow://abc1234'>"), html);
             assertTrue(html.contains("<code>abc1234</code>"), html);
         }
@@ -722,7 +722,7 @@ class MarkdownRendererTest {
 
         @Test
         void markdownLinkResolvedAsGitCommit() {
-            String html = renderWithGit("[fix](abcdef1234)", sha -> "abcdef1234".equals(sha));
+            String html = renderWithGit("[fix](abcdef1234)", "abcdef1234"::equals);
             assertTrue(html.contains("gitshow://abcdef1234"), html);
         }
 
@@ -804,7 +804,7 @@ class MarkdownRendererTest {
     class GitShaDetection {
         @Test
         void bareGitShaInTextResolvesToLink() {
-            String html = renderWithGit("Fixed in abc1234 commit", sha -> "abc1234".equals(sha));
+            String html = renderWithGit("Fixed in abc1234 commit", "abc1234"::equals);
             assertTrue(html.contains("<a href='gitshow://abc1234'"), html);
             assertTrue(html.contains("class='git-commit-link'"), html);
         }
@@ -820,7 +820,7 @@ class MarkdownRendererTest {
         void gitShaMaxLength() {
             // 12 chars is within BARE_GIT_SHA_REGEX range
             String sha = "abcdef123456";
-            String html = renderWithGit("Commit " + sha, s -> sha.equals(s));
+            String html = renderWithGit("Commit " + sha, sha::equals);
             assertTrue(html.contains("gitshow://" + sha), html);
         }
 
@@ -1175,7 +1175,7 @@ class MarkdownRendererTest {
             String html = renderFull("[fix](" + sha + ")",
                 ref -> null,
                 ref -> null,
-                s -> sha.equals(s));
+                sha::equals);
             assertTrue(html.contains("gitshow://" + sha), html);
         }
     }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/HttpRequestRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/HttpRequestRendererTest.java
@@ -2,8 +2,6 @@ package com.github.catatafishen.agentbridge.ui.renderers;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/SimpleStatusRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/SimpleStatusRendererTest.java
@@ -1,6 +1,5 @@
 package com.github.catatafishen.agentbridge.ui.renderers;
 
-import kotlin.text.Regex;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
Mechanical SonarCloud cleanup batch.

- **S1611** ×12: remove redundant single-parameter lambda parens in `CustomMcpClientSessionTest`
- **S1612** ×7: replace lambdas with method references (`AbstractClaudeAgentClientTest`, `PopupGateLogicTest`, `MarkdownRendererTest`)
- **S1128** ×6: remove unused imports across 6 files
- **S125** ×2: suppress false positives in `build.gradle.kts` — both flagged sites are descriptive comment blocks (close-signal best-effort note in `ChatWebServer`, EDT-freeze rationale in `RunInspectionsTool`), not commented-out code.

Verified with clean rebuild.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>