### PR TITLE
fix(sonar): batch 4 — nested ternaries, switch labels, NPE false positive

### DIFF
--- a/plugin-core/chat-ui/src/BatchRenderer.ts
+++ b/plugin-core/chat-ui/src/BatchRenderer.ts
@@ -304,8 +304,11 @@ function _buildStatBar(stats: StatsTurn): HTMLElement {
             dur = s > 0 ? m + 'm ' + s + 's' : m + 'm';
         }
     }
-    const fmt = (n: number): string =>
-        n < 1000 ? String(n) : n < 10000 ? (n / 1000).toFixed(1) + 'k' : Math.round(n / 1000) + 'k';
+    const fmt = (n: number): string => {
+        if (n < 1000) return String(n);
+        if (n < 10000) return (n / 1000).toFixed(1) + 'k';
+        return Math.round(n / 1000) + 'k';
+    };
 
     const parts: Array<string | HTMLElement> = [];
 

--- a/plugin-core/chat-ui/src/components/ChatContainer.ts
+++ b/plugin-core/chat-ui/src/components/ChatContainer.ts
@@ -412,7 +412,8 @@ export default class ChatContainer extends HTMLElement {
      * via _scrollToInstant() regardless of this CSS property.
      */
     setStreaming(active: boolean, smoothScrollEnabled: boolean): void {
-        this.style.scrollBehavior = active ? 'auto' : (smoothScrollEnabled ? 'smooth' : 'auto');
+        const restored = smoothScrollEnabled ? 'smooth' : 'auto';
+        this.style.scrollBehavior = active ? 'auto' : restored;
     }
 
     disconnectedCallback(): void {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
@@ -417,7 +417,8 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
         @NotNull Map<String, Long> lastEditedAt,
         @NotNull Map<String, Integer> linesAdded,
         @NotNull Map<String, Integer> linesRemoved
-    ) {}
+    ) {
+    }
 
     static @NotNull List<ReviewItem> buildReviewItems(
         @NotNull Map<String, String> snapshots,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
@@ -1600,29 +1600,15 @@ public final class ChatWebServer implements Disposable {
         if (profileId == null) {
             name = "agentbridge";
         } else {
-            switch (profileId) {
-                case "anthropic", "claude-cli":
-                    name = "claude";
-                    break;
-                case "copilot":
-                    name = "copilot";
-                    break;
-                case "opencode":
-                    name = "opencode";
-                    break;
-                case "junie":
-                    name = "junie";
-                    break;
-                case "kiro":
-                    name = "kiro";
-                    break;
-                case "codex":
-                    name = "codex";
-                    break;
-                default:
-                    name = "agentbridge";
-                    break;
-            }
+            name = switch (profileId) {
+                case "anthropic", "claude-cli" -> "claude";
+                case "copilot" -> "copilot";
+                case "opencode" -> "opencode";
+                case "junie" -> "junie";
+                case "kiro" -> "kiro";
+                case "codex" -> "codex";
+                default -> "agentbridge";
+            };
         }
         String suffix = isDark ? "_dark" : "";
         String path = "/icons/expui/" + name + suffix + ".svg";


### PR DESCRIPTION
Mechanical Sonar fixes (5 issues):

**S3358** — extract 4 nested ternaries:
- `NewSessionResponseDeserializer.parseConfigOption` (values/options lookup)
- `AbstractClaudeAgentClient.emitToolCallStart` (agent_type/subagent_type)
- `ChatContainer.setStreaming` (scroll-behavior)
- `BatchRenderer.fmt` (count→k formatting)

**S6208** — `ChatWebServer.getAgentIconSvg` switch converted to arrow form with comma-separated case labels for `anthropic`,`claude-cli`.

**S2589** — `AgentEditSession.readCurrentContent` flagged null check is a false positive. The method `readDocumentText` IS `@Nullable` but Sonar can't see through `ReadAction.compute` lambda. Added `// NOSONAR` with explanatory comment.

Build + tests pass.