### PR TITLE
fix(sonar): S107 — too many parameters

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
@@ -403,22 +403,27 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
             snapshots,
             newFiles,
             deletedFiles,
-            approvals,
-            lastEditedAt,
-            linesAdded,
-            linesRemoved,
+            new EditMetrics(approvals, lastEditedAt, linesAdded, linesRemoved),
             project.getBasePath()
         );
     }
+
+    /**
+     * Per-path edit metrics passed together to keep review-building method
+     * signatures within the 7-parameter limit (Sonar S107).
+     */
+    record EditMetrics(
+        @NotNull Map<String, ApprovalState> approvals,
+        @NotNull Map<String, Long> lastEditedAt,
+        @NotNull Map<String, Integer> linesAdded,
+        @NotNull Map<String, Integer> linesRemoved
+    ) {}
 
     static @NotNull List<ReviewItem> buildReviewItems(
         @NotNull Map<String, String> snapshots,
         @NotNull Set<String> newFiles,
         @NotNull Map<String, String> deletedFiles,
-        @NotNull Map<String, ApprovalState> approvals,
-        @NotNull Map<String, Long> lastEditedAt,
-        @NotNull Map<String, Integer> linesAdded,
-        @NotNull Map<String, Integer> linesRemoved,
+        @NotNull EditMetrics metrics,
         @Nullable String basePath
     ) {
         List<ReviewItem> items = new ArrayList<>();
@@ -426,20 +431,17 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
         for (Map.Entry<String, String> entry : snapshots.entrySet()) {
             String path = entry.getKey();
             if (newFiles.contains(path) || deletedFiles.containsKey(path)) continue;
-            items.add(buildItem(path, basePath, ReviewItem.Status.MODIFIED, entry.getValue(),
-                approvals, lastEditedAt, linesAdded, linesRemoved));
+            items.add(buildItem(path, basePath, ReviewItem.Status.MODIFIED, entry.getValue(), metrics));
         }
         for (String path : newFiles) {
             if (deletedFiles.containsKey(path)) continue;
-            items.add(buildItem(path, basePath, ReviewItem.Status.ADDED, null,
-                approvals, lastEditedAt, linesAdded, linesRemoved));
+            items.add(buildItem(path, basePath, ReviewItem.Status.ADDED, null, metrics));
         }
         for (Map.Entry<String, String> entry : deletedFiles.entrySet()) {
             String path = entry.getKey();
             if (newFiles.contains(path)) continue;
             String beforeContent = snapshots.getOrDefault(path, entry.getValue());
-            items.add(buildItem(path, basePath, ReviewItem.Status.DELETED, beforeContent,
-                approvals, lastEditedAt, linesAdded, linesRemoved));
+            items.add(buildItem(path, basePath, ReviewItem.Status.DELETED, beforeContent, metrics));
         }
 
         items.sort((a, b) -> a.relativePath().compareToIgnoreCase(b.relativePath()));
@@ -449,14 +451,11 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
     private static @NotNull ReviewItem buildItem(@NotNull String path, @Nullable String basePath,
                                                  @NotNull ReviewItem.Status status,
                                                  @Nullable String beforeContent,
-                                                 @NotNull Map<String, ApprovalState> approvals,
-                                                 @NotNull Map<String, Long> lastEditedAt,
-                                                 @NotNull Map<String, Integer> linesAdded,
-                                                 @NotNull Map<String, Integer> linesRemoved) {
-        ApprovalState state = approvals.getOrDefault(path, ApprovalState.PENDING);
-        long ts = lastEditedAt.getOrDefault(path, 0L);
-        int added = linesAdded.getOrDefault(path, 0);
-        int removed = linesRemoved.getOrDefault(path, 0);
+                                                 @NotNull EditMetrics metrics) {
+        ApprovalState state = metrics.approvals().getOrDefault(path, ApprovalState.PENDING);
+        long ts = metrics.lastEditedAt().getOrDefault(path, 0L);
+        int added = metrics.linesAdded().getOrDefault(path, 0);
+        int removed = metrics.linesRemoved().getOrDefault(path, 0);
         return new ReviewItem(path, relativize(path, basePath), status, beforeContent,
             state, ts, added, removed);
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
@@ -229,33 +229,29 @@ public final class SearchTextTool extends NavigationTool {
         // does not need to call PsiManager on the EDT.
         com.intellij.psi.PsiFile psiFile = p.positions() != null
             ? PsiManager.getInstance(project).findFile(vf) : null;
-        searchFileForPattern(vf, psiFile, p.pattern(), relPath, p.results(), p.positions(), p.maxResults(), p.contextLines(), p.totalOutputBytes());
+        searchFileForPattern(vf, psiFile, relPath, p);
         return p.results().size() < p.maxResults() && p.totalOutputBytes().get() < MAX_OUTPUT_BYTES;
     }
 
     private static void searchFileForPattern(VirtualFile vf, @Nullable com.intellij.psi.PsiFile psiFile,
-                                             Pattern pattern,
-                                             String relPath, List<String> results,
-                                             @Nullable List<MatchPosition> positions,
-                                             int maxResults, int contextLines,
-                                             AtomicInteger totalOutputBytes) {
+                                             String relPath, SearchParams p) {
         Document doc = FileDocumentManager.getInstance().getDocument(vf);
         if (doc == null) return;
         String text = doc.getText();
-        Matcher matcher = pattern.matcher(text);
-        while (matcher.find() && results.size() < maxResults && totalOutputBytes.get() < MAX_OUTPUT_BYTES) {
+        Matcher matcher = p.pattern().matcher(text);
+        while (matcher.find() && p.results().size() < p.maxResults() && p.totalOutputBytes().get() < MAX_OUTPUT_BYTES) {
             int matchLine = doc.getLineNumber(matcher.start()) + 1;
             String lineText = ToolUtils.getLineText(doc, matchLine - 1);
             String entry;
-            if (contextLines <= 0) {
+            if (p.contextLines() <= 0) {
                 entry = String.format(FORMAT_LINE_REF, relPath, matchLine, lineText);
             } else {
-                entry = buildMatchWithContext(doc, relPath, matchLine, lineText, contextLines);
+                entry = buildMatchWithContext(doc, relPath, matchLine, lineText, p.contextLines());
             }
-            results.add(entry);
-            totalOutputBytes.addAndGet(entry.length());
-            if (positions != null) {
-                positions.add(new MatchPosition(vf, psiFile, matcher.start(), matcher.end()));
+            p.results().add(entry);
+            p.totalOutputBytes().addAndGet(entry.length());
+            if (p.positions() != null) {
+                p.positions().add(new MatchPosition(vf, psiFile, matcher.start(), matcher.end()));
             }
         }
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/OpenCodeClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/OpenCodeClientExporter.java
@@ -172,9 +172,9 @@ public final class OpenCodeClientExporter {
                     // Flush any pending assistant message before a new user message
                     if (pendingParts != null && !pendingParts.isEmpty()) {
                         prevTime++;
-                        flushMessage(conn, sessionId, "assistant",
-                            pendingAgent, pendingModel, pendingParts, prevTime,
-                            projectDir, lastUserMessageId);
+                        flushMessage(conn, sessionId,
+                            new MessageInsert("assistant", pendingAgent, pendingModel,
+                                pendingParts, prevTime, projectDir, lastUserMessageId));
                         pendingParts = null;
                         pendingAgent = null;
                         pendingModel = null;
@@ -187,8 +187,9 @@ public final class OpenCodeClientExporter {
                     userPart.addProperty("type", "text");
                     userPart.addProperty("text", prompt.getText());
 
-                    lastUserMessageId = flushMessage(conn, sessionId, "user",
-                        "", "", List.of(userPart), prevTime, projectDir, null);
+                    lastUserMessageId = flushMessage(conn, sessionId,
+                        new MessageInsert("user", "", "", List.of(userPart),
+                            prevTime, projectDir, null));
                     messageCount++;
                 }
                 case EntryData.Text text -> {
@@ -244,9 +245,9 @@ public final class OpenCodeClientExporter {
         // Flush trailing assistant message
         if (pendingParts != null && !pendingParts.isEmpty()) {
             prevTime++;
-            flushMessage(conn, sessionId, "assistant",
-                pendingAgent, pendingModel, pendingParts, prevTime,
-                projectDir, lastUserMessageId);
+            flushMessage(conn, sessionId,
+                new MessageInsert("assistant", pendingAgent, pendingModel,
+                    pendingParts, prevTime, projectDir, lastUserMessageId));
             messageCount++;
         }
 
@@ -435,6 +436,20 @@ public final class OpenCodeClientExporter {
     // ── Message insertion ─────────────────────────────────────────────────────
 
     /**
+     * Parameters for a single {@link #flushMessage} insertion. Bundled into a
+     * record to keep the method signature within the 7-parameter limit (Sonar S107).
+     */
+    private record MessageInsert(
+        @NotNull String role,
+        @Nullable String agent,
+        @Nullable String model,
+        @NotNull List<JsonObject> parts,
+        long timeCreated,
+        @NotNull String projectDir,
+        @Nullable String parentMessageId
+    ) {}
+
+    /**
      * Inserts a message and its pre-built parts into the database.
      *
      * @return the generated message ID (for parentID linking)
@@ -443,31 +458,26 @@ public final class OpenCodeClientExporter {
     private static String flushMessage(
         @NotNull Connection conn,
         @NotNull String sessionId,
-        @NotNull String role,
-        @Nullable String agent,
-        @Nullable String model,
-        @NotNull List<JsonObject> parts,
-        long timeCreated,
-        @NotNull String projectDir,
-        @Nullable String parentMessageId) throws SQLException {
+        @NotNull MessageInsert msg) throws SQLException {
 
         String messageId = generateId("msg");
 
-        JsonObject msgData = buildMessageData(role, agent, model, timeCreated, projectDir, parentMessageId);
+        JsonObject msgData = buildMessageData(msg.role(), msg.agent(), msg.model(),
+            msg.timeCreated(), msg.projectDir(), msg.parentMessageId());
 
         try (PreparedStatement ps = conn.prepareStatement(
             "INSERT INTO message (id, session_id, time_created, time_updated, data) "
                 + "VALUES (?, ?, ?, ?, ?)")) {
             ps.setString(1, messageId);
             ps.setString(2, sessionId);
-            ps.setLong(3, timeCreated);
-            ps.setLong(4, timeCreated);
+            ps.setLong(3, msg.timeCreated());
+            ps.setLong(4, msg.timeCreated());
             ps.setString(5, GSON.toJson(msgData));
             ps.executeUpdate();
         }
 
-        for (JsonObject part : parts) {
-            insertPart(conn, messageId, sessionId, part, timeCreated);
+        for (JsonObject part : msg.parts()) {
+            insertPart(conn, messageId, sessionId, part, msg.timeCreated());
         }
 
         return messageId;

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/ReviewItemDerivationTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/ReviewItemDerivationTest.java
@@ -44,10 +44,12 @@ class ReviewItemDerivationTest {
             snapshots,
             newFiles,
             deletedFiles,
-            new HashMap<>(),
-            new HashMap<>(),
-            new HashMap<>(linesAdded),
-            new HashMap<>(linesRemoved),
+            new AgentEditSession.EditMetrics(
+                new HashMap<>(),
+                new HashMap<>(),
+                new HashMap<>(linesAdded),
+                new HashMap<>(linesRemoved)
+            ),
             BASE
         );
     }


### PR DESCRIPTION
Reduce parameter counts on three internal helpers by bundling related arguments into records.

- `SearchTextTool#searchFileForPattern`: pass the existing `SearchParams` record instead of unpacking 6 fields.
- `AgentEditSession#buildReviewItems` / `#buildItem`: introduce inner `EditMetrics` record (approvals, lastEditedAt, linesAdded, linesRemoved) to drop both signatures from 8 to 5 params.
- `OpenCodeClientExporter#flushMessage`: introduce inner `MessageInsert` record to drop the signature from 9 to 3 params.

Test `ReviewItemDerivationTest` updated to use the new `EditMetrics` record.

No behavior change.