### PR TITLE
fix(sonar): S112 — narrow generic exceptions, suppress intentional contracts

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/AbstractAgentClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/AbstractAgentClient.java
@@ -37,7 +37,9 @@ public abstract class AbstractAgentClient {
     /**
      * Start the agent process and perform handshake.
      */
-    public abstract void start() throws Exception;
+    // S112: throws Exception is intentional — subclasses (AcpClient, ClaudeCliClient, etc.) throw
+    // different checked exceptions during process startup. Narrowing would be a breaking API change.
+    public abstract void start() throws Exception; // NOSONAR java:S112
 
     /**
      * Gracefully stop the agent process.
@@ -89,7 +91,7 @@ public abstract class AbstractAgentClient {
      * @param cwd working directory for the session
      * @return session ID
      */
-    public abstract String createSession(String cwd) throws Exception;
+    public abstract String createSession(String cwd) throws Exception; // NOSONAR java:S112 — see start()
 
     /**
      * Returns conversation history replayed by the agent during the most recent
@@ -135,7 +137,7 @@ public abstract class AbstractAgentClient {
      * @return the final prompt response when the turn completes
      */
     public abstract PromptResponse sendPrompt(PromptRequest request,
-                                              Consumer<SessionUpdate> onUpdate) throws Exception;
+                                              Consumer<SessionUpdate> onUpdate) throws Exception; // NOSONAR java:S112 — see start()
 
     // ─── Modes (built-in interaction modes, e.g. default/agent/plan/autopilot) ──
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/Embedder.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/Embedder.java
@@ -17,5 +17,7 @@ public interface Embedder {
      * @return float array of dimension {@link EmbeddingService#EMBEDDING_DIM}
      * @throws Exception if embedding fails (I/O, inference, etc.)
      */
-    float[] embed(@NotNull String text) throws Exception;
+    // S112: throws Exception is intentional — this is a generic embedding abstraction allowing any
+    // implementation (ML inference, I/O-based models, test fakes) to throw any checked exception.
+    float[] embed(@NotNull String text) throws Exception; // NOSONAR java:S112
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingService.java
@@ -30,7 +30,8 @@ public final class EmbeddingService implements Disposable, Embedder {
      */
     @FunctionalInterface
     interface InferenceFunction {
-        float[] run(WordPieceTokenizer.TokenizedInput input) throws Exception;
+        // S112: intentional — mirrors Embedder contract; different backends throw different exceptions
+        float[] run(WordPieceTokenizer.TokenizedInput input) throws Exception; // NOSONAR java:S112
     }
 
     public EmbeddingService(@NotNull Project project) {
@@ -65,7 +66,7 @@ public final class EmbeddingService implements Disposable, Embedder {
      * @throws Exception   if inference fails
      */
     @Override
-    public float[] embed(@NotNull String text) throws Exception {
+    public float[] embed(@NotNull String text) throws Exception { // NOSONAR java:S112 — required by Embedder interface
         ensureInitialized();
 
         WordPieceTokenizer.TokenizedInput input = tokenizer.tokenize(text);
@@ -76,7 +77,7 @@ public final class EmbeddingService implements Disposable, Embedder {
      * Batch-embed multiple texts. More efficient than repeated single calls
      * when processing multiple chunks from a turn.
      */
-    public List<float[]> embedBatch(@NotNull List<String> texts) throws Exception {
+    public List<float[]> embedBatch(@NotNull List<String> texts) throws Exception { // NOSONAR java:S112 — delegates to Embedder.embed()
         ensureInitialized();
 
         List<float[]> results = new ArrayList<>(texts.size());

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupRespondTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupRespondTool.java
@@ -15,7 +15,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Resolves a pending {@link PendingPopupService.Pending} popup by re-running the original
@@ -240,7 +242,7 @@ public final class PopupRespondTool extends QualityTool {
 
     private static String invokeReplay(@NotNull Replayable replayable,
                                        @NotNull JsonObject args,
-                                       @NotNull PopupHandler.SelectByValue handler) throws Exception {
+                                       @NotNull PopupHandler.SelectByValue handler) throws InterruptedException, ExecutionException, TimeoutException {
         // Replay needs to run on the EDT (same as the original execute()) because most quality
         // tools dispatch their core work via EdtUtil.invokeLater. Calling replay directly from
         // an MCP worker thread would just chain another invokeLater — that's fine, but we

--- a/plugin-experimental/src/main/java/com/github/catatafishen/agentbridge/experimental/psi/tools/database/ExecuteQueryTool.java
+++ b/plugin-experimental/src/main/java/com/github/catatafishen/agentbridge/experimental/psi/tools/database/ExecuteQueryTool.java
@@ -14,6 +14,8 @@ import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
+import java.rmi.RemoteException;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -136,7 +138,7 @@ public final class ExecuteQueryTool extends DatabaseTool {
     private static @NotNull String formatResultSet(
         @NotNull RemoteResultSet rs,
         @NotNull String dataSourceName,
-        int maxRows) throws Exception {
+        int maxRows) throws SQLException, RemoteException {
         RemoteResultSetMetaData meta = rs.getMetaData();
         int colCount = meta.getColumnCount();
 


### PR DESCRIPTION
## Changes

**Narrowed exception signatures** (private methods with no contract obligations):
- `PopupRespondTool.invokeReplay`: `throws Exception` → `throws InterruptedException, ExecutionException, TimeoutException`
- `ExecuteQueryTool.formatResultSet`: `throws Exception` → `throws SQLException, RemoteException`

**Suppressed with NOSONAR** (intentional API contracts with explanatory comments):
- `Embedder.embed` — generic `@FunctionalInterface` allowing any embedding backend (ML, I/O, test fakes)
- `EmbeddingService.InferenceFunction.run` — mirrors Embedder contract
- `EmbeddingService.embed/embedBatch` — `@Override` of Embedder interface
- `AbstractAgentClient.start/createSession/sendPrompt` — abstract class with 13+ subclasses throwing diverse checked exceptions; narrowing would be a breaking API change

Addresses all 7 S112 findings across 5 files.