### PR TITLE
fix(sonar): S7785 — ignore top-level-await for IIFE-bundled web-app.ts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,7 +104,12 @@ sonar {
         ).mapIndexed { i, path -> IgnoredIssue("s3776_$i", "java:S3776", path) } + listOf(
             IgnoredIssue("ts_s3776_render", "typescript:S3776", "**/chat-ui/src/renderMarkdown.ts"),
             IgnoredIssue("ts_s3776_batch", "typescript:S3776", "**/chat-ui/src/BatchRenderer.ts"),
-            IgnoredIssue("ts_s2004_app", "typescript:S2004", "**/chat-ui/src/web-app.ts")
+            IgnoredIssue("ts_s2004_app", "typescript:S2004", "**/chat-ui/src/web-app.ts"),
+            // typescript:S7785 — top-level await is unsupported in IIFE bundles, and
+            // web-app.ts is intentionally bundled as IIFE (see chat-ui/build.js) so it
+            // can be loaded via a plain <script> tag without a module loader. The
+            // existing .then()/.catch() chains are the only option in that format.
+            IgnoredIssue("ts_s7785_app", "typescript:S7785", "**/chat-ui/src/web-app.ts")
         ) + listOf(
             // java:S3077 (volatile non-primitive). All these fields hold either an immutable
             // value (String, Path) or a snapshot reference that is only ever wholesale


### PR DESCRIPTION
Three S7785 `Prefer top-level await` findings on `chat-ui/src/web-app.ts` cannot be applied: the file is bundled as an IIFE (esbuild config in `chat-ui/build.js`) so it can be loaded via a plain `<script>` tag without a module loader. esbuild rejects top-level await in IIFE output.

Adds a project-wide ignore for `typescript:S7785` on this single file, following the existing `ts_s2004_app` pattern.

Closes 3 S7785 findings.