### PR TITLE
feat: add depth parameter to call hierarchy tool

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/CallHierarchySupport.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/CallHierarchySupport.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Language-agnostic call hierarchy support.
@@ -30,27 +32,28 @@ public class CallHierarchySupport {
     }
 
     /**
-     * Finds all callers of the named element at the given file/line.
+     * Finds all callers of the named element at the given file/line, up to the given depth.
      * Must be called inside a read action.
+     *
+     * @param depth how many levels to traverse (1 = direct callers only)
      */
     public static String getCallHierarchy(@NotNull Project project, @NotNull String elementName,
-                                          @NotNull String filePath, int line) {
+                                          @NotNull String filePath, int line, int depth) {
         PsiNameIdentifierOwner element = resolveNamedElementAtLocation(project, filePath, line, elementName);
         if (element == null) {
             return "Error: Could not find '" + elementName + "' at " + filePath + ":" + line;
         }
 
-        Collection<PsiReference> references = ReferencesSearch.search(
-            element, GlobalSearchScope.projectScope(project)).findAll();
-        if (references.isEmpty()) {
-            return "No callers found for: " + formatElementSignature(element);
-        }
-
         String basePath = project.getBasePath();
         StringBuilder sb = new StringBuilder();
-        sb.append("Callers of ").append(formatElementSignature(element)).append(":\n\n");
-        for (PsiReference ref : references) {
-            appendCallerInfo(sb, ref, basePath);
+        sb.append("Callers of ").append(formatElementSignature(element)).append(":\n");
+
+        Set<PsiElement> visited = new HashSet<>();
+        visited.add(element);
+        collectCallers(sb, element, project, basePath, visited, 1, depth);
+
+        if (sb.indexOf("\n  ") == -1) {
+            return "No callers found for: " + formatElementSignature(element);
         }
         return sb.toString();
     }
@@ -64,16 +67,28 @@ public class CallHierarchySupport {
         return ToolUtils.findNamedElement(ctx, elementName);
     }
 
-    private static void appendCallerInfo(@NotNull StringBuilder sb, @NotNull PsiReference ref,
-                                         @Nullable String basePath) {
-        PsiElement element = ref.getElement();
-        // Walk up the PSI tree to find the nearest named containing element (function/method/class)
-        PsiNamedElement containingNamed = PsiTreeUtil.getParentOfType(element, PsiNamedElement.class);
+    private static void collectCallers(@NotNull StringBuilder sb, @NotNull PsiElement target,
+                                       @NotNull Project project, @Nullable String basePath,
+                                       @NotNull Set<PsiElement> visited, int currentDepth, int maxDepth) {
+        Collection<PsiReference> references = ReferencesSearch.search(
+            target, GlobalSearchScope.projectScope(project)).findAll();
 
-        sb.append("  ");
-        sb.append(containingNamed != null ? containingNamed.getName() : "(top level)");
-        appendFileLocation(sb, element, basePath);
-        sb.append("\n");
+        String indent = "  ".repeat(currentDepth);
+        for (PsiReference ref : references) {
+            PsiElement element = ref.getElement();
+            PsiNamedElement containingNamed = PsiTreeUtil.getParentOfType(element, PsiNamedElement.class);
+
+            sb.append(indent);
+            sb.append(containingNamed != null ? containingNamed.getName() : "(top level)");
+            appendFileLocation(sb, element, basePath);
+            sb.append("\n");
+
+            // Recurse into callers if we haven't reached max depth and the containing element is new
+            if (currentDepth < maxDepth && containingNamed instanceof PsiNameIdentifierOwner named
+                && visited.add(named)) {
+                collectCallers(sb, named, project, basePath, visited, currentDepth + 1, maxDepth);
+            }
+        }
     }
 
     private static void appendFileLocation(@NotNull StringBuilder sb, @NotNull PsiElement element,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetCallHierarchyTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetCallHierarchyTool.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.psi.tools.refactoring;
 
+import com.github.catatafishen.agentbridge.psi.CallHierarchySupport;
 import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.ui.renderers.SearchResultRenderer;
 import com.google.gson.JsonObject;
@@ -37,7 +38,8 @@ public final class GetCallHierarchyTool extends RefactoringTool {
 
     @Override
     public @NotNull String description() {
-        return "Find all callers of a function, method, or named element with file paths and line numbers";
+        return "Find all callers of a function, method, or named element with file paths and line numbers. "
+            + "Use 'depth' to traverse multiple levels (e.g., depth=2 finds callers of callers).";
     }
 
     @Override
@@ -55,7 +57,9 @@ public final class GetCallHierarchyTool extends RefactoringTool {
         return schema(
             Param.required(PARAM_SYMBOL, TYPE_STRING, "Function, method, or named element to find callers for"),
             Param.required("file", TYPE_STRING, "Path to the file containing the definition"),
-            Param.required("line", TYPE_INTEGER, "Line number where the definition is located")
+            Param.required("line", TYPE_INTEGER, "Line number where the definition is located"),
+            Param.optional("depth", TYPE_INTEGER, "How many levels of callers to traverse (default: 1, max: 5). "
+                + "depth=1 finds direct callers, depth=2 also finds callers of those callers, etc.")
         );
     }
 
@@ -72,10 +76,13 @@ public final class GetCallHierarchyTool extends RefactoringTool {
         String elementName = args.get(PARAM_SYMBOL).getAsString();
         String filePath = args.get("file").getAsString();
         int line = args.get("line").getAsInt();
+        int depth = args.has("depth") ? Math.min(args.get("depth").getAsInt(), 5) : 1;
+        if (depth < 1) depth = 1;
 
+        int finalDepth = depth;
         String result = ApplicationManager.getApplication().runReadAction(
-            (Computable<String>) () -> com.github.catatafishen.agentbridge.psi.CallHierarchySupport
-                .getCallHierarchy(project, elementName, filePath, line)
+            (Computable<String>) () -> CallHierarchySupport
+                .getCallHierarchy(project, elementName, filePath, line, finalDepth)
         );
         return ToolUtils.truncateOutput(result);
     }


### PR DESCRIPTION
Adds a `depth` parameter (default: 1, max: 5) to the `get_call_hierarchy` tool.

## Changes

**GetCallHierarchyTool**:
- Added `depth` parameter to `inputSchema()` with description
- Updated `execute()` to read and clamp depth (1-5)
- Updated description to mention depth capability

**CallHierarchySupport**:
- Added `depth` parameter to `getCallHierarchy()`
- New recursive `collectCallers()` method with cycle detection via `Set<PsiElement>`
- Results indented by depth level for readability
- Removed old flat `appendCallerInfo()` method

## Example
```json
{"symbol": "processFile", "file": "SearchTextTool.java", "line": 223, "depth": 2}
```
Returns direct callers + callers of those callers, indented.