### PR TITLE
fix(sonar): S2589 — remove redundant null checks on @NotNull Kotlin getters

### DIFF
--- a/.idea/runConfigurations/JS_Tests.xml
+++ b/.idea/runConfigurations/JS_Tests.xml
@@ -4,7 +4,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" />
+      <option name="scriptParameters" value="" />
       <option name="taskDescriptions">
         <list />
       </option>

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
@@ -804,11 +804,7 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
     private @Nullable String readCurrentContent(@NotNull String path) {
         VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(path);
         if (vf == null) return null;
-        // getDocument() requires a read action, not just getText().
-        String text = ReadAction.compute(() -> {
-            Document doc = FileDocumentManager.getInstance().getDocument(vf);
-            return doc != null ? doc.getText() : null;
-        });
+        String text = readDocumentText(vf);
         if (text != null) return text;
         try {
             return new String(vf.contentsToByteArray(), StandardCharsets.UTF_8);
@@ -816,6 +812,20 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
             LOG.warn("Failed to read current content for review line counts: " + path, e);
             return null;
         }
+    }
+
+    /**
+     * Reads the document text under a read action, returning {@code null} when the
+     * platform has no live document for the file (e.g. binary, deleted, or not opened).
+     * Extracted so the {@code @Nullable} contract is visible to static analysis — without
+     * it, Sonar incorrectly assumes {@link ReadAction#compute} returns non-null.
+     */
+    private static @Nullable String readDocumentText(@NotNull VirtualFile vf) {
+        // getDocument() requires a read action, not just getText().
+        return ReadAction.compute(() -> {
+            Document doc = FileDocumentManager.getInstance().getDocument(vf);
+            return doc != null ? doc.getText() : null;
+        });
     }
 
     static int countLines(@Nullable String content) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/AnthropicClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/AnthropicClientExporter.java
@@ -179,7 +179,7 @@ public final class AnthropicClientExporter {
                 flushPending();
                 currentTimestamp = parseTimestamp(text.getTimestamp());
                 String entryModel = text.getModel();
-                currentModel = (entryModel != null && !entryModel.isEmpty()) ? entryModel : "";
+                currentModel = !entryModel.isEmpty() ? entryModel : "";
             }
             assistantBlocks.add(textBlock(content));
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/OpenCodeClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/OpenCodeClientExporter.java
@@ -257,7 +257,7 @@ public final class OpenCodeClientExporter {
         StringBuilder sb = new StringBuilder("[Subagent");
         sb.append(" (").append(subAgent.getAgentType()).append(")");
         String desc = subAgent.getDescription();
-        if (desc != null && !desc.isEmpty()) sb.append(": ").append(desc);
+        if (!desc.isEmpty()) sb.append(": ").append(desc);
         sb.append("]");
         String subResult = subAgent.getResult();
         if (subResult != null && !subResult.isBlank()) {


### PR DESCRIPTION
Two genuine dead branches in the exporters: `text.getModel()` and `subAgent.getDescription()` come from Kotlin classes with non-null `String` types, so the `!= null` guards were never false.

For `AgentEditSession.readCurrentContent`, Sonar incorrectly assumed `ReadAction.compute(lambda)` is non-null. Extracted the read-action into a private `@Nullable` helper so the contract is visible to static analysis without changing behavior.

Closes 3 S2589 findings.