### PR TITLE
fix(sonar): S1130 — remove unnecessary throws declarations

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalTool.java
@@ -43,7 +43,7 @@ public abstract class TerminalTool extends Tool {
         return ToolRegistry.Category.TERMINAL;
     }
 
-    protected Object findTerminalWidget(Class<?> managerClass, String tabName) throws Exception {
+    protected Object findTerminalWidget(Class<?> managerClass, String tabName) {
         if (tabName != null) {
             return findTerminalWidgetByTabName(managerClass, tabName);
         }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/AbstractAgentClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/AbstractAgentClientTest.java
@@ -137,27 +137,27 @@ class AbstractAgentClientTest {
         }
 
         @Test
-        void startConnects() throws Exception {
+        void startConnects() {
             client.start();
             assertTrue(client.isConnected());
         }
 
         @Test
-        void stopDisconnects() throws Exception {
+        void stopDisconnects() {
             client.start();
             client.stop();
             assertFalse(client.isConnected());
         }
 
         @Test
-        void isHealthyDelegatesToIsConnected() throws Exception {
+        void isHealthyDelegatesToIsConnected() {
             assertFalse(client.isHealthy());
             client.start();
             assertTrue(client.isHealthy());
         }
 
         @Test
-        void closeDelegatesToStop() throws Exception {
+        void closeDelegatesToStop() {
             client.start();
             assertTrue(client.isConnected());
             client.close();
@@ -165,7 +165,7 @@ class AbstractAgentClientTest {
         }
 
         @Test
-        void checkAuthenticationReturnsNullWhenConnected() throws Exception {
+        void checkAuthenticationReturnsNullWhenConnected() {
             client.start();
             assertNull(client.checkAuthentication());
         }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/claude/ClaudeCliClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/claude/ClaudeCliClientTest.java
@@ -355,7 +355,7 @@ class ClaudeCliClientTest {
     class RespondToControlRequest {
 
         @Test
-        void canUseToolSubtype_writesAllowDecision() throws Exception {
+        void canUseToolSubtype_writesAllowDecision() {
             JsonObject event = new JsonObject();
             event.addProperty("subtype", "can_use_tool");
             event.addProperty("requestId", "req-42");
@@ -374,7 +374,7 @@ class ClaudeCliClientTest {
         }
 
         @Test
-        void nonToolSubtype_noResponseField() throws Exception {
+        void nonToolSubtype_noResponseField() {
             JsonObject event = new JsonObject();
             event.addProperty("subtype", "something_else");
             event.addProperty("requestId", "req-99");
@@ -392,7 +392,7 @@ class ClaudeCliClientTest {
         }
 
         @Test
-        void missingSubtype_defaultsToEmpty() throws Exception {
+        void missingSubtype_defaultsToEmpty() {
             JsonObject event = new JsonObject();
             event.addProperty("requestId", "req-1");
 
@@ -408,7 +408,7 @@ class ClaudeCliClientTest {
         }
 
         @Test
-        void missingRequestId_defaultsToEmpty() throws Exception {
+        void missingRequestId_defaultsToEmpty() {
             JsonObject event = new JsonObject();
             event.addProperty("subtype", "can_use_tool");
 
@@ -424,7 +424,7 @@ class ClaudeCliClientTest {
         }
 
         @Test
-        void outputEndsWithNewline() throws Exception {
+        void outputEndsWithNewline() {
             JsonObject event = new JsonObject();
             event.addProperty("subtype", "test");
             event.addProperty("requestId", "r");

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/CodexClientRoundTripTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/CodexClientRoundTripTest.java
@@ -250,7 +250,7 @@ class CodexClientRoundTripTest {
     // ── Round-trip tests ────────────────────────────────────────────
 
     @Test
-    void roundTripPreservesTextContent() throws IOException, SQLException {
+    void roundTripPreservesTextContent() throws SQLException {
         List<EntryData> original = List.of(
             new EntryData.Prompt("What is Rust?"),
             new EntryData.Text("A systems language.")
@@ -272,7 +272,7 @@ class CodexClientRoundTripTest {
     }
 
     @Test
-    void roundTripPreservesToolCalls() throws IOException, SQLException {
+    void roundTripPreservesToolCalls() throws SQLException {
         EntryData.ToolCall toolCall = new EntryData.ToolCall("read_file", "{\"path\":\"/a\"}", "other", "file data");
 
         List<EntryData> original = List.of(
@@ -305,7 +305,7 @@ class CodexClientRoundTripTest {
     }
 
     @Test
-    void roundTripPreservesReasoning() throws IOException, SQLException {
+    void roundTripPreservesReasoning() throws SQLException {
         List<EntryData> original = List.of(
             new EntryData.Prompt("Think"),
             new EntryData.Thinking("Let me think..."),

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/OpenCodeClientRoundTripTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/OpenCodeClientRoundTripTest.java
@@ -379,7 +379,7 @@ class OpenCodeClientRoundTripTest {
     }
 
     @Test
-    void roundTripPreservesTextContent() throws SQLException {
+    void roundTripPreservesTextContent() {
         List<EntryData> entries = List.of(
             promptEntry("What is Rust?"),
             textEntry("A systems language.")
@@ -397,7 +397,7 @@ class OpenCodeClientRoundTripTest {
     }
 
     @Test
-    void roundTripPreservesToolInvocations() throws SQLException {
+    void roundTripPreservesToolInvocations() {
         List<EntryData> entries = List.of(
             promptEntry("Read /a"),
             textEntry("Reading file"),
@@ -419,7 +419,7 @@ class OpenCodeClientRoundTripTest {
     }
 
     @Test
-    void roundTripMultipleTurns() throws SQLException {
+    void roundTripMultipleTurns() {
         List<EntryData> entries = List.of(
             promptEntry("Question 1"),
             textEntry("Answer 1"),

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/SessionSwitchServiceStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/SessionSwitchServiceStaticMethodsTest.java
@@ -198,7 +198,7 @@ class SessionSwitchServiceStaticMethodsTest {
         }
 
         @Test
-        void nonExistingDirectory_doesNotThrow() throws Exception {
+        void nonExistingDirectory_doesNotThrow() {
             Path nonExistent = Path.of("/tmp/non-existent-dir-" + System.nanoTime());
             List<Path> result = new ArrayList<>();
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2Test.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2Test.java
@@ -1336,7 +1336,7 @@ class SessionStoreV2Test {
 
         @Test
         @DisplayName("resetCurrentSessionId deletes the .current-session-id file when it exists")
-        void resetCurrentSessionId_deletesFile() throws IOException {
+        void resetCurrentSessionId_deletesFile() {
             SessionStoreV2 store = newStore();
             store.getCurrentSessionId(tempDir.toString()); // create the file
             assertTrue(currentSessionIdFile().toFile().exists(), "prerequisite: file must exist");


### PR DESCRIPTION
Mechanical S1130 cleanup: removes `throws Exception/IOException/SQLException` from methods whose bodies don't actually throw the declared checked exceptions.

**Files / counts:**
- AbstractAgentClientTest ×5
- ClaudeCliClientTest ×5 (4 are IDE-flagged-only, not yet in Sonar)
- CodexClientRoundTripTest ×3
- OpenCodeClientRoundTripTest ×3
- SessionSwitchServiceStaticMethodsTest ×1
- SessionStoreV2Test ×1
- TerminalTool#findTerminalWidget — body catches all exceptions internally

Verified with clean rebuild.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>