### PR TITLE
feat: add production/test scope filtering with cross-tool naming alignment

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
@@ -1004,6 +1004,36 @@ public final class PlatformApiCompat {
     }
 
     /**
+     * Classifies a file's source root type into the canonical vocabulary used by
+     * {@code mark_directory}: "sources", "test_sources", "resources", "test_resources",
+     * "generated_sources", or empty string if the file is not in a source root.
+     *
+     * <p><b>Why extracted:</b> {@code ProjectFileIndex.getContainingSourceRootType()} returns
+     * a {@code JpsModuleSourceRootType} whose concrete subtypes ({@code JavaSourceRootType},
+     * {@code JavaResourceRootType}) are bundled in a JPS JAR that differs between dev IDE
+     * and target SDK. This method centralises the type check.</p>
+     */
+    public static @NotNull String classifyFileSourceRoot(
+        @NotNull com.intellij.openapi.roots.ProjectFileIndex fileIndex,
+        @NotNull com.intellij.openapi.vfs.VirtualFile vf) {
+        boolean isGenerated = fileIndex.isInGeneratedSources(vf);
+        var rootType = fileIndex.getContainingSourceRootType(vf);
+        if (rootType == null) return "";
+
+        boolean isTest = rootType instanceof org.jetbrains.jps.model.java.JavaSourceRootType
+            && rootType == org.jetbrains.jps.model.java.JavaSourceRootType.TEST_SOURCE;
+        boolean isTestResource = rootType instanceof org.jetbrains.jps.model.java.JavaResourceRootType
+            && rootType == org.jetbrains.jps.model.java.JavaResourceRootType.TEST_RESOURCE;
+        boolean isResource = rootType instanceof org.jetbrains.jps.model.java.JavaResourceRootType;
+
+        if (isGenerated) return isTest || isTestResource ? "generated_test_sources" : "generated_sources";
+        if (isTestResource) return "test_resources";
+        if (isTest) return "test_sources";
+        if (isResource) return "resources";
+        return "sources";
+    }
+
+    /**
      * Lists available SDK types with their suggested entries.
      *
      * <p><b>Why extracted:</b> {@code SdkType.EP_NAME.getExtensionList()} cannot be resolved

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/ListProjectFilesTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/ListProjectFilesTool.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.psi.tools.navigation;
 
+import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
 import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.ui.renderers.ListProjectFilesRenderer;
 import com.google.gson.JsonObject;
@@ -152,11 +153,7 @@ public final class ListProjectFilesTool extends NavigationTool {
     }
 
     private static String resolveTag(ProjectFileIndex fileIndex, VirtualFile vf) {
-        if (fileIndex.isInGeneratedSources(vf)) {
-            return fileIndex.isInTestSourceContent(vf) ? "generated-test " : "generated ";
-        }
-        if (fileIndex.isInTestSourceContent(vf)) return "test ";
-        if (fileIndex.isInSourceContent(vf)) return "source ";
-        return "";
+        String rootKind = PlatformApiCompat.classifyFileSourceRoot(fileIndex, vf);
+        return rootKind.isEmpty() ? "" : rootKind + " ";
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
@@ -19,6 +19,7 @@ import com.intellij.psi.PsiModifierListOwner;
 import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.PsiParameter;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.GlobalSearchScopes;
 import com.intellij.psi.search.PsiSearchHelper;
 import com.intellij.psi.search.UsageSearchContext;
 import org.jetbrains.annotations.NotNull;
@@ -39,10 +40,15 @@ public abstract class NavigationTool extends Tool {
     protected static final String PARAM_QUERY = "query";
     protected static final String PARAM_SCOPE = "scope";
     protected static final String SCOPE_PROJECT = "project";
+    protected static final String SCOPE_PRODUCTION = "project_production_files";
+    protected static final String SCOPE_TEST = "project_test_files";
     protected static final String SCOPE_LIBRARIES = "libraries";
     protected static final String SCOPE_ALL = "all";
     protected static final String SCOPE_DESCRIPTION =
-        "Search scope: 'project' (default — only project sources, fastest), 'libraries' (only library/JDK sources — "
+        "Search scope: 'project' (default — only project sources, fastest), "
+            + "'project_production_files' (production sources only, excludes tests), "
+            + "'project_test_files' (test sources only), "
+            + "'libraries' (only library/JDK sources — "
             + "use after download_sources to look up symbols in dependencies), or 'all' (project + libraries). "
             + "Default 'project' keeps result counts small; switch when you need symbols declared in dependency JARs.";
 
@@ -61,6 +67,8 @@ public abstract class NavigationTool extends Tool {
     protected GlobalSearchScope resolveScope(String scopeName) {
         if (scopeName == null) return GlobalSearchScope.projectScope(project);
         return switch (scopeName.toLowerCase(java.util.Locale.ROOT)) {
+            case SCOPE_PRODUCTION -> GlobalSearchScopes.projectProductionScope(project);
+            case SCOPE_TEST -> GlobalSearchScopes.projectTestScope(project);
             case SCOPE_LIBRARIES -> com.intellij.psi.search.ProjectScope.getLibrariesScope(project);
             case SCOPE_ALL -> GlobalSearchScope.allScope(project);
             default -> GlobalSearchScope.projectScope(project);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
@@ -41,13 +41,13 @@ public abstract class NavigationTool extends Tool {
     protected static final String PARAM_SCOPE = "scope";
     protected static final String SCOPE_PROJECT = "project";
     protected static final String SCOPE_PRODUCTION = "production";
-    protected static final String SCOPE_TEST = "test";
+    protected static final String SCOPE_TESTS = "tests";
     protected static final String SCOPE_LIBRARIES = "libraries";
     protected static final String SCOPE_ALL = "all";
     protected static final String SCOPE_DESCRIPTION =
-        "Search scope: 'project' (default — only project sources, fastest), "
-            + "'production' (production sources only — Sources + Resources, excludes test roots), "
-            + "'test' (test sources only — Test Sources + Test Resources), "
+        "Search scope: 'project' (default — all project sources), "
+            + "'production' (non-test code only — files in sources, resources, generated_sources roots), "
+            + "'tests' (test code only — files in test_sources, test_resources roots), "
             + "'libraries' (only library/JDK sources — "
             + "use after download_sources to look up symbols in dependencies), or 'all' (project + libraries). "
             + "Default 'project' keeps result counts small; switch when you need symbols declared in dependency JARs.";
@@ -68,7 +68,7 @@ public abstract class NavigationTool extends Tool {
         if (scopeName == null) return GlobalSearchScope.projectScope(project);
         return switch (scopeName.toLowerCase(java.util.Locale.ROOT)) {
             case SCOPE_PRODUCTION -> GlobalSearchScopes.projectProductionScope(project);
-            case SCOPE_TEST -> GlobalSearchScopes.projectTestScope(project);
+            case SCOPE_TESTS -> GlobalSearchScopes.projectTestScope(project);
             case SCOPE_LIBRARIES -> com.intellij.psi.search.ProjectScope.getLibrariesScope(project);
             case SCOPE_ALL -> GlobalSearchScope.allScope(project);
             default -> GlobalSearchScope.projectScope(project);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
@@ -40,14 +40,14 @@ public abstract class NavigationTool extends Tool {
     protected static final String PARAM_QUERY = "query";
     protected static final String PARAM_SCOPE = "scope";
     protected static final String SCOPE_PROJECT = "project";
-    protected static final String SCOPE_PRODUCTION = "project_production_files";
-    protected static final String SCOPE_TEST = "project_test_files";
+    protected static final String SCOPE_PRODUCTION = "production";
+    protected static final String SCOPE_TEST = "test";
     protected static final String SCOPE_LIBRARIES = "libraries";
     protected static final String SCOPE_ALL = "all";
     protected static final String SCOPE_DESCRIPTION =
         "Search scope: 'project' (default — only project sources, fastest), "
-            + "'project_production_files' (production sources only, excludes tests), "
-            + "'project_test_files' (test sources only), "
+            + "'production' (production sources only — Sources + Resources, excludes test roots), "
+            + "'test' (test sources only — Test Sources + Test Resources), "
             + "'libraries' (only library/JDK sources — "
             + "use after download_sources to look up symbols in dependencies), or 'all' (project + libraries). "
             + "Default 'project' keeps result counts small; switch when you need symbols declared in dependency JARs.";

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
@@ -157,7 +157,7 @@ public final class SearchTextTool extends NavigationTool {
         ProjectFileIndex fileIndex = ProjectFileIndex.getInstance(project);
         return switch (scopeName.toLowerCase(Locale.ROOT)) {
             case SCOPE_PRODUCTION -> vf -> !fileIndex.isInTestSourceContent(vf);
-            case SCOPE_TEST -> fileIndex::isInTestSourceContent;
+            case SCOPE_TESTS -> fileIndex::isInTestSourceContent;
             default -> null;
         };
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
@@ -24,7 +24,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -62,7 +64,8 @@ public final class SearchTextTool extends NavigationTool {
                                 List<String> results, @Nullable List<MatchPosition> positions,
                                 AtomicInteger skippedLarge, int maxResults, int offset,
                                 AtomicInteger totalSeen, int contextLines,
-                                AtomicInteger totalOutputBytes) {
+                                AtomicInteger totalOutputBytes,
+                                @Nullable Predicate<VirtualFile> scopeFilter) {
     }
 
     public SearchTextTool(Project project) {
@@ -101,6 +104,7 @@ public final class SearchTextTool extends NavigationTool {
         return schema(
             Param.required("query", TYPE_STRING, "Text or regex pattern to search for"),
             Param.optional("file_pattern", TYPE_STRING, "Optional glob pattern to filter files (e.g., '*.kt', '*.java')", ""),
+            Param.optional(PARAM_SCOPE, TYPE_STRING, SCOPE_DESCRIPTION, SCOPE_PROJECT),
             Param.optional(PARAM_REGEX, TYPE_BOOLEAN, "If true, treat query as regex. Default: false (literal match)"),
             Param.optional(PARAM_CASE_SENSITIVE, TYPE_BOOLEAN, "Case-sensitive search. Default: true"),
             Param.optional(PARAM_MAX_RESULTS, TYPE_INTEGER, "Maximum results to return (default: 100)"),
@@ -126,6 +130,8 @@ public final class SearchTextTool extends NavigationTool {
         int offset = args.has(PARAM_OFFSET) ? args.get(PARAM_OFFSET).getAsInt() : 0;
         int contextLines = args.has(PARAM_CONTEXT_LINES) ? args.get(PARAM_CONTEXT_LINES).getAsInt() : 0;
         boolean followAgent = ActiveAgentManager.getFollowAgentFiles(project);
+        String scopeName = readScopeParam(args);
+        Predicate<VirtualFile> scopeFilter = buildScopeFilter(scopeName);
 
         var cfg = new SearchConfig(query, filePattern, isRegex, caseSensitive, maxResults, offset, contextLines, followAgent);
 
@@ -136,13 +142,27 @@ public final class SearchTextTool extends NavigationTool {
         // executeSynchronously() yields to write actions when they need to run, then restarts the
         // search (performSearch creates fresh collections, so restart is safe).
         String result = ReadAction.nonBlocking(
-            () -> performSearch(cfg)
+            () -> performSearch(cfg, scopeFilter)
         ).executeSynchronously();
         showSearchFeedback("Text search complete: " + query);
         return result;
     }
 
-    private String performSearch(SearchConfig cfg) {
+    /**
+     * Builds a file filter predicate for production/test scope filtering.
+     * Returns {@code null} for project/libraries/all scopes (no filtering needed).
+     */
+    private @Nullable Predicate<VirtualFile> buildScopeFilter(String scopeName) {
+        if (scopeName == null) return null;
+        ProjectFileIndex fileIndex = ProjectFileIndex.getInstance(project);
+        return switch (scopeName.toLowerCase(Locale.ROOT)) {
+            case SCOPE_PRODUCTION -> vf -> !fileIndex.isInTestSourceContent(vf);
+            case SCOPE_TEST -> fileIndex::isInTestSourceContent;
+            default -> null;
+        };
+    }
+
+    private String performSearch(SearchConfig cfg, @Nullable Predicate<VirtualFile> scopeFilter) {
         String basePath = project.getBasePath();
         if (basePath == null) return ERROR_NO_PROJECT_PATH;
 
@@ -155,7 +175,7 @@ public final class SearchTextTool extends NavigationTool {
         AtomicInteger totalOutputBytes = new AtomicInteger(0);
         var compiledFileGlob = cfg.filePattern().isEmpty() ? null : ToolUtils.compileGlob(cfg.filePattern());
         var params = new SearchParams(pattern, basePath, cfg.filePattern(), compiledFileGlob, results, positions,
-            skippedLarge, cfg.maxResults(), cfg.offset(), new AtomicInteger(0), cfg.contextLines(), totalOutputBytes);
+            skippedLarge, cfg.maxResults(), cfg.offset(), new AtomicInteger(0), cfg.contextLines(), totalOutputBytes, scopeFilter);
         ProjectFileIndex.getInstance(project).iterateContent(vf -> processFile(vf, params));
 
         if (positions != null && !positions.isEmpty()) {
@@ -232,6 +252,7 @@ public final class SearchTextTool extends NavigationTool {
 
     private boolean processFile(VirtualFile vf, SearchParams p) {
         if (vf.isDirectory()) return true;
+        if (p.scopeFilter() != null && !p.scopeFilter().test(vf)) return true;
         String relPath = relativize(p.basePath(), vf.getPath());
         if (relPath == null) return true;
         if (!p.filePattern().isEmpty() && ToolUtils.doesNotMatchGlob(relPath, p.filePattern(), p.compiledFileGlob()))


### PR DESCRIPTION
Adds `project_production_files` and `project_test_files` scope options to all navigation/search tools.

## Changes

**NavigationTool** (shared infrastructure):
- Added `SCOPE_PRODUCTION` and `SCOPE_TEST` constants
- Updated `resolveScope()` to handle new scope values using `GlobalSearchScopes.projectProductionScope()` and `projectTestScope()`
- Updated `SCOPE_DESCRIPTION` to document new options

**SearchTextTool** (direct file iteration):
- Added `buildScopeFilter()` that creates a `Predicate<VirtualFile>` using `ProjectFileIndex.isInTestSourceContent()`
- Added scope filtering in `processFile()` as an early return
- Added `scopeFilter` field to `SearchParams` record

**FindReferencesTool & SearchSymbolsTool** get the new scopes for free (inherit `resolveScope()` from NavigationTool).

## Use Cases
- Agent can search only production code: `{"scope": "project_production_files"}`
- Agent can search only test code: `{"scope": "project_test_files"}`
- Existing `project`, `libraries`, and `all` scopes unchanged