### PR TITLE
feat: add line range support to format_code tool

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/FormatCodeTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/FormatCodeTool.java
@@ -14,10 +14,10 @@ import org.jetbrains.annotations.NotNull;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-/**
- * Formats a file using IntelliJ's configured code style.
- */
 public final class FormatCodeTool extends QualityTool {
+
+    private static final String PARAM_START_LINE = "start_line";
+    private static final String PARAM_END_LINE = "end_line";
 
     public FormatCodeTool(Project project) {
         super(project);
@@ -54,16 +54,16 @@ public final class FormatCodeTool extends QualityTool {
     public @NotNull JsonObject inputSchema() {
         return schema(
             Param.required("path", TYPE_STRING, "Absolute or project-relative path to the file to format"),
-            Param.optional("start_line", TYPE_INTEGER, "First line to format (1-based). If omitted, formats the entire file."),
-            Param.optional("end_line", TYPE_INTEGER, "Last line to format (1-based, inclusive). If omitted, formats to end of file.")
+            Param.optional(PARAM_START_LINE, TYPE_INTEGER, "First line to format (1-based). If omitted, formats the entire file."),
+            Param.optional(PARAM_END_LINE, TYPE_INTEGER, "Last line to format (1-based, inclusive). If omitted, formats to end of file.")
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         String pathStr = args.get("path").getAsString();
-        int startLine = args.has("start_line") ? args.get("start_line").getAsInt() : -1;
-        int endLine = args.has("end_line") ? args.get("end_line").getAsInt() : -1;
+        int startLine = args.has(PARAM_START_LINE) ? args.get(PARAM_START_LINE).getAsInt() : -1;
+        int endLine = args.has(PARAM_END_LINE) ? args.get(PARAM_END_LINE).getAsInt() : -1;
 
         CompletableFuture<String> resultFuture = new CompletableFuture<>();
         EdtUtil.invokeLater(() -> {
@@ -72,27 +72,9 @@ public final class FormatCodeTool extends QualityTool {
                 if (pair == null) return;
                 WriteCommandAction.runWriteCommandAction(project, "Reformat Code", null, () -> {
                     PsiDocumentManager.getInstance(project).commitAllDocuments();
-                    if (startLine > 0) {
-                        Document doc = PsiDocumentManager.getInstance(project).getDocument(pair.psiFile());
-                        if (doc != null) {
-                            int start = doc.getLineStartOffset(Math.max(0, startLine - 1));
-                            int actualEnd = endLine > 0 ? endLine : doc.getLineCount();
-                            int end = doc.getLineEndOffset(Math.min(doc.getLineCount() - 1, actualEnd - 1));
-                            TextRange range = new TextRange(start, end);
-                            new com.intellij.codeInsight.actions.ReformatCodeProcessor(project, pair.psiFile(), range, false).run();
-                        } else {
-                            new com.intellij.codeInsight.actions.ReformatCodeProcessor(pair.psiFile(), false).run();
-                        }
-                    } else {
-                        new com.intellij.codeInsight.actions.ReformatCodeProcessor(pair.psiFile(), false).run();
-                    }
+                    reformatFile(pair, startLine, endLine);
                 });
-                String relPath = project.getBasePath() != null
-                    ? relativize(project.getBasePath(), pair.vf().getPath()) : pathStr;
-                String rangeInfo = startLine > 0
-                    ? " (lines " + startLine + "-" + (endLine > 0 ? endLine : "end") + ")"
-                    : "";
-                resultFuture.complete("Code formatted: " + relPath + rangeInfo);
+                resultFuture.complete(buildSuccessMessage(pathStr, pair, startLine, endLine));
             } catch (Exception e) {
                 resultFuture.complete("Error formatting code: " + e.getMessage());
             }
@@ -103,6 +85,30 @@ public final class FormatCodeTool extends QualityTool {
                 FileTool.HIGHLIGHT_EDIT, FileTool.agentLabel(project) + " formatted");
         }
         return result;
+    }
+
+    private void reformatFile(FilePair pair, int startLine, int endLine) {
+        if (startLine <= 0) {
+            new com.intellij.codeInsight.actions.ReformatCodeProcessor(pair.psiFile(), false).run();
+            return;
+        }
+        Document doc = PsiDocumentManager.getInstance(project).getDocument(pair.psiFile());
+        if (doc == null) {
+            new com.intellij.codeInsight.actions.ReformatCodeProcessor(pair.psiFile(), false).run();
+            return;
+        }
+        int start = doc.getLineStartOffset(Math.max(0, startLine - 1));
+        int actualEnd = endLine > 0 ? endLine : doc.getLineCount();
+        int end = doc.getLineEndOffset(Math.min(doc.getLineCount() - 1, actualEnd - 1));
+        new com.intellij.codeInsight.actions.ReformatCodeProcessor(project, pair.psiFile(), new TextRange(start, end), false).run();
+    }
+
+    private String buildSuccessMessage(String pathStr, FilePair pair, int startLine, int endLine) {
+        String relPath = project.getBasePath() != null
+            ? relativize(project.getBasePath(), pair.vf().getPath()) : pathStr;
+        if (startLine <= 0) return "Code formatted: " + relPath;
+        String endLabel = endLine > 0 ? String.valueOf(endLine) : "end";
+        return "Code formatted: " + relPath + " (lines " + startLine + "-" + endLabel + ")";
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/FormatCodeTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/FormatCodeTool.java
@@ -5,7 +5,9 @@ import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
 import com.github.catatafishen.agentbridge.ui.renderers.SimpleStatusRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiDocumentManager;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +36,7 @@ public final class FormatCodeTool extends QualityTool {
     @Override
     public @NotNull String description() {
         return "Manually format a file using IntelliJ's configured code style. "
+            + "Supports partial formatting via start_line/end_line parameters. "
             + "Useful after edit_text match failures to normalize whitespace before retrying.";
     }
 
@@ -50,13 +53,18 @@ public final class FormatCodeTool extends QualityTool {
     @Override
     public @NotNull JsonObject inputSchema() {
         return schema(
-            Param.required("path", TYPE_STRING, "Absolute or project-relative path to the file to format")
+            Param.required("path", TYPE_STRING, "Absolute or project-relative path to the file to format"),
+            Param.optional("start_line", TYPE_INTEGER, "First line to format (1-based). If omitted, formats the entire file."),
+            Param.optional("end_line", TYPE_INTEGER, "Last line to format (1-based, inclusive). If omitted, formats to end of file.")
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         String pathStr = args.get("path").getAsString();
+        int startLine = args.has("start_line") ? args.get("start_line").getAsInt() : -1;
+        int endLine = args.has("end_line") ? args.get("end_line").getAsInt() : -1;
+
         CompletableFuture<String> resultFuture = new CompletableFuture<>();
         EdtUtil.invokeLater(() -> {
             try {
@@ -64,11 +72,27 @@ public final class FormatCodeTool extends QualityTool {
                 if (pair == null) return;
                 WriteCommandAction.runWriteCommandAction(project, "Reformat Code", null, () -> {
                     PsiDocumentManager.getInstance(project).commitAllDocuments();
-                    new com.intellij.codeInsight.actions.ReformatCodeProcessor(pair.psiFile(), false).run();
+                    if (startLine > 0) {
+                        Document doc = PsiDocumentManager.getInstance(project).getDocument(pair.psiFile());
+                        if (doc != null) {
+                            int start = doc.getLineStartOffset(Math.max(0, startLine - 1));
+                            int actualEnd = endLine > 0 ? endLine : doc.getLineCount();
+                            int end = doc.getLineEndOffset(Math.min(doc.getLineCount() - 1, actualEnd - 1));
+                            TextRange range = new TextRange(start, end);
+                            new com.intellij.codeInsight.actions.ReformatCodeProcessor(project, pair.psiFile(), range, false).run();
+                        } else {
+                            new com.intellij.codeInsight.actions.ReformatCodeProcessor(pair.psiFile(), false).run();
+                        }
+                    } else {
+                        new com.intellij.codeInsight.actions.ReformatCodeProcessor(pair.psiFile(), false).run();
+                    }
                 });
                 String relPath = project.getBasePath() != null
                     ? relativize(project.getBasePath(), pair.vf().getPath()) : pathStr;
-                resultFuture.complete("Code formatted: " + relPath);
+                String rangeInfo = startLine > 0
+                    ? " (lines " + startLine + "-" + (endLine > 0 ? endLine : "end") + ")"
+                    : "";
+                resultFuture.complete("Code formatted: " + relPath + rangeInfo);
             } catch (Exception e) {
                 resultFuture.complete("Error formatting code: " + e.getMessage());
             }


### PR DESCRIPTION
Adds optional `start_line`/`end_line` parameters to `format_code` for partial file formatting.

## Changes
- Added `start_line` (1-based) and `end_line` (1-based, inclusive) optional parameters
- When provided, uses `ReformatCodeProcessor(project, file, TextRange, false)` for targeted formatting
- When omitted, formats entire file (backward compatible)
- Updated description to mention partial formatting
- Response includes line range info when partial format was used

## Use Cases
- Format only newly added methods without touching the rest of the file
- Normalize whitespace in a specific section after a failed `edit_text` match