### PR TITLE
fix(sonar): TS micro-cleanup — S7761 + S7781

### DIFF
--- a/plugin-core/chat-ui/src/BatchRenderer.ts
+++ b/plugin-core/chat-ui/src/BatchRenderer.ts
@@ -150,7 +150,7 @@ function _renderUserTurn(turn: UserTurn): HTMLElement {
 function _renderAgentSegment(agent: string, segment: AgentSegment): HTMLElement {
     const msg = document.createElement('chat-message');
     msg.setAttribute('type', 'agent');
-    if (agent) msg.setAttribute('data-agent', agent);
+    if (agent) msg.dataset.agent = agent;
 
     const meta = document.createElement('message-meta');
     if (segment.timestamp) {
@@ -226,7 +226,7 @@ function _appendThinking(entry: ThinkingEntry, meta: HTMLElement, details: HTMLE
     const chip = document.createElement('thinking-chip');
     chip.setAttribute('label', 'Thought');
     chip.setAttribute('status', 'complete');
-    chip.setAttribute('data-chip-for', entry.id);
+    chip.dataset.chipFor = entry.id;
     meta.appendChild(chip);
 
     const block = document.createElement('thinking-block');
@@ -244,9 +244,9 @@ function _appendToolChip(entry: ToolEntry, meta: HTMLElement): void {
     chip.setAttribute('label', entry.label);
     chip.setAttribute('status', entry.status);
     chip.setAttribute('kind', entry.kind);
-    chip.setAttribute('data-chip-for', entry.id);
-    if (entry.params) chip.setAttribute('data-params', entry.params);
-    if (entry.pluginTool) chip.setAttribute('data-mcp-handled', 'true');
+    chip.dataset.chipFor = entry.id;
+    if (entry.params) chip.dataset.params = entry.params;
+    if (entry.pluginTool) chip.dataset.mcpHandled = 'true';
     meta.appendChild(chip);
 }
 
@@ -261,7 +261,7 @@ function _appendSubAgent(entry: SubAgentEntry, meta: HTMLElement, msg: HTMLEleme
     chip.setAttribute('label', entry.label);
     chip.setAttribute('status', entry.status);
     chip.setAttribute('color-index', String(entry.colorIndex));
-    chip.setAttribute('data-chip-for', entry.id);
+    chip.dataset.chipFor = entry.id;
     meta.appendChild(chip);
 
     const indent = document.createElement('div');

--- a/plugin-core/chat-ui/src/renderMarkdown.ts
+++ b/plugin-core/chat-ui/src/renderMarkdown.ts
@@ -65,8 +65,8 @@ function buildThinkingBlockHtml(content: string): string {
 
 function preprocessXmlTags(text: string): string {
     return text
-        .replace(THINK_TAG_PATTERN, (_match, _tag, content) => buildThinkingBlockHtml(content))
-        .replace(WRAPPER_TAG_LINE_PATTERN, '');
+        .replaceAll(THINK_TAG_PATTERN, (_match, _tag, content) => buildThinkingBlockHtml(content))
+        .replaceAll(WRAPPER_TAG_LINE_PATTERN, '');
 }
 
 function preprocessXmlTagsOutsideCodeFences(text: string): string {


### PR DESCRIPTION
Two trivial Sonar TypeScript fixes:

**S7761** — Prefer `.dataset` over `setAttribute('data-*', ...)` (BatchRenderer.ts, 6 sites). Non-data attributes (type/label/status/kind/color-index) are unchanged because `.dataset` only covers `data-*`.

**S7781** — Prefer `String#replaceAll()` over `String#replace()` (renderMarkdown.ts, 2 sites). Both regex patterns already have the /g flag, so this is purely a style change with identical runtime behaviour.

Total: 6 + 2 = 8 Sonar findings closed.