### PR TITLE
test(sonar): S5976 — parameterize tests across 22 files

### DIFF
--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/KiroToolPurposeTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/KiroToolPurposeTest.java
@@ -3,6 +3,8 @@ package com.github.catatafishen.agentbridge.acp.client;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -129,10 +131,14 @@ class KiroToolPurposeTest {
             assertEquals("Check: is the test passing?", KiroClient.extractPurposeFromArgs(args));
         }
 
-        @Test
-        @DisplayName("different key name containing substring → null")
-        void differentKeyWithSubstring() {
-            String args = "{\"x__tool_use_purpose\": \"should not match\"}";
+        @ParameterizedTest(name = "malformed or mismatched key: {0}")
+        @ValueSource(strings = {
+            "{\"x__tool_use_purpose\": \"should not match\"}",
+            "{\"description\": \"the __tool_use_purpose field\"}",
+            "{\"__tool_use_purpose\"",
+            "{\"__tool_use_purpose\": }"
+        })
+        void malformedOrMismatchedKeyReturnsNull(String args) {
             assertNull(KiroClient.extractPurposeFromArgs(args));
         }
 
@@ -141,27 +147,6 @@ class KiroToolPurposeTest {
         void nestedPurpose() {
             String args = "{\"inner\": {\"__tool_use_purpose\": \"Nested\"}}";
             assertEquals("Nested", KiroClient.extractPurposeFromArgs(args));
-        }
-
-        @Test
-        @DisplayName("purpose appears in a string value but not as a key → null")
-        void purposeInStringValue() {
-            String args = "{\"description\": \"the __tool_use_purpose field\"}";
-            assertNull(KiroClient.extractPurposeFromArgs(args));
-        }
-
-        @Test
-        @DisplayName("purpose key with no colon after it → null")
-        void noColonAfterKey() {
-            String args = "{\"__tool_use_purpose\"";
-            assertNull(KiroClient.extractPurposeFromArgs(args));
-        }
-
-        @Test
-        @DisplayName("purpose key with colon but no value quotes → null")
-        void colonButNoQuotes() {
-            String args = "{\"__tool_use_purpose\": }";
-            assertNull(KiroClient.extractPurposeFromArgs(args));
         }
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpServerConfigTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpServerConfigTest.java
@@ -1,6 +1,8 @@
 package com.github.catatafishen.agentbridge.custommcp;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -9,25 +11,16 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class CustomMcpServerConfigTest {
 
-    @Test
-    void toolPrefix_simpleAsciiName_addsCmcpPrefix() {
+    @ParameterizedTest(name = "toolPrefix(\"{0}\") = \"{1}\"")
+    @CsvSource({
+        "database, cmcp_database",
+        "My Custom Server, cmcp_my_custom_server",
+        "'---db & tools---', cmcp_db_tools"
+    })
+    void toolPrefix_normalizesName(String name, String expected) {
         CustomMcpServerConfig config = new CustomMcpServerConfig();
-        config.setName("database");
-        assertEquals("cmcp_database", config.toolPrefix());
-    }
-
-    @Test
-    void toolPrefix_mixedCaseWithSpaces_normalisedToLowerUnderscore() {
-        CustomMcpServerConfig config = new CustomMcpServerConfig();
-        config.setName("My Custom Server");
-        assertEquals("cmcp_my_custom_server", config.toolPrefix());
-    }
-
-    @Test
-    void toolPrefix_specialCharsCollapsed() {
-        CustomMcpServerConfig config = new CustomMcpServerConfig();
-        config.setName("---db & tools---");
-        assertEquals("cmcp_db_tools", config.toolPrefix());
+        config.setName(name);
+        assertEquals(expected, config.toolPrefix());
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractorTest.java
@@ -1,6 +1,8 @@
 package com.github.catatafishen.agentbridge.memory.kg;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 
@@ -456,40 +458,18 @@ class TripleExtractorTest {
 
     // ── Negation guard tests ──────────────────────────────────────────────
 
-    @Test
-    void negation_neverUse_skipsTriple() {
-        String text = "Never use eval() in production code.";
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "Never use eval() in production code.",
+        "Don't use global variables for configuration.",
+        "The module should not depend on external services.",
+        "Avoid using deprecated APIs in the codebase."
+    })
+    void negation_skipsTriple(String text) {
         List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
 
         assertTrue(triples.isEmpty(),
-            "Negated usage should not produce a triple: " + triples);
-    }
-
-    @Test
-    void negation_dontUse_skipsTriple() {
-        String text = "Don't use global variables for configuration.";
-        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
-
-        assertTrue(triples.isEmpty(),
-            "Negated usage should not produce a triple: " + triples);
-    }
-
-    @Test
-    void negation_shouldNotDepend_skipsTriple() {
-        String text = "The module should not depend on external services.";
-        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
-
-        assertTrue(triples.isEmpty(),
-            "Negated dependency should not produce a triple: " + triples);
-    }
-
-    @Test
-    void negation_avoid_skipsTriple() {
-        String text = "Avoid using deprecated APIs in the codebase.";
-        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
-
-        assertTrue(triples.isEmpty(),
-            "Avoidance should not produce a 'uses' triple: " + triples);
+            "Negated/avoidance sentence should not produce a triple: " + triples);
     }
 
     // ── Object trimming tests ─────────────────────────────────────────────

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/layers/MemoryLayersTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/layers/MemoryLayersTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -184,19 +186,12 @@ class MemoryLayersTest {
         assertEquals("Deep Search", layer.displayName());
     }
 
-    @Test
-    void deepSearchNullQueryReturnsEmpty() {
+    @ParameterizedTest
+    @NullAndEmptySource
+    void deepSearchNullOrEmptyQueryReturnsEmpty(String query) {
         Embedder fake = text -> uniqueVector();
         DeepSearchLayer layer = new DeepSearchLayer(store, fake);
-        String result = layer.render(WING, null);
-        assertEquals("", result);
-    }
-
-    @Test
-    void deepSearchEmptyQueryReturnsEmpty() {
-        Embedder fake = text -> uniqueVector();
-        DeepSearchLayer layer = new DeepSearchLayer(store, fake);
-        String result = layer.render(WING, "");
+        String result = layer.render(WING, query);
         assertEquals("", result);
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/RunConfigurationServiceStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/RunConfigurationServiceStaticMethodsTest.java
@@ -6,9 +6,13 @@ import com.google.gson.JsonPrimitive;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -99,22 +103,23 @@ class RunConfigurationServiceStaticMethodsTest {
             assertNull(call(args, "application"));
         }
 
-        @Test
-        void gitCommandBlocked() throws Exception {
-            JsonObject args = new JsonObject();
-            args.addProperty("program_args", "git push origin main");
-            String result = call(args, "application");
-            assertNotNull(result);
-            assertTrue(result.startsWith("Error:"));
+        static Stream<Arguments> blockedCommands() {
+            return Stream.of(
+                Arguments.of("git push origin main", "application", "Error:"),
+                Arguments.of("test --info", "gradle", "run_tests"),
+                Arguments.of("sed -i 's/foo/bar/g' file.txt", "application", "edit_text")
+            );
         }
 
-        @Test
-        void gradleTestTaskBlocked() throws Exception {
+        @ParameterizedTest
+        @MethodSource("blockedCommands")
+        void blockedCommandDetected(String programArgs, String configType, String expectedSubstring) throws Exception {
             JsonObject args = new JsonObject();
-            args.addProperty("program_args", "test --info");
-            String result = call(args, "gradle");
+            args.addProperty("program_args", programArgs);
+            String result = call(args, configType);
             assertNotNull(result);
-            assertTrue(result.contains("run_tests"));
+            assertTrue(result.contains(expectedSubstring),
+                "Expected result to contain '" + expectedSubstring + "' but was: " + result);
         }
 
         @Test
@@ -123,15 +128,6 @@ class RunConfigurationServiceStaticMethodsTest {
             args.addProperty("program_args", "test --info");
             // "test" alone doesn't match general abuse patterns, only gradle-specific check
             assertNull(call(args, "application"));
-        }
-
-        @Test
-        void sedCommandBlocked() throws Exception {
-            JsonObject args = new JsonObject();
-            args.addProperty("program_args", "sed -i 's/foo/bar/g' file.txt");
-            String result = call(args, "application");
-            assertNotNull(result);
-            assertTrue(result.contains("edit_text"));
         }
 
         @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/PathCanonicalizationTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/PathCanonicalizationTest.java
@@ -1,6 +1,8 @@
 package com.github.catatafishen.agentbridge.psi.review;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,22 +28,14 @@ class PathCanonicalizationTest {
         return AgentEditSession.toAbsolutePath(path, basePath);
     }
 
-    @Test
-    void absolutePath_returnedAsIs() {
-        String abs = "/home/user/project/src/Foo.java";
-        assertEquals(abs, resolve(abs, BASE));
-    }
-
-    @Test
-    void relativePath_resolvedAgainstBase() {
-        assertEquals("/home/user/project/src/Foo.java",
-            resolve("src/Foo.java", BASE));
-    }
-
-    @Test
-    void nestedRelativePath_resolvedCorrectly() {
-        assertEquals("/home/user/project/plugin-core/src/main/java/Foo.kt",
-            resolve("plugin-core/src/main/java/Foo.kt", BASE));
+    @ParameterizedTest
+    @CsvSource({
+        "/home/user/project/src/Foo.java, /home/user/project/src/Foo.java",
+        "src/Foo.java, /home/user/project/src/Foo.java",
+        "plugin-core/src/main/java/Foo.kt, /home/user/project/plugin-core/src/main/java/Foo.kt"
+    })
+    void pathResolution(String inputPath, String expectedOutput) {
+        assertEquals(expectedOutput, resolve(inputPath, BASE));
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/HttpRequestToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/HttpRequestToolStaticMethodsTest.java
@@ -3,6 +3,10 @@ package com.github.catatafishen.agentbridge.psi.tools.infrastructure;
 import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -10,6 +14,7 @@ import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -160,62 +165,36 @@ class HttpRequestToolStaticMethodsTest {
     @Nested
     class ApplyAuthTest {
 
-        @Test
-        void bearerToken_setsAuthorizationHeader() throws Exception {
+        @ParameterizedTest
+        @CsvSource({
+            "bearer my-token-123, Bearer my-token-123",
+            "BEARER MY-TOKEN, Bearer MY-TOKEN",
+            "'  bearer   spaced-token  ', Bearer spaced-token"
+        })
+        void bearerToken_setsAuthorizationHeader(String authInput, String expectedHeader) throws Exception {
             JsonObject args = new JsonObject();
-            args.addProperty("auth", "bearer my-token-123");
+            args.addProperty("auth", authInput);
             HttpRequest request = buildRequestWithAuth(args);
-            assertEquals("Bearer my-token-123",
+            assertEquals(expectedHeader,
                 request.headers().firstValue("Authorization").orElse(null));
         }
 
-        @Test
-        void bearerToken_caseInsensitive() throws Exception {
-            JsonObject args = new JsonObject();
-            args.addProperty("auth", "BEARER MY-TOKEN");
-            HttpRequest request = buildRequestWithAuth(args);
-            assertEquals("Bearer MY-TOKEN",
-                request.headers().firstValue("Authorization").orElse(null));
+        static Stream<Arguments> basicAuthCases() {
+            return Stream.of(
+                Arguments.of("basic user:pass", "user:pass"),
+                Arguments.of("BASIC admin:secret", "admin:secret"),
+                Arguments.of("basic user:p@ss:word!", "user:p@ss:word!")
+            );
         }
 
-        @Test
-        void bearerToken_trimsWhitespace() throws Exception {
+        @ParameterizedTest
+        @MethodSource("basicAuthCases")
+        void basicAuth_setsBase64AuthorizationHeader(String authInput, String credentials) throws Exception {
             JsonObject args = new JsonObject();
-            args.addProperty("auth", "  bearer   spaced-token  ");
-            HttpRequest request = buildRequestWithAuth(args);
-            assertEquals("Bearer spaced-token",
-                request.headers().firstValue("Authorization").orElse(null));
-        }
-
-        @Test
-        void basicAuth_base64EncodesCredentials() throws Exception {
-            JsonObject args = new JsonObject();
-            args.addProperty("auth", "basic user:pass");
+            args.addProperty("auth", authInput);
             HttpRequest request = buildRequestWithAuth(args);
             String expected = "Basic " + Base64.getEncoder()
-                .encodeToString("user:pass".getBytes(StandardCharsets.UTF_8));
-            assertEquals(expected,
-                request.headers().firstValue("Authorization").orElse(null));
-        }
-
-        @Test
-        void basicAuth_caseInsensitive() throws Exception {
-            JsonObject args = new JsonObject();
-            args.addProperty("auth", "BASIC admin:secret");
-            HttpRequest request = buildRequestWithAuth(args);
-            String expected = "Basic " + Base64.getEncoder()
-                .encodeToString("admin:secret".getBytes(StandardCharsets.UTF_8));
-            assertEquals(expected,
-                request.headers().firstValue("Authorization").orElse(null));
-        }
-
-        @Test
-        void basicAuth_handlesColonInPassword() throws Exception {
-            JsonObject args = new JsonObject();
-            args.addProperty("auth", "basic user:p@ss:word!");
-            HttpRequest request = buildRequestWithAuth(args);
-            String expected = "Basic " + Base64.getEncoder()
-                .encodeToString("user:p@ss:word!".getBytes(StandardCharsets.UTF_8));
+                .encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
             assertEquals(expected,
                 request.headers().firstValue("Authorization").orElse(null));
         }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/DialogInterceptorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/DialogInterceptorTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.swing.*;
 import java.util.ArrayList;
@@ -233,60 +235,19 @@ class DialogInterceptorTest {
             assertTrue(clicked.get());
         }
 
-        @Test
-        @DisplayName("recognizes 'Refactor' as confirm button")
-        void refactorButton() {
+        @ParameterizedTest
+        @ValueSource(strings = {"Refactor", "Apply", "Run", "Yes"})
+        @DisplayName("recognizes confirm button labels")
+        void confirmButtonRecognized(String label) {
             JPanel panel = new JPanel();
-            JButton btn = new JButton("Refactor");
+            JButton btn = new JButton(label);
             AtomicBoolean clicked = new AtomicBoolean(false);
             btn.addActionListener(e -> clicked.set(true));
             panel.add(btn);
 
             DialogInterceptor.clickConfirmButton(panel);
 
-            assertTrue(clicked.get());
-        }
-
-        @Test
-        @DisplayName("recognizes 'Apply' as confirm button")
-        void applyButton() {
-            JPanel panel = new JPanel();
-            JButton btn = new JButton("Apply");
-            AtomicBoolean clicked = new AtomicBoolean(false);
-            btn.addActionListener(e -> clicked.set(true));
-            panel.add(btn);
-
-            DialogInterceptor.clickConfirmButton(panel);
-
-            assertTrue(clicked.get());
-        }
-
-        @Test
-        @DisplayName("recognizes 'Run' as confirm button")
-        void runButton() {
-            JPanel panel = new JPanel();
-            JButton btn = new JButton("Run");
-            AtomicBoolean clicked = new AtomicBoolean(false);
-            btn.addActionListener(e -> clicked.set(true));
-            panel.add(btn);
-
-            DialogInterceptor.clickConfirmButton(panel);
-
-            assertTrue(clicked.get());
-        }
-
-        @Test
-        @DisplayName("recognizes 'Yes' as confirm button")
-        void yesButton() {
-            JPanel panel = new JPanel();
-            JButton btn = new JButton("Yes");
-            AtomicBoolean clicked = new AtomicBoolean(false);
-            btn.addActionListener(e -> clicked.set(true));
-            panel.add(btn);
-
-            DialogInterceptor.clickConfirmButton(panel);
-
-            assertTrue(clicked.get());
+            assertTrue(clicked.get(), "Expected '" + label + "' to be recognized as confirm button");
         }
 
         @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/QualityToolResolveColumnTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/QualityToolResolveColumnTest.java
@@ -5,6 +5,11 @@ import com.intellij.openapi.util.TextRange;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -59,39 +64,21 @@ class QualityToolResolveColumnTest {
         assertEquals(LINE1.indexOf("Foo"), col);
     }
 
-    @Test
-    @DisplayName("symbol not found returns 0 (fallback)")
-    void symbolNotFound() {
-        int col = QualityTool.resolveColumn(doc, 1, "Missing", null);
-        assertEquals(0, col);
+    static Stream<Arguments> resolveColumnFallbackCases() {
+        return Stream.of(
+            Arguments.of("symbol not found returns 0", 1, "Missing", null, 0),
+            Arguments.of("no symbol and no column returns 0", 1, null, null, 0),
+            Arguments.of("blank symbol treated as absent", 1, "  ", null, 0),
+            Arguments.of("column=1 returns 0", 1, null, 1, 0),
+            Arguments.of("explicit column returns column-1", 1, null, 5, 4)
+        );
     }
 
-    @Test
-    @DisplayName("explicit column returns column-1 (0-based)")
-    void explicitColumn() {
-        int col = QualityTool.resolveColumn(doc, 1, null, 5);
-        assertEquals(4, col);
-    }
-
-    @Test
-    @DisplayName("column=1 returns 0")
-    void columnOne() {
-        int col = QualityTool.resolveColumn(doc, 1, null, 1);
-        assertEquals(0, col);
-    }
-
-    @Test
-    @DisplayName("no symbol and no column returns 0")
-    void noSymbolNoColumn() {
-        int col = QualityTool.resolveColumn(doc, 1, null, null);
-        assertEquals(0, col);
-    }
-
-    @Test
-    @DisplayName("blank symbol treated as absent, falls back to 0")
-    void blankSymbol() {
-        int col = QualityTool.resolveColumn(doc, 1, "  ", null);
-        assertEquals(0, col);
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("resolveColumnFallbackCases")
+    void resolveColumn_fallbackAndExplicit(String desc, int line, String symbol, Integer column, int expected) {
+        int col = QualityTool.resolveColumn(doc, line, symbol, column);
+        assertEquals(expected, col);
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ChatWebServerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ChatWebServerTest.java
@@ -4,7 +4,9 @@ import com.github.catatafishen.agentbridge.ui.MessageFormatter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -51,33 +54,27 @@ class ChatWebServerTest {
         assertEquals("ChatController.addThinkingText('t3','agent-2',", result);
     }
 
-    @Test
-    void buildStreamingPrefix_returnsNullWhenNoQuotes() {
-        String result = ChatWebServer.buildStreamingPrefix(
-            "ChatController.finalizeAgentText(no-quotes)",
-            "ChatController.finalizeAgentText(",
-            "ChatController.appendAgentText("
+    static Stream<Arguments> buildStreamingPrefix_nullCases() {
+        return Stream.of(
+            Arguments.of("no quotes",
+                "ChatController.finalizeAgentText(no-quotes)",
+                "ChatController.finalizeAgentText(",
+                "ChatController.appendAgentText("),
+            Arguments.of("only one quoted arg",
+                "ChatController.finalizeAgentText('t0')",
+                "ChatController.finalizeAgentText(",
+                "ChatController.appendAgentText("),
+            Arguments.of("missing closing quote",
+                "ChatController.finalizeAgentText('t0','main",
+                "ChatController.finalizeAgentText(",
+                "ChatController.appendAgentText(")
         );
-        assertNull(result);
     }
 
-    @Test
-    void buildStreamingPrefix_returnsNullWhenOnlyOneQuotedArg() {
-        String result = ChatWebServer.buildStreamingPrefix(
-            "ChatController.finalizeAgentText('t0')",
-            "ChatController.finalizeAgentText(",
-            "ChatController.appendAgentText("
-        );
-        assertNull(result);
-    }
-
-    @Test
-    void buildStreamingPrefix_returnsNullWhenMissingClosingQuote() {
-        String result = ChatWebServer.buildStreamingPrefix(
-            "ChatController.finalizeAgentText('t0','main",
-            "ChatController.finalizeAgentText(",
-            "ChatController.appendAgentText("
-        );
+    @ParameterizedTest(name = "returns null when {0}")
+    @MethodSource("buildStreamingPrefix_nullCases")
+    void buildStreamingPrefix_returnsNull(String desc, String js, String fromPrefix, String toPrefix) {
+        String result = ChatWebServer.buildStreamingPrefix(js, fromPrefix, toPrefix);
         assertNull(result);
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpSseTransportTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpSseTransportTest.java
@@ -4,8 +4,11 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.lang.reflect.Method;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -152,33 +155,23 @@ class McpSseTransportTest {
     @Nested
     class BuildJsonErrorResponseTest {
 
-        @Test
-        void basicErrorStructure() {
-            String json = McpSseTransport.buildJsonErrorResponse("Something went wrong");
-            JsonObject parsed = JsonParser.parseString(json).getAsJsonObject();
-            assertEquals("Something went wrong", parsed.get("error").getAsString());
+        static Stream<String> errorMessages() {
+            return Stream.of(
+                "Something went wrong",
+                "SSE session limit reached (10)",
+                "Error with \"quotes\"",
+                "",
+                "Unknown or closed session: abc-123",
+                "Missing sessionId parameter"
+            );
         }
 
-        @Test
-        void sessionLimitMessage() {
-            String json = McpSseTransport.buildJsonErrorResponse("SSE session limit reached (10)");
+        @ParameterizedTest(name = "errorMessage=''{0}''")
+        @MethodSource("errorMessages")
+        void errorMessageRoundTrips(String message) {
+            String json = McpSseTransport.buildJsonErrorResponse(message);
             JsonObject parsed = JsonParser.parseString(json).getAsJsonObject();
-            assertEquals("SSE session limit reached (10)", parsed.get("error").getAsString());
-        }
-
-        @Test
-        void quotesInMessageAreEscaped() {
-            String json = McpSseTransport.buildJsonErrorResponse("Error with \"quotes\"");
-            // Gson properly escapes double quotes; the result should be valid JSON
-            JsonObject parsed = JsonParser.parseString(json).getAsJsonObject();
-            assertEquals("Error with \"quotes\"", parsed.get("error").getAsString());
-        }
-
-        @Test
-        void emptyMessage() {
-            String json = McpSseTransport.buildJsonErrorResponse("");
-            JsonObject parsed = JsonParser.parseString(json).getAsJsonObject();
-            assertEquals("", parsed.get("error").getAsString());
+            assertEquals(message, parsed.get("error").getAsString());
         }
 
         @Test
@@ -186,20 +179,6 @@ class McpSseTransportTest {
             String json = McpSseTransport.buildJsonErrorResponse("test");
             JsonObject parsed = JsonParser.parseString(json).getAsJsonObject();
             assertEquals(1, parsed.size(), "Error response should have exactly 1 field");
-        }
-
-        @Test
-        void missingSessionMessage() {
-            String json = McpSseTransport.buildJsonErrorResponse("Unknown or closed session: abc-123");
-            JsonObject parsed = JsonParser.parseString(json).getAsJsonObject();
-            assertEquals("Unknown or closed session: abc-123", parsed.get("error").getAsString());
-        }
-
-        @Test
-        void missingSessionIdParam() {
-            String json = McpSseTransport.buildJsonErrorResponse("Missing sessionId parameter");
-            JsonObject parsed = JsonParser.parseString(json).getAsJsonObject();
-            assertEquals("Missing sessionId parameter", parsed.get("error").getAsString());
         }
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceStaticMethodsTest.java
@@ -1,9 +1,13 @@
 package com.github.catatafishen.agentbridge.services;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -76,39 +80,21 @@ class ToolCallStatisticsServiceStaticMethodsTest {
     // isDbMoved tests
     // ──────────────────────────────────────────────
 
-    @Test
-    void isDbMoved_messageContainsDbMoved_returnsTrue() {
-        SQLException ex = new SQLException("[SQLITE_READONLY_DBMOVED] database file has been moved");
-        assertTrue(ToolCallStatisticsService.isDbMoved(ex));
+    static Stream<Arguments> isDbMovedCases() {
+        return Stream.of(
+            Arguments.of("[SQLITE_READONLY_DBMOVED] database file has been moved", true),
+            Arguments.of("SQLITE_READONLY_DBMOVED", true),
+            Arguments.of("table not found", false),
+            Arguments.of(null, false),
+            Arguments.of("", false),
+            Arguments.of("SQLITE_READONLY", false)
+        );
     }
 
-    @Test
-    void isDbMoved_messageExactMatch_returnsTrue() {
-        SQLException ex = new SQLException("SQLITE_READONLY_DBMOVED");
-        assertTrue(ToolCallStatisticsService.isDbMoved(ex));
-    }
-
-    @Test
-    void isDbMoved_unrelatedMessage_returnsFalse() {
-        SQLException ex = new SQLException("table not found");
-        assertFalse(ToolCallStatisticsService.isDbMoved(ex));
-    }
-
-    @Test
-    void isDbMoved_nullMessage_returnsFalse() {
-        SQLException ex = new SQLException((String) null);
-        assertFalse(ToolCallStatisticsService.isDbMoved(ex));
-    }
-
-    @Test
-    void isDbMoved_emptyMessage_returnsFalse() {
-        SQLException ex = new SQLException("");
-        assertFalse(ToolCallStatisticsService.isDbMoved(ex));
-    }
-
-    @Test
-    void isDbMoved_partialMatch_returnsFalse() {
-        SQLException ex = new SQLException("SQLITE_READONLY");
-        assertFalse(ToolCallStatisticsService.isDbMoved(ex));
+    @ParameterizedTest(name = "isDbMoved(\"{0}\") = {1}")
+    @MethodSource("isDbMovedCases")
+    void isDbMoved_parameterized(String message, boolean expected) {
+        SQLException ex = new SQLException(message);
+        assertEquals(expected, ToolCallStatisticsService.isDbMoved(ex));
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.nio.file.Path;
@@ -16,6 +19,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -603,37 +607,24 @@ class ToolCallStatisticsServiceTest {
         assertEquals("feat/round-trip", results.get(0).branch());
     }
 
-    @Test
-    @DisplayName("recordTurnStats attributes branch to turn end when end is feature branch")
-    void recordTurnStatsUsesEndBranchForAttribution() {
-        service.recordTurnStats(turnRecordWithBranches("s1", "copilot", "2025-01-15",
-            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z", "master", "feat/end"));
-
-        var results = service.queryBranchTotals("2025-01-01", "2025-01-31");
-        assertEquals(1, results.size());
-        assertEquals("feat/end", results.get(0).branch());
+    static Stream<Arguments> branchAttributionCases() {
+        return Stream.of(
+            Arguments.of("end is feature branch → uses end", "master", "feat/end", "feat/end"),
+            Arguments.of("end is master → falls back to start", "feat/start", "master", "feat/start"),
+            Arguments.of("end is missing → falls back to start", "feat/start", null, "feat/start")
+        );
     }
 
-    @Test
-    @DisplayName("recordTurnStats falls back to start branch when end is master")
-    void recordTurnStatsFallsBackToStartWhenEndIsDefaultBranch() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("branchAttributionCases")
+    @DisplayName("recordTurnStats branch attribution")
+    void recordTurnStatsBranchAttribution(String desc, String startBranch, String endBranch, String expectedBranch) {
         service.recordTurnStats(turnRecordWithBranches("s1", "copilot", "2025-01-15",
-            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z", "feat/start", "master"));
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z", startBranch, endBranch));
 
         var results = service.queryBranchTotals("2025-01-01", "2025-01-31");
         assertEquals(1, results.size());
-        assertEquals("feat/start", results.get(0).branch());
-    }
-
-    @Test
-    @DisplayName("recordTurnStats falls back to start branch when end branch is missing")
-    void recordTurnStatsFallsBackToStartWhenEndMissing() {
-        service.recordTurnStats(turnRecordWithBranches("s1", "copilot", "2025-01-15",
-            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z", "feat/start", null));
-
-        var results = service.queryBranchTotals("2025-01-01", "2025-01-31");
-        assertEquals(1, results.size());
-        assertEquals("feat/start", results.get(0).branch());
+        assertEquals(expectedBranch, results.get(0).branch());
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/exporters/ClaudeCliExporterTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/exporters/ClaudeCliExporterTest.java
@@ -7,6 +7,9 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -16,6 +19,7 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -318,28 +322,20 @@ class ClaudeCliExporterTest {
 
     // ── Git branch detection tests ───────────────────────────────────
 
-    @Test
-    void detectsGitBranch(@TempDir Path tmpDir) throws IOException {
-        // Create a fake .git/HEAD file
-        Path gitDir = tmpDir.resolve(".git");
-        Files.createDirectories(gitDir);
-        Files.writeString(gitDir.resolve("HEAD"), "ref: refs/heads/main\n", StandardCharsets.UTF_8);
-
-        List<JsonObject> events = exportAndParse(
-            List.of(prompt("Hi"), text("Hello")), tmpDir);
-
-        JsonObject messageEvent = events.stream()
-            .filter(e -> "user".equals(safeGetType(e)) || "assistant".equals(safeGetType(e)))
-            .findFirst()
-            .orElseThrow();
-        assertEquals("main", messageEvent.get("gitBranch").getAsString());
+    static Stream<Arguments> gitBranchCases() {
+        return Stream.of(
+            Arguments.of("main branch", "ref: refs/heads/main\n", "main"),
+            Arguments.of("feature branch", "ref: refs/heads/feature/my-branch\n", "feature/my-branch"),
+            Arguments.of("detached HEAD", "abc123def456789\n", "abc123def456")
+        );
     }
 
-    @Test
-    void detectsFeatureBranch(@TempDir Path tmpDir) throws IOException {
+    @ParameterizedTest(name = "detects {0}")
+    @MethodSource("gitBranchCases")
+    void detectsGitBranch(String desc, String headContent, String expectedBranch, @TempDir Path tmpDir) throws IOException {
         Path gitDir = tmpDir.resolve(".git");
         Files.createDirectories(gitDir);
-        Files.writeString(gitDir.resolve("HEAD"), "ref: refs/heads/feature/my-branch\n", StandardCharsets.UTF_8);
+        Files.writeString(gitDir.resolve("HEAD"), headContent, StandardCharsets.UTF_8);
 
         List<JsonObject> events = exportAndParse(
             List.of(prompt("Hi"), text("Hello")), tmpDir);
@@ -348,24 +344,7 @@ class ClaudeCliExporterTest {
             .filter(e -> "user".equals(safeGetType(e)) || "assistant".equals(safeGetType(e)))
             .findFirst()
             .orElseThrow();
-        assertEquals("feature/my-branch", messageEvent.get("gitBranch").getAsString());
-    }
-
-    @Test
-    void detectsDetachedHead(@TempDir Path tmpDir) throws IOException {
-        Path gitDir = tmpDir.resolve(".git");
-        Files.createDirectories(gitDir);
-        Files.writeString(gitDir.resolve("HEAD"), "abc123def456789\n", StandardCharsets.UTF_8);
-
-        List<JsonObject> events = exportAndParse(
-            List.of(prompt("Hi"), text("Hello")), tmpDir);
-
-        JsonObject messageEvent = events.stream()
-            .filter(e -> "user".equals(safeGetType(e)) || "assistant".equals(safeGetType(e)))
-            .findFirst()
-            .orElseThrow();
-        // Detached HEAD → uses first 12 chars as branch name
-        assertEquals("abc123def456", messageEvent.get("gitBranch").getAsString());
+        assertEquals(expectedBranch, messageEvent.get("gitBranch").getAsString());
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/ConversationFileUtilsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/ConversationFileUtilsTest.java
@@ -2,12 +2,17 @@ package com.github.catatafishen.agentbridge.settings;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -122,25 +127,9 @@ class ConversationFileUtilsTest {
 
     // ── formatTimestamp ─────────────────────────────────────────────────
 
-    @Test
-    void formatTimestamp_validFormat() {
-        String input = "2025-01-15T14-30-00";
-        LocalDateTime dateTime = LocalDateTime.parse(input, ConversationFileUtils.TIMESTAMP_PARSER);
-        String expected = dateTime.format(ConversationFileUtils.DISPLAY_FORMATTER);
-        assertEquals(expected, ConversationFileUtils.formatTimestamp(input));
-    }
-
-    @Test
-    void formatTimestamp_anotherValidTimestamp() {
-        String input = "2024-12-31T23-59-59";
-        LocalDateTime dateTime = LocalDateTime.parse(input, ConversationFileUtils.TIMESTAMP_PARSER);
-        String expected = dateTime.format(ConversationFileUtils.DISPLAY_FORMATTER);
-        assertEquals(expected, ConversationFileUtils.formatTimestamp(input));
-    }
-
-    @Test
-    void formatTimestamp_midnightTimestamp() {
-        String input = "2025-06-01T00-00-00";
+    @ParameterizedTest
+    @ValueSource(strings = {"2025-01-15T14-30-00", "2024-12-31T23-59-59", "2025-06-01T00-00-00"})
+    void formatTimestamp_validFormat(String input) {
         LocalDateTime dateTime = LocalDateTime.parse(input, ConversationFileUtils.TIMESTAMP_PARSER);
         String expected = dateTime.format(ConversationFileUtils.DISPLAY_FORMATTER);
         assertEquals(expected, ConversationFileUtils.formatTimestamp(input));
@@ -257,31 +246,22 @@ class ConversationFileUtilsTest {
         assertEquals(5, ConversationFileUtils.countMessages(file));
     }
 
-    @Test
-    void countMessages_invalidJson_returnsNegativeOne(@TempDir Path tempDir) throws IOException {
-        Path file = tempDir.resolve("invalid.json");
-        Files.writeString(file, "this is not json");
-        assertEquals(-1, ConversationFileUtils.countMessages(file));
+    static Stream<Arguments> countMessages_negativeOneInputs() {
+        return Stream.of(
+            Arguments.of("invalid.json", "this is not json"),
+            Arguments.of("object.json", "{\"key\":\"value\"}"),
+            Arguments.of("empty.txt", ""),
+            Arguments.of("nofile.json", null)
+        );
     }
 
-    @Test
-    void countMessages_jsonObject_returnsNegativeOne(@TempDir Path tempDir) throws IOException {
-        // A JSON object (not array) should cause getAsJsonArray() to fail
-        Path file = tempDir.resolve("object.json");
-        Files.writeString(file, "{\"key\":\"value\"}");
-        assertEquals(-1, ConversationFileUtils.countMessages(file));
-    }
-
-    @Test
-    void countMessages_emptyFile_returnsNegativeOne(@TempDir Path tempDir) throws IOException {
-        Path file = tempDir.resolve("empty.txt");
-        Files.writeString(file, "");
-        assertEquals(-1, ConversationFileUtils.countMessages(file));
-    }
-
-    @Test
-    void countMessages_nonExistentFile_returnsNegativeOne(@TempDir Path tempDir) {
-        Path file = tempDir.resolve("does-not-exist.json");
+    @ParameterizedTest
+    @MethodSource("countMessages_negativeOneInputs")
+    void countMessages_invalidInput_returnsNegativeOne(String filename, String content, @TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve(filename);
+        if (content != null) {
+            Files.writeString(file, content);
+        }
         assertEquals(-1, ConversationFileUtils.countMessages(file));
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/MarkdownRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/MarkdownRendererTest.java
@@ -5,7 +5,11 @@ import kotlin.jvm.functions.Function1;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -595,27 +599,20 @@ class MarkdownRendererTest {
             assertEquals(2, count, "Expected 2 rows (header + data): " + html);
         }
 
-        @Test
-        void tableWithInlineFormatting() {
-            String md = "| **Bold** | `code` |\n|---|---|\n| normal | normal |";
-            String html = render(md);
-            assertTrue(html.contains("<b>Bold</b>"), html);
-            assertTrue(html.contains("<code>code</code>"), html);
+        static Stream<Arguments> tableClosingScenarios() {
+            return Stream.of(
+                Arguments.of("| **Bold** | `code` |\n|---|---|\n| normal | normal |", "<b>Bold</b>", "<code>code</code>"),
+                Arguments.of("| H1 | H2 |\n|---|---|\n| D1 | D2 |\nParagraph after", "</table>", "<p>Paragraph after</p>"),
+                Arguments.of("| H1 | H2 |\n| --- | --- |\n| D1 | D2 |", "</table>", "<table>")
+            );
         }
 
-        @Test
-        void tableClosedByNonTableLine() {
-            String md = "| H1 | H2 |\n|---|---|\n| D1 | D2 |\nParagraph after";
+        @ParameterizedTest(name = "table scenario: contains {1} and {2}")
+        @MethodSource("tableClosingScenarios")
+        void tableContainsExpectedElements(String md, String expected1, String expected2) {
             String html = render(md);
-            assertTrue(html.contains("</table>"), html);
-            assertTrue(html.contains("<p>Paragraph after</p>"), html);
-        }
-
-        @Test
-        void tableClosedAtEndOfInput() {
-            String md = "| H1 | H2 |\n| --- | --- |\n| D1 | D2 |";
-            String html = render(md);
-            assertTrue(html.contains("</table>"), html);
+            assertTrue(html.contains(expected1), html);
+            assertTrue(html.contains(expected2), html);
         }
 
         @Test
@@ -896,29 +893,23 @@ class MarkdownRendererTest {
 
     @Nested
     class BlockTransitions {
-        @Test
-        void listFollowedByTable() {
-            String md = "- item\n| H1 | H2 |\n|---|---|\n| A | B |";
-            String html = render(md);
-            assertTrue(html.contains("</ul>"), html);
-            assertTrue(html.contains("<table>"), html);
+        static Stream<Arguments> blockTransitionScenarios() {
+            return Stream.of(
+                Arguments.of("- item\n| H1 | H2 |\n|---|---|\n| A | B |", "</ul>", "<table>"),
+                Arguments.of("| H1 | H2 |\n|---|---|\n| D1 | D2 |\n- item", "</table>", "<ul>"),
+                Arguments.of("> quote\n# Heading", "</blockquote>", "<h2>")
+            );
         }
 
-        @Test
-        void tableFollowedByList() {
-            String md = "| H1 | H2 |\n|---|---|\n| D1 | D2 |\n- item";
+        @ParameterizedTest(name = "block transition: {1} before {2}")
+        @MethodSource("blockTransitionScenarios")
+        void blockTransition(String md, String closingTag, String openingTag) {
             String html = render(md);
-            assertTrue(html.contains("</table>"), html);
-            assertTrue(html.contains("<ul>"), html);
-        }
-
-        @Test
-        void headingClosesOpenBlockquote() {
-            String md = "> quote\n# Heading";
-            String html = render(md);
-            int bqClose = html.indexOf("</blockquote>");
-            int h2Open = html.indexOf("<h2>");
-            assertTrue(bqClose < h2Open, "Blockquote should close before heading: " + html);
+            assertTrue(html.contains(closingTag), html);
+            assertTrue(html.contains(openingTag), html);
+            int closePos = html.indexOf(closingTag);
+            int openPos = html.indexOf(openingTag);
+            assertTrue(closePos < openPos, closingTag + " should appear before " + openingTag + ": " + html);
         }
 
         @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/PromptBubbleBuilderTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/PromptBubbleBuilderTest.java
@@ -1,9 +1,13 @@
 package com.github.catatafishen.agentbridge.ui;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -266,35 +270,23 @@ class PromptBubbleBuilderTest {
         assertTrue(result.contains("&#39;xss&#39;"));
     }
 
-    @Test
-    void buildBubbleHtml_ampersandInPromptText_escaped() {
-        ContextItemData item = fileItem("f.java", "f.java");
-        String result = PromptBubbleBuilder.INSTANCE.buildBubbleHtml(
-            "a & b " + ORC, List.of(item));
-
-        assertNotNull(result);
-        assertTrue(result.contains("a &amp; b"));
+    static Stream<Arguments> buildBubbleHtml_escapingInputs() {
+        return Stream.of(
+            Arguments.of("a & b ", "a &amp; b"),
+            Arguments.of("say \"hello\" ", "&quot;hello&quot;"),
+            Arguments.of("line1\nline2 ", "line1\nline2")
+        );
     }
 
-    @Test
-    void buildBubbleHtml_doubleQuotesInPromptText_escapedViaAppendHtmlChar() {
+    @ParameterizedTest
+    @MethodSource("buildBubbleHtml_escapingInputs")
+    void buildBubbleHtml_specialCharsInPromptText_handled(String inputPrefix, String expectedFragment) {
         ContextItemData item = fileItem("f.java", "f.java");
         String result = PromptBubbleBuilder.INSTANCE.buildBubbleHtml(
-            "say \"hello\" " + ORC, List.of(item));
+            inputPrefix + ORC, List.of(item));
 
         assertNotNull(result);
-        // appendHtmlChar encodes double-quote characters as HTML &quot; entities
-        assertTrue(result.contains("&quot;hello&quot;"));
-    }
-
-    @Test
-    void buildBubbleHtml_newlineInPromptText_preserved() {
-        ContextItemData item = fileItem("f.java", "f.java");
-        String result = PromptBubbleBuilder.INSTANCE.buildBubbleHtml(
-            "line1\nline2 " + ORC, List.of(item));
-
-        assertNotNull(result);
-        assertTrue(result.contains("line1\nline2"));
+        assertTrue(result.contains(expectedFragment));
     }
 
     // ── buildBubbleHtml — HTML in item name / path ──────────────────────

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/PromptErrorClassifierTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/PromptErrorClassifierTest.java
@@ -2,6 +2,8 @@ package com.github.catatafishen.agentbridge.ui;
 
 import com.github.catatafishen.agentbridge.agent.AgentException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 import java.util.function.Function;
@@ -306,15 +308,10 @@ class PromptErrorClassifierTest {
         assertEquals(List.of("A"), replies);
     }
 
-    @Test
-    void detectQuickReplies_noTag_returnsEmptyList() {
-        List<String> replies = PromptErrorClassifier.INSTANCE.detectQuickReplies("no quick replies here");
-        assertTrue(replies.isEmpty());
-    }
-
-    @Test
-    void detectQuickReplies_emptyString_returnsEmptyList() {
-        List<String> replies = PromptErrorClassifier.INSTANCE.detectQuickReplies("");
+    @ParameterizedTest
+    @ValueSource(strings = {"no quick replies here", "", "[quick-reply: | | ]"})
+    void detectQuickReplies_noValidReplies_returnsEmptyList(String input) {
+        List<String> replies = PromptErrorClassifier.INSTANCE.detectQuickReplies(input);
         assertTrue(replies.isEmpty());
     }
 
@@ -342,12 +339,6 @@ class PromptErrorClassifierTest {
     void detectQuickReplies_extraWhitespaceInTag_parsesCorrectly() {
         List<String> replies = PromptErrorClassifier.INSTANCE.detectQuickReplies("[  quick-reply:  Yes  |  No  ]");
         assertEquals(List.of("Yes", "No"), replies);
-    }
-
-    @Test
-    void detectQuickReplies_onlyPipeSeparators_filtersEmptyStrings() {
-        List<String> replies = PromptErrorClassifier.INSTANCE.detectQuickReplies("[quick-reply: | | ]");
-        assertTrue(replies.isEmpty());
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/ToolCallArgParserTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/ToolCallArgParserTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -247,31 +248,10 @@ class ToolCallArgParserTest {
             assertEquals("", parser.extractTaskCompleteSummary("  "));
         }
 
-        @Test
-        @DisplayName("returns raw text when no summary key")
-        void returnsRawWhenNoSummaryKey() {
-            String raw = "{\"result\":\"ok\"}";
-            assertEquals(raw, parser.extractTaskCompleteSummary(raw));
-        }
-
-        @Test
-        @DisplayName("returns raw text for invalid JSON")
-        void returnsRawForInvalidJson() {
-            String raw = "plain text summary";
-            assertEquals(raw, parser.extractTaskCompleteSummary(raw));
-        }
-
-        @Test
-        @DisplayName("returns raw text for JSON array")
-        void returnsRawForJsonArray() {
-            String raw = "[\"a\",\"b\"]";
-            assertEquals(raw, parser.extractTaskCompleteSummary(raw));
-        }
-
-        @Test
-        @DisplayName("ignores non-primitive summary value")
-        void ignoresNonPrimitiveSummary() {
-            String raw = "{\"summary\":{\"detail\":\"nested\"}}";
+        @ParameterizedTest
+        @DisplayName("returns raw text when summary is absent or unparseable")
+        @ValueSource(strings = {"{\"result\":\"ok\"}", "plain text summary", "[\"a\",\"b\"]", "{\"summary\":{\"detail\":\"nested\"}}"})
+        void returnsRawWhenNoSummary(String raw) {
             assertEquals(raw, parser.extractTaskCompleteSummary(raw));
         }
     }
@@ -312,46 +292,12 @@ class ToolCallArgParserTest {
             assertEquals("", result.getSecond());
         }
 
-        @Test
-        @DisplayName("returns null when both old_str and new_str are blank")
-        void returnsNullWhenBothBlank() {
-            assertNull(parser.extractDiffFromArgs("{\"old_str\":\"\",\"new_str\":\"\"}"));
-        }
-
-        @Test
-        @DisplayName("returns null for null arguments")
-        void returnsNullForNull() {
-            assertNull(parser.extractDiffFromArgs(null));
-        }
-
-        @Test
-        @DisplayName("returns null for blank arguments")
-        void returnsNullForBlank() {
-            assertNull(parser.extractDiffFromArgs("  "));
-        }
-
-        @Test
-        @DisplayName("returns null for invalid JSON")
-        void returnsNullForInvalidJson() {
-            assertNull(parser.extractDiffFromArgs("not json"));
-        }
-
-        @Test
-        @DisplayName("returns null when old_str is missing")
-        void returnsNullWhenOldStrMissing() {
-            assertNull(parser.extractDiffFromArgs("{\"new_str\":\"bar\"}"));
-        }
-
-        @Test
-        @DisplayName("returns null when new_str is missing")
-        void returnsNullWhenNewStrMissing() {
-            assertNull(parser.extractDiffFromArgs("{\"old_str\":\"foo\"}"));
-        }
-
-        @Test
-        @DisplayName("returns null when neither key present")
-        void returnsNullWhenNeitherKey() {
-            assertNull(parser.extractDiffFromArgs("{\"content\":\"something\"}"));
+        @ParameterizedTest
+        @DisplayName("returns null for invalid or incomplete arguments")
+        @NullSource
+        @ValueSource(strings = {"  ", "not json", "{\"old_str\":\"\",\"new_str\":\"\"}", "{\"new_str\":\"bar\"}", "{\"old_str\":\"foo\"}", "{\"content\":\"something\"}"})
+        void returnsNullForInvalidInput(String args) {
+            assertNull(parser.extractDiffFromArgs(args));
         }
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/HtmlToolRendererSupportTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/HtmlToolRendererSupportTest.java
@@ -1,8 +1,12 @@
 package com.github.catatafishen.agentbridge.ui.renderers;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.swing.*;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -23,42 +27,25 @@ class HtmlToolRendererSupportTest {
         assertEquals("text/html", editorPane.getContentType());
     }
 
-    @Test
-    void markdownPaneRendersBold() {
-        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("**bold**");
-
+    @ParameterizedTest
+    @MethodSource("markdownRenderingCases")
+    void markdownPaneRendersExpectedContent(String markdown, String expectedInHtml) {
+        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane(markdown);
         JEditorPane editorPane = (JEditorPane) pane;
         String html = editorPane.getText();
-        assertTrue(html.contains("<b>bold</b>"), html);
+        assertTrue(html.contains(expectedInHtml), html);
     }
 
-    @Test
-    void markdownPaneRendersParagraphText() {
-        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("plain text");
-
-        JEditorPane editorPane = (JEditorPane) pane;
-        String html = editorPane.getText();
-        // JEditorPane adds whitespace; just check the text content is present
-        assertTrue(html.contains("plain text"), html);
-    }
-
-    @Test
-    void markdownPaneRendersListItemContent() {
-        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("- item1\n- item2");
-
-        JEditorPane editorPane = (JEditorPane) pane;
-        String html = editorPane.getText();
-        assertTrue(html.contains("item1"), html);
-        assertTrue(html.contains("item2"), html);
-    }
-
-    @Test
-    void markdownPaneAppliesFontFamily() {
-        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("text");
-
-        JEditorPane editorPane = (JEditorPane) pane;
-        String html = editorPane.getText();
-        assertTrue(html.contains("font-family:"), html);
+    static Stream<Arguments> markdownRenderingCases() {
+        return Stream.of(
+            Arguments.of("**bold**", "<b>bold</b>"),
+            Arguments.of("plain text", "plain text"),
+            Arguments.of("- item1\n- item2", "item1"),
+            Arguments.of("- item1\n- item2", "item2"),
+            Arguments.of("text", "font-family:"),
+            Arguments.of("Use `println()`", "<code>println()</code>"),
+            Arguments.of("[click](https://example.com)", "https://example.com")
+        );
     }
 
     @Test
@@ -66,23 +53,5 @@ class HtmlToolRendererSupportTest {
         JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("");
 
         assertNotNull(pane);
-    }
-
-    @Test
-    void markdownPaneRendersCode() {
-        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("Use `println()`");
-
-        JEditorPane editorPane = (JEditorPane) pane;
-        String html = editorPane.getText();
-        assertTrue(html.contains("<code>println()</code>"), html);
-    }
-
-    @Test
-    void markdownPaneRendersLinkHref() {
-        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("[click](https://example.com)");
-
-        JEditorPane editorPane = (JEditorPane) pane;
-        String html = editorPane.getText();
-        assertTrue(html.contains("https://example.com"), html);
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/HttpRequestRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/HttpRequestRendererTest.java
@@ -2,6 +2,8 @@ package com.github.catatafishen.agentbridge.ui.renderers;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 
@@ -50,24 +52,10 @@ class HttpRequestRendererTest {
             assertEquals(301, info.code());
         }
 
-        @Test
-        void returnsNullForNonHttpLine() {
-            assertNull(HttpRequestRenderer.parseStatusLine("Not an HTTP response"));
-        }
-
-        @Test
-        void returnsNullForEmptyString() {
-            assertNull(HttpRequestRenderer.parseStatusLine(""));
-        }
-
-        @Test
-        void returnsNullForHttpWithoutSpace() {
-            assertNull(HttpRequestRenderer.parseStatusLine("HTTP200"));
-        }
-
-        @Test
-        void returnsNullForNonNumericCode() {
-            assertNull(HttpRequestRenderer.parseStatusLine("HTTP abc OK"));
+        @ParameterizedTest
+        @ValueSource(strings = {"Not an HTTP response", "", "HTTP200", "HTTP abc OK"})
+        void returnsNullForInvalidInput(String input) {
+            assertNull(HttpRequestRenderer.parseStatusLine(input));
         }
 
         @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/InspectionResultRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/InspectionResultRendererTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -80,14 +81,10 @@ class InspectionResultRendererTest {
             assertEquals("WEAK_WARNING", match.getGroupValues().get(3));
         }
 
-        @Test
-        void doesNotMatchBlankLine() {
-            assertNull(FINDING_PATTERN.matchEntire(""));
-        }
-
-        @Test
-        void doesNotMatchSummaryLine() {
-            assertNull(FINDING_PATTERN.matchEntire("Found 5 problems across 3 files"));
+        @ParameterizedTest
+        @ValueSource(strings = {"", "Found 5 problems across 3 files"})
+        void doesNotMatchNonFindingInput(String input) {
+            assertNull(FINDING_PATTERN.matchEntire(input));
         }
 
         @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/RunConfigCrudRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/RunConfigCrudRendererTest.java
@@ -3,6 +3,8 @@ package com.github.catatafishen.agentbridge.ui.renderers;
 import kotlin.text.MatchResult;
 import kotlin.text.Regex;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -73,25 +75,16 @@ class RunConfigCrudRendererTest {
 
     // ── STARTED ─────────────────────────────────────────────
 
-    @Test
-    void started_matchesStarted() {
-        MatchResult m = started.find("Started 'My Config'", 0);
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', value = {
+        "Started 'My Config'|My Config",
+        "Executed 'Build'|Build",
+        "Running 'Server'|Server"
+    })
+    void started_matchesVerb(String input, String expectedName) {
+        MatchResult m = started.find(input, 0);
         assertNotNull(m);
-        assertEquals("My Config", m.getGroupValues().get(1));
-    }
-
-    @Test
-    void started_matchesExecuted() {
-        MatchResult m = started.find("Executed 'Build'", 0);
-        assertNotNull(m);
-        assertEquals("Build", m.getGroupValues().get(1));
-    }
-
-    @Test
-    void started_matchesRunning() {
-        MatchResult m = started.find("Running 'Server'", 0);
-        assertNotNull(m);
-        assertEquals("Server", m.getGroupValues().get(1));
+        assertEquals(expectedName, m.getGroupValues().get(1));
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/SearchResultRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/SearchResultRendererTest.java
@@ -4,6 +4,7 @@ import kotlin.text.MatchResult;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -91,40 +92,19 @@ class SearchResultRendererTest {
     @Nested
     class CountHeader {
 
-        @Test
-        void matchesMatchesFound() {
-            MatchResult match = R.getCOUNT_HEADER().find("15 matches found in 3 files", 0);
+        @ParameterizedTest
+        @CsvSource(delimiter = '|', value = {
+            "15 matches found in 3 files|15|matches",
+            "7 results in project|7|results",
+            "3 references found|3|references",
+            "1 symbol found|1|symbol"
+        })
+        void matchesCountVariants(String input, String expectedCount, String expectedType) {
+            MatchResult match = R.getCOUNT_HEADER().find(input, 0);
 
             assertNotNull(match);
-            assertEquals("15", match.getGroupValues().get(1));
-            assertEquals("matches", match.getGroupValues().get(2));
-        }
-
-        @Test
-        void matchesResults() {
-            MatchResult match = R.getCOUNT_HEADER().find("7 results in project", 0);
-
-            assertNotNull(match);
-            assertEquals("7", match.getGroupValues().get(1));
-            assertEquals("results", match.getGroupValues().get(2));
-        }
-
-        @Test
-        void matchesReferences() {
-            MatchResult match = R.getCOUNT_HEADER().find("3 references found", 0);
-
-            assertNotNull(match);
-            assertEquals("3", match.getGroupValues().get(1));
-            assertEquals("references", match.getGroupValues().get(2));
-        }
-
-        @Test
-        void matchesSymbol() {
-            MatchResult match = R.getCOUNT_HEADER().find("1 symbol found", 0);
-
-            assertNotNull(match);
-            assertEquals("1", match.getGroupValues().get(1));
-            assertEquals("symbol", match.getGroupValues().get(2));
+            assertEquals(expectedCount, match.getGroupValues().get(1));
+            assertEquals(expectedType, match.getGroupValues().get(2));
         }
 
         @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TaskToolRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TaskToolRendererTest.java
@@ -1,6 +1,11 @@
 package com.github.catatafishen.agentbridge.ui.renderers;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -10,11 +15,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TaskToolRendererTest {
 
-    @Test
-    void parseTaskOutputReturnsEmptyForEmptyInput() {
-        TaskToolRenderer.ParsedTaskResult parsed = TaskToolRenderer.INSTANCE.parseTaskOutput("");
+    @ParameterizedTest
+    @MethodSource("nullTaskIdCases")
+    void parseTaskOutputReturnsNullTaskIdWithExpectedContent(String input, String expectedContent) {
+        TaskToolRenderer.ParsedTaskResult parsed = TaskToolRenderer.INSTANCE.parseTaskOutput(input);
         assertNull(parsed.getTaskId());
-        assertEquals("", parsed.getContent());
+        assertEquals(expectedContent, parsed.getContent());
+    }
+
+    static Stream<Arguments> nullTaskIdCases() {
+        return Stream.of(
+            Arguments.of("", ""),
+            Arguments.of("plain subagent output", "plain subagent output"),
+            Arguments.of("literal <task_result>text</task_result> body", "literal <task_result>text</task_result> body")
+        );
+    }
+
+    @Test
+    void renderReturnsPanelForTaskOutput() {
+        assertNotNull(TaskToolRenderer.INSTANCE.render("<task_result>hello</task_result>"));
     }
 
     @Test
@@ -55,28 +74,5 @@ class TaskToolRendererTest {
         assertTrue(parsed.getContent().contains("## Result"), parsed.getContent());
         assertFalse(parsed.getContent().contains("<task_result>"), parsed.getContent());
         assertFalse(parsed.getContent().contains("</task_result>"), parsed.getContent());
-    }
-
-    @Test
-    void parseTaskOutputKeepsPlainContent() {
-        TaskToolRenderer.ParsedTaskResult parsed =
-            TaskToolRenderer.INSTANCE.parseTaskOutput("plain subagent output");
-
-        assertNull(parsed.getTaskId());
-        assertEquals("plain subagent output", parsed.getContent());
-    }
-
-    @Test
-    void parseTaskOutputPreservesInlineTaskResultText() {
-        TaskToolRenderer.ParsedTaskResult parsed =
-            TaskToolRenderer.INSTANCE.parseTaskOutput("literal <task_result>text</task_result> body");
-
-        assertNull(parsed.getTaskId());
-        assertEquals("literal <task_result>text</task_result> body", parsed.getContent());
-    }
-
-    @Test
-    void renderReturnsPanelForTaskOutput() {
-        assertNotNull(TaskToolRenderer.INSTANCE.render("<task_result>hello</task_result>"));
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TodoRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TodoRendererTest.java
@@ -3,6 +3,9 @@ package com.github.catatafishen.agentbridge.ui.renderers;
 import kotlin.text.MatchResult;
 import kotlin.text.Regex;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -17,77 +20,43 @@ class TodoRendererTest {
 
     // ── CHECKBOX_LINE ───────────────────────────────────────
 
-    @Test
-    void checkboxLine_matchesCheckedLowercase() {
-        MatchResult m = checkboxLine.find("- [x] Buy groceries", 0);
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', value = {
+        "- [x] Buy groceries|x|Buy groceries",
+        "- [X] Done item|X|Done item",
+        "- [ ] Pending item|' '|Pending item"
+    })
+    void checkboxLine_matchesCheckedAndUnchecked(String input, String expectedMark, String expectedText) {
+        MatchResult m = checkboxLine.find(input, 0);
         assertNotNull(m);
-        assertEquals("x", m.getGroupValues().get(1));
-        assertEquals("Buy groceries", m.getGroupValues().get(2));
+        assertEquals(expectedMark, m.getGroupValues().get(1));
+        assertEquals(expectedText, m.getGroupValues().get(2));
     }
 
-    @Test
-    void checkboxLine_matchesCheckedUppercase() {
-        MatchResult m = checkboxLine.find("- [X] Done item", 0);
-        assertNotNull(m);
-        assertEquals("X", m.getGroupValues().get(1));
-        assertEquals("Done item", m.getGroupValues().get(2));
-    }
-
-    @Test
-    void checkboxLine_matchesUnchecked() {
-        MatchResult m = checkboxLine.find("- [ ] Pending item", 0);
-        assertNotNull(m);
-        assertEquals(" ", m.getGroupValues().get(1));
-        assertEquals("Pending item", m.getGroupValues().get(2));
-    }
-
-    @Test
-    void checkboxLine_doesNotMatchNoSpaceInBrackets() {
-        assertNull(checkboxLine.find("- [] No space", 0));
-    }
-
-    @Test
-    void checkboxLine_doesNotMatchNoDashPrefix() {
-        assertNull(checkboxLine.find("[x] no dash prefix", 0));
+    @ParameterizedTest
+    @ValueSource(strings = {"- [] No space", "[x] no dash prefix"})
+    void checkboxLine_doesNotMatchInvalid(String input) {
+        assertNull(checkboxLine.find(input, 0));
     }
 
     // ── HEADER_LINE ─────────────────────────────────────────
 
-    @Test
-    void headerLine_matchesOneHash() {
-        MatchResult m = headerLine.find("# Top heading", 0);
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', value = {
+        "# Top heading|Top heading",
+        "## Section|Section",
+        "### Sub-section|Sub-section",
+        "#### Deep|Deep"
+    })
+    void headerLine_matchesValidHeaders(String input, String expectedText) {
+        MatchResult m = headerLine.find(input, 0);
         assertNotNull(m);
-        assertEquals("Top heading", m.getGroupValues().get(1));
+        assertEquals(expectedText, m.getGroupValues().get(1));
     }
 
-    @Test
-    void headerLine_matchesTwoHashes() {
-        MatchResult m = headerLine.find("## Section", 0);
-        assertNotNull(m);
-        assertEquals("Section", m.getGroupValues().get(1));
-    }
-
-    @Test
-    void headerLine_matchesThreeHashes() {
-        MatchResult m = headerLine.find("### Sub-section", 0);
-        assertNotNull(m);
-        assertEquals("Sub-section", m.getGroupValues().get(1));
-    }
-
-    @Test
-    void headerLine_matchesFourHashes() {
-        MatchResult m = headerLine.find("#### Deep", 0);
-        assertNotNull(m);
-        assertEquals("Deep", m.getGroupValues().get(1));
-    }
-
-    @Test
-    void headerLine_doesNotMatchFiveHashes() {
-        assertNull(headerLine.find("##### 5 levels", 0));
-    }
-
-    @Test
-    void headerLine_doesNotMatchNoHash() {
-        assertNull(headerLine.find("No hash heading", 0));
+    @ParameterizedTest
+    @ValueSource(strings = {"##### 5 levels", "No hash heading"})
+    void headerLine_doesNotMatchInvalid(String input) {
+        assertNull(headerLine.find(input, 0));
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TypeHierarchyRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TypeHierarchyRendererTest.java
@@ -3,6 +3,8 @@ package com.github.catatafishen.agentbridge.ui.renderers;
 import kotlin.text.MatchResult;
 import kotlin.text.Regex;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,25 +44,16 @@ class TypeHierarchyRendererTest {
 
     // ── SECTION_HEADER ──────────────────────────────────────
 
-    @Test
-    void sectionHeader_matchesSupertypes() {
-        MatchResult m = sectionHeader.find("Supertypes:", 0);
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', value = {
+        "Supertypes:|Supertypes",
+        "Subtypes:|Subtypes",
+        "Implementations:|Implementations"
+    })
+    void sectionHeader_matchesKnownSections(String input, String expectedName) {
+        MatchResult m = sectionHeader.find(input, 0);
         assertNotNull(m);
-        assertEquals("Supertypes", m.getGroupValues().get(1));
-    }
-
-    @Test
-    void sectionHeader_matchesSubtypes() {
-        MatchResult m = sectionHeader.find("Subtypes:", 0);
-        assertNotNull(m);
-        assertEquals("Subtypes", m.getGroupValues().get(1));
-    }
-
-    @Test
-    void sectionHeader_matchesImplementations() {
-        MatchResult m = sectionHeader.find("Implementations:", 0);
-        assertNotNull(m);
-        assertEquals("Implementations", m.getGroupValues().get(1));
+        assertEquals(expectedName, m.getGroupValues().get(1));
     }
 
     @Test


### PR DESCRIPTION
Addresses ~30 S5976 findings by converting structurally identical test methods into parameterized tests using JUnit 5 annotations.

## Changes

**Batch 1** (3 files):
- KiroToolPurposeTest, CustomMcpServerConfigTest, MarkdownRendererTest

**Batch 2** (6 files):
- TripleExtractorTest, MemoryLayersTest, RunConfigurationServiceStaticMethodsTest
- PathCanonicalizationTest, HttpRequestToolStaticMethodsTest, DialogInterceptorTest

**Batch 3** (6 files):
- QualityToolResolveColumnTest, ChatWebServerTest, McpSseTransportTest
- ToolCallStatisticsServiceStaticMethodsTest, ToolCallStatisticsServiceTest, ClaudeCliExporterTest

**Batch 4** (4 files):
- ConversationFileUtilsTest, PromptBubbleBuilderTest, PromptErrorClassifierTest, ToolCallArgParserTest

**Batch 5** (8 files — renderers):
- HtmlToolRendererSupportTest, HttpRequestRendererTest, InspectionResultRendererTest
- RunConfigCrudRendererTest, SearchResultRendererTest, TaskToolRendererTest
- TodoRendererTest, TypeHierarchyRendererTest

## Approach
- @ValueSource for simple same-type inputs
- @CsvSource for multi-param cases
- @MethodSource for complex objects or special characters
- @NullAndEmptySource where applicable

All 8220+ tests pass.