### PR TITLE
fix(sonar): S5778 — single-invocation lambdas in assertThrows

### DIFF
--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/AcpTerminalHandlerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/AcpTerminalHandlerTest.java
@@ -63,7 +63,8 @@ class AcpTerminalHandlerTest {
 
     @Test
     void createRequiresCommand() {
-        assertThrows(IllegalArgumentException.class, () -> handler.create(new JsonObject()),
+        JsonObject empty = new JsonObject();
+        assertThrows(IllegalArgumentException.class, () -> handler.create(empty),
             "Must reject missing 'command' parameter");
     }
 
@@ -121,8 +122,8 @@ class AcpTerminalHandlerTest {
 
     @Test
     void outputRejectsUnknownTerminalId() {
-        assertThrows(IllegalArgumentException.class,
-            () -> handler.output(terminalParams("nonexistent")));
+        JsonObject params = terminalParams("nonexistent");
+        assertThrows(IllegalArgumentException.class, () -> handler.output(params));
     }
 
     // ── terminal/wait_for_exit — per spec: blocks, returns {exitCode, signal} ─
@@ -190,8 +191,10 @@ class AcpTerminalHandlerTest {
         handler.release(terminalParams(id));
 
         // Per spec: "terminal ID becomes invalid for all other terminal/* methods"
-        assertThrows(IllegalArgumentException.class, () -> handler.output(terminalParams(id)));
-        assertThrows(IllegalArgumentException.class, () -> handler.kill(terminalParams(id)));
+        JsonObject outParams = terminalParams(id);
+        JsonObject killParams = terminalParams(id);
+        assertThrows(IllegalArgumentException.class, () -> handler.output(outParams));
+        assertThrows(IllegalArgumentException.class, () -> handler.kill(killParams));
     }
 
     @Test
@@ -201,8 +204,10 @@ class AcpTerminalHandlerTest {
 
         handler.releaseAll();
 
-        assertThrows(IllegalArgumentException.class, () -> handler.output(terminalParams(id1)));
-        assertThrows(IllegalArgumentException.class, () -> handler.output(terminalParams(id2)));
+        JsonObject params1 = terminalParams(id1);
+        JsonObject params2 = terminalParams(id2);
+        assertThrows(IllegalArgumentException.class, () -> handler.output(params1));
+        assertThrows(IllegalArgumentException.class, () -> handler.output(params2));
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/claude/ClaudeCliClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/claude/ClaudeCliClientTest.java
@@ -163,8 +163,8 @@ class ClaudeCliClientTest {
 
         @Test
         void listIsUnmodifiable() {
-            assertThrows(UnsupportedOperationException.class,
-                () -> models.add(new Model("test", "test", null, null)));
+            Model extra = new Model("test", "test", null, null);
+            assertThrows(UnsupportedOperationException.class, () -> models.add(extra));
         }
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpSettingsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpSettingsTest.java
@@ -27,8 +27,9 @@ class CustomMcpSettingsTest {
         settings.setServers(List.of(config));
 
         List<CustomMcpServerConfig> returned = settings.getServers();
-        assertThrows(UnsupportedOperationException.class, () -> returned.add(
-                new CustomMcpServerConfig("id-2", "Server B", "http://localhost:4000/mcp", "", true)));
+        CustomMcpServerConfig extra = new CustomMcpServerConfig(
+                "id-2", "Server B", "http://localhost:4000/mcp", "", true);
+        assertThrows(UnsupportedOperationException.class, () -> returned.add(extra));
 
         // Original settings unchanged
         assertEquals(1, settings.getServers().size());

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/kg/KgTripleTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/kg/KgTripleTest.java
@@ -128,8 +128,8 @@ class KgTripleTest {
 
     @Test
     void builder_throwsOnEmptySubject() {
-        assertThrows(IllegalArgumentException.class,
-            () -> KgTriple.builder().subject("   "));
+        KgTriple.Builder builder = KgTriple.builder();
+        assertThrows(IllegalArgumentException.class, () -> builder.subject("   "));
     }
 
     @Test


### PR DESCRIPTION
Mechanical S5778 cleanup: extract argument allocations to local variables so assertThrows lambdas contain exactly one invocation that can throw. Pure refactor, no behaviour change.

**Sites:**
- AcpTerminalHandlerTest ×6
- ClaudeCliClientTest ×1
- CustomMcpSettingsTest ×1
- KgTripleTest ×1

Verified with clean rebuild.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>