### PR TITLE
fix(sonar): document intentional PCE instanceof; drop redundant eq() in test

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -465,7 +465,10 @@ public final class PsiBridgeService implements Disposable {
             ToolChipRegistry.getInstance(project).storeMcpResult(req.toolName(), req.arguments(), result);
             return result;
         } catch (com.intellij.openapi.progress.ProcessCanceledException e) {
-            if (e instanceof com.intellij.openapi.application.ex.ApplicationUtil.CannotRunReadActionException) {
+            // The instanceof + early-return pattern is intentional: splitting into a separate
+            // catch for CannotRunReadActionException would trigger IntelliJ's "PCE inheritor
+            // must be rethrown" inspection (CannotRunReadActionException extends PCE).
+            if (e instanceof com.intellij.openapi.application.ex.ApplicationUtil.CannotRunReadActionException) { // NOSONAR java:S1193
                 // IDE was temporarily busy — not a shutdown signal; return a retryable error.
                 success = false;
                 errorMessage = "Error: IDE is busy, please retry. " + e.getMessage();

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/layers/EssentialStoryLayerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/layers/EssentialStoryLayerTest.java
@@ -153,7 +153,7 @@ class EssentialStoryLayerTest {
     @Test
     void customMaxDrawersLimitIsPassedToStore() throws IOException {
         int customLimit = 5;
-        when(store.getTopDrawersDiverse(eq(WING), eq(customLimit))).thenReturn(Collections.emptyList());
+        when(store.getTopDrawersDiverse(WING, customLimit)).thenReturn(Collections.emptyList());
 
         EssentialStoryLayer layer = new EssentialStoryLayer(store, customLimit);
         layer.render(WING, null);


### PR DESCRIPTION
Two small Sonar fixes.

### PsiBridgeService
`PsiBridgeService` catches `ProcessCanceledException` and uses `instanceof CannotRunReadActionException` to short-circuit recovery. Sonar S1193 wants this split into separate catch blocks, but doing so triggers IntelliJ's `CancellationExceptionHandledIncorrectly` inspection (`CannotRunReadActionException` extends `ProcessCanceledException`, and the inspection requires PCE inheritors to be rethrown). The single-catch + instanceof pattern is the canonical IntelliJ workaround.

Added `// NOSONAR java:S1193` and a comment explaining why.

### EssentialStoryLayerTest
Drop redundant Mockito `eq()` wrappers on literal arguments (S6068).

Both changes are minimal. Tests pass.