### PR TITLE
fix(sonar): S6885 — use Math.clamp

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
@@ -820,7 +820,7 @@ public abstract class AcpClient extends AbstractAgentClient {
                     "Agent inactive for " + silenceSec + "s (no session/update received)"
                 );
             }
-            long waitMillis = Math.max(1L, Math.min(pollMs, TimeUnit.NANOSECONDS.toMillis(remainingNanos)));
+            long waitMillis = Math.clamp(TimeUnit.NANOSECONDS.toMillis(remainingNanos), 1L, pollMs);
             try {
                 return future.get(waitMillis, TimeUnit.MILLISECONDS);
             } catch (java.util.concurrent.TimeoutException e) {

--- a/plugin-experimental/src/main/java/com/github/catatafishen/agentbridge/experimental/psi/tools/database/ExecuteQueryTool.java
+++ b/plugin-experimental/src/main/java/com/github/catatafishen/agentbridge/experimental/psi/tools/database/ExecuteQueryTool.java
@@ -153,7 +153,7 @@ public final class ExecuteQueryTool extends DatabaseTool {
             for (int i = 0; i < colCount; i++) {
                 String val = rs.getString(i + 1);
                 row[i] = val != null ? val : "NULL";
-                colWidths[i] = Math.max(colWidths[i], Math.min(row[i].length(), 50));
+                colWidths[i] = Math.clamp(row[i].length(), colWidths[i], 50);
             }
             rows.add(row);
         }


### PR DESCRIPTION
Replace nested Math.min/max with Math.clamp.

- `AcpClient.waitForPromptResult`: `Math.max(1L, Math.min(pollMs, remainingMs))` → `Math.clamp(remainingMs, 1L, pollMs)`. Safe because pollMs is a constant 5000.
- `ExecuteQueryTool.formatResultSet`: `Math.max(colWidths[i], Math.min(rowLen, 50))` → `Math.clamp(rowLen, colWidths[i], 50)`. Safe because the invariant `colWidths[i] ≤ 50` always holds (starts at 0 and only grows by `min(rowLen, 50)`).