### PR TITLE
fix: add INFO-level model list logging for stale-model diagnosis

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
@@ -360,8 +360,7 @@ public abstract class AcpClient extends AbstractAgentClient {
             LOG.debug(displayName() + ": session/new raw response: " + result);
 
             NewSessionResponse response = gson.fromJson(result, NewSessionResponse.class);
-            LOG.debug(displayName() + ": session/new: " + (response.models() != null ? response.models().size() : 0) + " model(s), "
-                + (response.modes() != null ? response.modes().size() : 0) + " mode(s)");
+            logModelList("session/new", response.models());
 
             currentSessionId = response.sessionId();
             processSessionResponse(response);
@@ -448,6 +447,21 @@ public abstract class AcpClient extends AbstractAgentClient {
         if (response.configOptions() != null) {
             updateConfigOptions(response);
         }
+    }
+
+    /**
+     * Logs model IDs received from a session response at INFO level.
+     * Aids diagnosis of stale model list reports (ref: issue #416).
+     */
+    private void logModelList(String source, @Nullable List<Model> models) {
+        if (models == null || models.isEmpty()) {
+            LOG.info(displayName() + ": " + source + " returned 0 model(s)");
+            return;
+        }
+        String ids = models.stream()
+            .map(Model::id)
+            .collect(java.util.stream.Collectors.joining(", "));
+        LOG.info(displayName() + ": " + source + " returned " + models.size() + " model(s): [" + ids + "]");
     }
 
     static List<AbstractAgentClient.AgentMode> mapModesStatic(@Nullable List<NewSessionResponse.AvailableMode> modes) {
@@ -573,6 +587,7 @@ public abstract class AcpClient extends AbstractAgentClient {
             // Some agents (e.g. OpenCode's session/resume) return models/modes/configOptions.
             if (result != null && !result.isJsonNull()) {
                 NewSessionResponse response = gson.fromJson(result, NewSessionResponse.class);
+                logModelList(method, response.models());
                 processSessionResponse(response);
             }
         } finally {


### PR DESCRIPTION
Adds INFO-level logging of all model IDs received from `session/new` and `session/load` responses. Previously only the model count was logged at DEBUG level, making it difficult to diagnose reports of stale or missing models in the model picker.

## Changes

**AcpClient.java**:
- Added `logModelList()` helper that logs model count and all model IDs at INFO level
- Called from both `session/new` and `session/load` paths
- Aids diagnosis of stale-model reports (ref: #416)

## Context

Investigation of the model list issue in #416 found **no bug in the plugin's model parsing**. The model list comes 100% from what the Copilot CLI returns in the `session/new` ACP response — there is no cache, fallback, or hardcoded list. Stale models are most likely caused by:
1. An outdated Copilot CLI version that doesn't advertise newer models
2. The schema validation error (fixed in #424) breaking `session/new` entirely

This logging improvement will make it easier to diagnose such reports in the future.

---
*Written by Copilot on behalf of Henrik.*

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>