### PR TITLE
feat: increase index wait timeout from 2s to 30s

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolReadinessGate.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolReadinessGate.java
@@ -29,7 +29,7 @@ public final class ToolReadinessGate {
     private static final Logger LOG = Logger.getInstance(ToolReadinessGate.class);
 
     /** How long we opportunistically wait for indexing to finish. */
-    static final long INDEX_WAIT_MS = 2_000L;
+    static final long INDEX_WAIT_MS = 30_000L;
 
     /** How long we opportunistically wait for project initialisation. */
     static final long PROJECT_INIT_WAIT_MS = 2_000L;
@@ -74,9 +74,9 @@ public final class ToolReadinessGate {
 
     @NotNull
     public static String indexingErrorMessage(@NotNull String toolName) {
-        return "Error: IDE is indexing. Tool '" + toolName
+        return "Error: IDE is still indexing after waiting 30s. Tool '" + toolName
             + "' depends on the symbol index, which is not yet ready. "
-            + "Call get_indexing_status with wait=true to be notified when indexing finishes, then retry.";
+            + "Call get_indexing_status with wait=true to wait longer, then retry.";
     }
 
     @NotNull


### PR DESCRIPTION
Tools that require the symbol index now wait up to 30 seconds for indexing to complete before returning an error.

Previously, the 2-second timeout was too aggressive — most indexing pauses resolve in 5-15 seconds, but the short timeout forced agents to manually poll `get_indexing_status`. Now the tool call transparently blocks until indexing finishes, and only errors if indexing takes longer than 30s.

**Change:**
- `INDEX_WAIT_MS`: 2,000 → 30,000
- Updated error message to reflect the wait already occurred

**User decision:** 'The tool call should just wait for indexing to complete. The agent can wait a few seconds for that.'