### PR TITLE
fix(sonar): S112 — replace generic exceptions (partial, 5 of 12)

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpFileSystemHandler.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpFileSystemHandler.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -53,7 +54,7 @@ final class AcpFileSystemHandler {
                 try {
                     holder[0] = new String(vf.contentsToByteArray(), StandardCharsets.UTF_8);
                 } catch (IOException e) {
-                    throw new RuntimeException("Failed to read file: " + absolutePath, e);
+                    throw new UncheckedIOException("Failed to read file: " + absolutePath, e);
                 }
             }
         });
@@ -120,7 +121,7 @@ final class AcpFileSystemHandler {
                     try {
                         vf.setBinaryContent(content.getBytes(StandardCharsets.UTF_8));
                     } catch (IOException e) {
-                        throw new RuntimeException("Failed to write file: " + absolutePath, e);
+                        throw new UncheckedIOException("Failed to write file: " + absolutePath, e);
                     }
                 });
             }
@@ -138,7 +139,7 @@ final class AcpFileSystemHandler {
             LocalFileSystem.getInstance().refreshAndFindFileByPath(absolutePath);
             LOG.info("Created new file: " + absolutePath);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to create file: " + absolutePath, e);
+            throw new UncheckedIOException("Failed to create file: " + absolutePath, e);
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/debug/navigation/DebugStepTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/debug/navigation/DebugStepTool.java
@@ -80,7 +80,7 @@ public final class DebugStepTool extends DebugTool {
             case "into" -> session.stepInto();
             case "out" -> session.stepOut();
             case "continue" -> session.resume();
-            default -> throw new Exception("Unknown action '" + action + "'. Use: over, into, out, continue");
+            default -> throw new IllegalArgumentException("Unknown action '" + action + "'. Use: over, into, out, continue");
         }
 
         boolean completed = latch.await(30, TimeUnit.SECONDS);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/HttpRequestTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/HttpRequestTool.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -391,7 +392,7 @@ public final class HttpRequestTool extends InfrastructureTool {
     }
 
     private @NotNull String handleSaveTo(@NotNull String saveTo, byte[] responseBytes,
-                                         int statusCode, long elapsedMs) throws Exception {
+                                         int statusCode, long elapsedMs) throws IOException {
         String basePath = project.getBasePath();
         if (basePath == null) return "Error: No project base path";
 


### PR DESCRIPTION
Address 5 of 12 S112 findings with mechanical narrowing:

- `AcpFileSystemHandler` × 3: `throw new RuntimeException` wrapping `IOException` → `UncheckedIOException` (the proper standard-library type for forwarding `IOException` out of lambdas passed to `runReadAction` / `runWriteAction`).
- `HttpRequestTool#handleSaveTo`: `throws Exception` → `throws IOException` (only `Files.createDirectories` / `Files.write` are thrown).
- `DebugStepTool`: `throw new Exception` for an unknown action argument → `IllegalArgumentException`.

The remaining 7 S112 sites (AbstractAgentClient × 3, Embedder/EmbeddingService × 2, PopupRespondTool × 1, ExecuteQueryTool × 1) all sit on abstract method signatures whose narrowing requires a custom checked exception type or a wider inference-pipeline refactor — deferred to follow-up PRs to keep this one purely mechanical.