### PR TITLE
feat: add cursor-based pagination to search/navigation tools

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/FindReferencesTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/FindReferencesTool.java
@@ -13,9 +13,11 @@ import com.intellij.psi.search.PsiSearchHelper;
 import com.intellij.psi.search.UsageSearchContext;
 import com.intellij.psi.search.searches.ReferencesSearch;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Finds all usages of a symbol throughout the project.
@@ -87,7 +89,7 @@ public final class FindReferencesTool extends NavigationTool {
         int offset = pagination[1];
 
         showSearchFeedback("🔍 Finding references: " + symbol);
-        String result = ApplicationManager.getApplication().<String>runReadAction(() -> {
+        String result = ApplicationManager.getApplication().runReadAction((Computable<String>) () -> {
             List<String> results = new ArrayList<>();
             String basePath = project.getBasePath();
             GlobalSearchScope scope = resolveScope(scopeName);
@@ -131,10 +133,9 @@ public final class FindReferencesTool extends NavigationTool {
         PsiSearchHelper.getInstance(project).processElementsWithWord(
             (element, offsetInElement) -> {
                 String entry = buildWordEntry(element, filePattern, compiledGlob, basePath);
-                if (entry != null && !results.contains(entry)) {
-                    if (seen[0]++ >= offset) {
-                        results.add(entry);
-                    }
+                if (entry == null || results.contains(entry)) return results.size() < maxResults;
+                if (seen[0]++ >= offset) {
+                    results.add(entry);
                 }
                 return results.size() < maxResults;
             },

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/FindReferencesTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/FindReferencesTool.java
@@ -64,7 +64,9 @@ public final class FindReferencesTool extends NavigationTool {
         return schema(
             Param.required("symbol", TYPE_STRING, "The exact symbol name to search for"),
             Param.optional("file_pattern", TYPE_STRING, "Optional glob pattern to filter files (e.g., '*.java')", ""),
-            Param.optional(PARAM_SCOPE, TYPE_STRING, SCOPE_DESCRIPTION, SCOPE_PROJECT)
+            Param.optional(PARAM_SCOPE, TYPE_STRING, SCOPE_DESCRIPTION, SCOPE_PROJECT),
+            Param.optional(PARAM_MAX_RESULTS, TYPE_INTEGER, "Maximum results to return (default: 100)"),
+            Param.optional(PARAM_OFFSET, TYPE_INTEGER, "Number of results to skip for pagination (default: 0)")
         );
     }
 
@@ -80,6 +82,9 @@ public final class FindReferencesTool extends NavigationTool {
         String symbol = args.get(PARAM_SYMBOL).getAsString();
         String filePattern = args.has(PARAM_FILE_PATTERN) ? args.get(PARAM_FILE_PATTERN).getAsString() : "";
         String scopeName = readScopeParam(args);
+        int[] pagination = readPaginationParams(args, DEFAULT_MAX_RESULTS);
+        int maxResults = pagination[0];
+        int offset = pagination[1];
 
         showSearchFeedback("🔍 Finding references: " + symbol);
         String result = ApplicationManager.getApplication().runReadAction((Computable<String>) () -> {
@@ -89,31 +94,41 @@ public final class FindReferencesTool extends NavigationTool {
 
             PsiElement definition = findDefinition(symbol, scope);
             if (definition != null) {
-                collectDefinitionReferences(definition, scope, filePattern, basePath, results);
+                collectDefinitionReferences(definition, scope, filePattern, basePath, results, maxResults, offset);
             }
             if (results.isEmpty()) {
-                collectWordReferences(symbol, scope, filePattern, basePath, results);
+                collectWordReferences(symbol, scope, filePattern, basePath, results, maxResults, offset);
             }
             if (results.isEmpty()) return "No references found for '" + symbol + "'";
-            return results.size() + " references found:\n" + String.join("\n", results);
+            String footer = results.size() >= maxResults
+                ? "\n\n(Showing " + maxResults + " results starting at offset " + offset + ". Use offset=" + (offset + maxResults) + " to see more)"
+                : "";
+            return results.size() + " references found:\n" + String.join("\n", results) + footer;
         });
         showSearchFeedback("✓ Reference search complete: " + symbol);
         return result;
     }
 
     private void collectDefinitionReferences(PsiElement definition, GlobalSearchScope scope,
-                                             String filePattern, String basePath, List<String> results) {
+                                             String filePattern, String basePath, List<String> results,
+                                             int maxResults, int offset) {
         var compiledGlob = filePattern.isEmpty() ? null : ToolUtils.compileGlob(filePattern);
+        int seen = 0;
         for (PsiReference ref : ReferencesSearch.search(definition, scope).findAll()) {
-            if (results.size() >= 100) break;
+            if (results.size() >= maxResults) break;
             String entry = buildReferenceEntry(ref, filePattern, compiledGlob, basePath);
-            if (entry != null) results.add(entry);
+            if (entry != null) {
+                if (seen++ < offset) continue;
+                results.add(entry);
+            }
         }
     }
 
     private void collectWordReferences(String symbol, GlobalSearchScope scope,
-                                       String filePattern, String basePath, List<String> results) {
+                                       String filePattern, String basePath, List<String> results,
+                                       int maxResults, int offset) {
         var compiledGlob = filePattern.isEmpty() ? null : ToolUtils.compileGlob(filePattern);
+        int[] seen = {0};
         PsiSearchHelper.getInstance(project).processElementsWithWord(
             (element, offsetInElement) -> {
                 com.intellij.psi.PsiFile file = element.getContainingFile();
@@ -128,9 +143,12 @@ public final class FindReferencesTool extends NavigationTool {
                     int line = doc.getLineNumber(element.getTextOffset()) + 1;
                     String lineText = ToolUtils.getLineText(doc, line - 1);
                     String entry = String.format(FORMAT_LINE_REF, relPath, line, lineText);
-                    if (!results.contains(entry)) results.add(entry);
+                    if (!results.contains(entry)) {
+                        if (seen[0]++ < offset) return true;
+                        results.add(entry);
+                    }
                 }
-                return results.size() < 100;
+                return results.size() < maxResults;
             },
             scope, symbol, UsageSearchContext.IN_CODE, true
         );

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/FindReferencesTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/FindReferencesTool.java
@@ -87,7 +87,7 @@ public final class FindReferencesTool extends NavigationTool {
         int offset = pagination[1];
 
         showSearchFeedback("🔍 Finding references: " + symbol);
-        String result = ApplicationManager.getApplication().runReadAction((Computable<String>) () -> {
+        String result = ApplicationManager.getApplication().<String>runReadAction(() -> {
             List<String> results = new ArrayList<>();
             String basePath = project.getBasePath();
             GlobalSearchScope scope = resolveScope(scopeName);
@@ -117,8 +117,7 @@ public final class FindReferencesTool extends NavigationTool {
         for (PsiReference ref : ReferencesSearch.search(definition, scope).findAll()) {
             if (results.size() >= maxResults) break;
             String entry = buildReferenceEntry(ref, filePattern, compiledGlob, basePath);
-            if (entry != null) {
-                if (seen++ < offset) continue;
+            if (entry != null && seen++ >= offset) {
                 results.add(entry);
             }
         }
@@ -131,20 +130,9 @@ public final class FindReferencesTool extends NavigationTool {
         int[] seen = {0};
         PsiSearchHelper.getInstance(project).processElementsWithWord(
             (element, offsetInElement) -> {
-                com.intellij.psi.PsiFile file = element.getContainingFile();
-                if (file == null || file.getVirtualFile() == null) return true;
-                String relPath = safeRelativize(basePath, file.getVirtualFile().getPath());
-                if (!filePattern.isEmpty() && ToolUtils.doesNotMatchGlob(relPath, filePattern, compiledGlob))
-                    return true;
-
-                com.intellij.openapi.editor.Document doc = com.intellij.openapi.fileEditor.FileDocumentManager.getInstance()
-                    .getDocument(file.getVirtualFile());
-                if (doc != null) {
-                    int line = doc.getLineNumber(element.getTextOffset()) + 1;
-                    String lineText = ToolUtils.getLineText(doc, line - 1);
-                    String entry = String.format(FORMAT_LINE_REF, relPath, line, lineText);
-                    if (!results.contains(entry)) {
-                        if (seen[0]++ < offset) return true;
+                String entry = buildWordEntry(element, filePattern, compiledGlob, basePath);
+                if (entry != null && !results.contains(entry)) {
+                    if (seen[0]++ >= offset) {
                         results.add(entry);
                     }
                 }
@@ -152,5 +140,23 @@ public final class FindReferencesTool extends NavigationTool {
             },
             scope, symbol, UsageSearchContext.IN_CODE, true
         );
+    }
+
+    /**
+     * Builds a reference entry for a word-search element, or returns null if filtered out.
+     */
+    private @Nullable String buildWordEntry(com.intellij.psi.PsiElement element,
+                                            String filePattern, Pattern compiledGlob, String basePath) {
+        com.intellij.psi.PsiFile file = element.getContainingFile();
+        if (file == null || file.getVirtualFile() == null) return null;
+        String relPath = safeRelativize(basePath, file.getVirtualFile().getPath());
+        if (!filePattern.isEmpty() && ToolUtils.doesNotMatchGlob(relPath, filePattern, compiledGlob)) return null;
+
+        com.intellij.openapi.editor.Document doc = com.intellij.openapi.fileEditor.FileDocumentManager.getInstance()
+            .getDocument(file.getVirtualFile());
+        if (doc == null) return null;
+        int line = doc.getLineNumber(element.getTextOffset()) + 1;
+        String lineText = ToolUtils.getLineText(doc, line - 1);
+        return String.format(FORMAT_LINE_REF, relPath, line, lineText);
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
@@ -46,6 +46,10 @@ public abstract class NavigationTool extends Tool {
             + "use after download_sources to look up symbols in dependencies), or 'all' (project + libraries). "
             + "Default 'project' keeps result counts small; switch when you need symbols declared in dependency JARs.";
 
+    protected static final String PARAM_MAX_RESULTS = "max_results";
+    protected static final String PARAM_OFFSET = "offset";
+    protected static final int DEFAULT_MAX_RESULTS = 100;
+
     protected NavigationTool(Project project) {
         super(project);
     }
@@ -67,6 +71,27 @@ public abstract class NavigationTool extends Tool {
         return args.has(PARAM_SCOPE) && !args.get(PARAM_SCOPE).isJsonNull()
             ? args.get(PARAM_SCOPE).getAsString()
             : SCOPE_PROJECT;
+    }
+
+    /**
+     * Reads pagination params (max_results, offset) from tool arguments.
+     * Returns an int array: [maxResults, offset].
+     */
+    protected int[] readPaginationParams(com.google.gson.JsonObject args, int defaultMax) {
+        int maxResults = args.has(PARAM_MAX_RESULTS) ? args.get(PARAM_MAX_RESULTS).getAsInt() : defaultMax;
+        int offset = args.has(PARAM_OFFSET) ? args.get(PARAM_OFFSET).getAsInt() : 0;
+        return new int[]{maxResults, offset};
+    }
+
+    /**
+     * Builds a pagination footer when results were limited.
+     * Returns empty string if all results fit, otherwise returns hint with next offset.
+     */
+    protected static String paginationFooter(int totalFound, int offset, int maxResults) {
+        int nextOffset = offset + maxResults;
+        if (totalFound <= offset + maxResults) return "";
+        return "\n\n(Showing " + maxResults + " of " + totalFound + " results. "
+            + "Use offset=" + nextOffset + " to see more)";
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchSymbolsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchSymbolsTool.java
@@ -72,7 +72,9 @@ public final class SearchSymbolsTool extends NavigationTool {
         return schema(
             Param.required("query", TYPE_STRING, "Symbol name to search for, or '*' to list all symbols in the project"),
             Param.optional("type", TYPE_STRING, "Optional: filter by type (class, method, field, property). Default: all types", ""),
-            Param.optional(PARAM_SCOPE, TYPE_STRING, SCOPE_DESCRIPTION, SCOPE_PROJECT)
+            Param.optional(PARAM_SCOPE, TYPE_STRING, SCOPE_DESCRIPTION, SCOPE_PROJECT),
+            Param.optional(PARAM_MAX_RESULTS, TYPE_INTEGER, "Maximum results to return (default: 50 for exact, 200 for wildcard)"),
+            Param.optional(PARAM_OFFSET, TYPE_INTEGER, "Number of results to skip for pagination (default: 0)")
         );
     }
 
@@ -86,6 +88,9 @@ public final class SearchSymbolsTool extends NavigationTool {
         String query = args.has(PARAM_QUERY) ? args.get(PARAM_QUERY).getAsString() : "";
         String typeFilter = args.has("type") ? args.get("type").getAsString() : "";
         String scopeName = readScopeParam(args);
+        int[] pagination = readPaginationParams(args, -1); // -1 means "use per-mode default"
+        int maxResults = pagination[0];
+        int offset = pagination[1];
 
         showSearchFeedback("🔍 Searching symbols: " + query);
         String result = ApplicationManager.getApplication().runReadAction((Computable<String>) () -> {
@@ -94,15 +99,15 @@ public final class SearchSymbolsTool extends NavigationTool {
                     return "Error: Wildcard symbol listing is only supported with scope='project'. "
                         + "Use an exact query name when searching scope='libraries' or scope='all'.";
                 }
-                return searchWildcard(typeFilter);
+                return searchWildcard(typeFilter, maxResults > 0 ? maxResults : 200, offset);
             }
-            return searchExact(query, typeFilter, resolveScope(scopeName));
+            return searchExact(query, typeFilter, resolveScope(scopeName), maxResults > 0 ? maxResults : 50, offset);
         });
         showSearchFeedback("✓ Symbol search complete: " + query);
         return result;
     }
 
-    private String searchWildcard(String typeFilter) {
+    private String searchWildcard(String typeFilter, int maxResults, int offset) {
         if (typeFilter.isEmpty())
             return "Provide a 'type' filter (class, interface, method, field) when using wildcard query";
 
@@ -122,16 +127,24 @@ public final class SearchSymbolsTool extends NavigationTool {
             if (doc == null) return true;
 
             collectSymbolsFromFile(psiFile, doc, vf, typeFilter, basePath, seen, results);
-            return results.size() < 200;
+            return results.size() < offset + maxResults;
         });
 
         if (results.isEmpty())
             return "No " + typeFilter + " symbols found (scanned " + fileCount[0]
                 + " source files using AST analysis). This is a definitive result — no grep needed.";
-        return results.size() + " " + typeFilter + " symbols:\n" + String.join("\n", results);
+
+        // Apply offset
+        List<String> page = offset >= results.size() ? List.of() : results.subList(offset, Math.min(results.size(), offset + maxResults));
+        if (page.isEmpty()) return "No more results at offset " + offset;
+
+        String footer = page.size() >= maxResults
+            ? "\n\n(Showing " + maxResults + " results starting at offset " + offset + ". Use offset=" + (offset + maxResults) + " to see more)"
+            : "";
+        return page.size() + " " + typeFilter + " symbols:\n" + String.join("\n", page) + footer;
     }
 
-    private String searchExact(String query, String typeFilter, GlobalSearchScope scope) {
+    private String searchExact(String query, String typeFilter, GlobalSearchScope scope, int maxResults, int offset) {
         List<String> results = new ArrayList<>();
         Set<String> seen = new HashSet<>();
         String basePath = project.getBasePath();
@@ -145,12 +158,17 @@ public final class SearchSymbolsTool extends NavigationTool {
                         addSymbolResult(parent, basePath, seen, results);
                     }
                 }
-                return results.size() < 50;
+                return results.size() < offset + maxResults;
             },
             scope, query, UsageSearchContext.IN_CODE, true
         );
 
-        if (results.isEmpty()) return "No symbols found matching '" + query + "'";
-        return String.join("\n", results);
+        // Apply offset
+        List<String> page = offset >= results.size() ? List.of() : results.subList(offset, Math.min(results.size(), offset + maxResults));
+        if (page.isEmpty()) return "No symbols found matching '" + query + "'";
+        String footer = page.size() >= maxResults
+            ? "\n\n(Showing " + maxResults + " results starting at offset " + offset + ". Use offset=" + (offset + maxResults) + " to see more)"
+            : "";
+        return String.join("\n", page) + footer;
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
@@ -33,7 +33,6 @@ public final class SearchTextTool extends NavigationTool {
 
     private static final String PARAM_REGEX = "regex";
     private static final String PARAM_CASE_SENSITIVE = "case_sensitive";
-    private static final String PARAM_MAX_RESULTS = "max_results";
     private static final String PARAM_CONTEXT_LINES = "context_lines";
 
     /**
@@ -53,7 +52,8 @@ public final class SearchTextTool extends NavigationTool {
     private record SearchParams(Pattern pattern, String basePath, String filePattern,
                                 Pattern compiledFileGlob,
                                 List<String> results, @Nullable List<MatchPosition> positions,
-                                AtomicInteger skippedLarge, int maxResults, int contextLines,
+                                AtomicInteger skippedLarge, int maxResults, int offset,
+                                AtomicInteger totalSeen, int contextLines,
                                 AtomicInteger totalOutputBytes) {
     }
 
@@ -96,6 +96,7 @@ public final class SearchTextTool extends NavigationTool {
             Param.optional(PARAM_REGEX, TYPE_BOOLEAN, "If true, treat query as regex. Default: false (literal match)"),
             Param.optional(PARAM_CASE_SENSITIVE, TYPE_BOOLEAN, "Case-sensitive search. Default: true"),
             Param.optional(PARAM_MAX_RESULTS, TYPE_INTEGER, "Maximum results to return (default: 100)"),
+            Param.optional(PARAM_OFFSET, TYPE_INTEGER, "Number of results to skip for pagination (default: 0)"),
             Param.optional(PARAM_CONTEXT_LINES, TYPE_INTEGER, "Lines of context before and after each match (default: 0). Reduces need for follow-up read_file calls.")
         );
     }
@@ -114,6 +115,7 @@ public final class SearchTextTool extends NavigationTool {
         boolean isRegex = args.has(PARAM_REGEX) && args.get(PARAM_REGEX).getAsBoolean();
         boolean caseSensitive = !args.has(PARAM_CASE_SENSITIVE) || args.get(PARAM_CASE_SENSITIVE).getAsBoolean();
         int maxResults = args.has(PARAM_MAX_RESULTS) ? args.get(PARAM_MAX_RESULTS).getAsInt() : 100;
+        int offset = args.has(PARAM_OFFSET) ? args.get(PARAM_OFFSET).getAsInt() : 0;
         int contextLines = args.has(PARAM_CONTEXT_LINES) ? args.get(PARAM_CONTEXT_LINES).getAsInt() : 0;
         boolean followAgent = ActiveAgentManager.getFollowAgentFiles(project);
 
@@ -124,15 +126,15 @@ public final class SearchTextTool extends NavigationTool {
         // executeSynchronously() yields to write actions when they need to run, then restarts the
         // search (performSearch creates fresh collections, so restart is safe).
         String result = ReadAction.nonBlocking(
-            () -> performSearch(query, filePattern, isRegex, caseSensitive, maxResults, contextLines, followAgent)
+            () -> performSearch(query, filePattern, isRegex, caseSensitive, maxResults, offset, contextLines, followAgent)
         ).executeSynchronously();
         showSearchFeedback("Text search complete: " + query);
         return result;
     }
 
     private String performSearch(String query, String filePattern, boolean isRegex,
-                                 boolean caseSensitive, int maxResults, int contextLines,
-                                 boolean followAgent) {
+                                 boolean caseSensitive, int maxResults, int offset,
+                                 int contextLines, boolean followAgent) {
         String basePath = project.getBasePath();
         if (basePath == null) return ERROR_NO_PROJECT_PATH;
 
@@ -144,7 +146,7 @@ public final class SearchTextTool extends NavigationTool {
         AtomicInteger skippedLarge = new AtomicInteger(0);
         AtomicInteger totalOutputBytes = new AtomicInteger(0);
         var compiledFileGlob = filePattern.isEmpty() ? null : ToolUtils.compileGlob(filePattern);
-        var params = new SearchParams(pattern, basePath, filePattern, compiledFileGlob, results, positions, skippedLarge, maxResults, contextLines, totalOutputBytes);
+        var params = new SearchParams(pattern, basePath, filePattern, compiledFileGlob, results, positions, skippedLarge, maxResults, offset, new AtomicInteger(0), contextLines, totalOutputBytes);
         ProjectFileIndex.getInstance(project).iterateContent(vf -> processFile(vf, params));
 
         if (positions != null && !positions.isEmpty()) {
@@ -164,6 +166,10 @@ public final class SearchTextTool extends NavigationTool {
         }
         if (totalOutputBytes.get() >= MAX_OUTPUT_BYTES) {
             sb.append("\n(output truncated at 256 KB — use a more specific query or file_pattern to narrow results)");
+        }
+        if (results.size() >= maxResults) {
+            sb.append("\n\n(Showing ").append(maxResults).append(" results starting at offset ").append(offset)
+                .append(". Use offset=").append(offset + maxResults).append(" to see more)");
         }
         return sb.toString();
     }
@@ -248,8 +254,9 @@ public final class SearchTextTool extends NavigationTool {
             } else {
                 entry = buildMatchWithContext(doc, relPath, matchLine, lineText, p.contextLines());
             }
-            p.results().add(entry);
             p.totalOutputBytes().addAndGet(entry.length());
+            if (p.totalSeen().getAndIncrement() < p.offset()) continue;
+            p.results().add(entry);
             if (p.positions() != null) {
                 p.positions().add(new MatchPosition(vf, psiFile, matcher.start(), matcher.end()));
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
@@ -49,6 +49,14 @@ public final class SearchTextTool extends NavigationTool {
      */
     private static final int MAX_OUTPUT_BYTES = 256 * 1024; // 256 KB
 
+    /**
+     * Encapsulates the user-provided search configuration (resolves S107: too many params).
+     */
+    private record SearchConfig(String query, String filePattern, boolean isRegex,
+                                boolean caseSensitive, int maxResults, int offset,
+                                int contextLines, boolean followAgent) {
+    }
+
     private record SearchParams(Pattern pattern, String basePath, String filePattern,
                                 Pattern compiledFileGlob,
                                 List<String> results, @Nullable List<MatchPosition> positions,
@@ -119,6 +127,8 @@ public final class SearchTextTool extends NavigationTool {
         int contextLines = args.has(PARAM_CONTEXT_LINES) ? args.get(PARAM_CONTEXT_LINES).getAsInt() : 0;
         boolean followAgent = ActiveAgentManager.getFollowAgentFiles(project);
 
+        var cfg = new SearchConfig(query, filePattern, isRegex, caseSensitive, maxResults, offset, contextLines, followAgent);
+
         showSearchFeedback("Searching text: " + query);
         // NonBlockingReadAction: iterating all project files can hold the read lock for several
         // seconds on large projects. runReadAction() would block ALL write actions (EDT, indexing,
@@ -126,39 +136,38 @@ public final class SearchTextTool extends NavigationTool {
         // executeSynchronously() yields to write actions when they need to run, then restarts the
         // search (performSearch creates fresh collections, so restart is safe).
         String result = ReadAction.nonBlocking(
-            () -> performSearch(query, filePattern, isRegex, caseSensitive, maxResults, offset, contextLines, followAgent)
+            () -> performSearch(cfg)
         ).executeSynchronously();
         showSearchFeedback("Text search complete: " + query);
         return result;
     }
 
-    private String performSearch(String query, String filePattern, boolean isRegex,
-                                 boolean caseSensitive, int maxResults, int offset,
-                                 int contextLines, boolean followAgent) {
+    private String performSearch(SearchConfig cfg) {
         String basePath = project.getBasePath();
         if (basePath == null) return ERROR_NO_PROJECT_PATH;
 
-        Pattern pattern = compileSearchPattern(query, isRegex, caseSensitive);
-        if (pattern == null) return "Error: invalid regex: " + query;
+        Pattern pattern = compileSearchPattern(cfg.query(), cfg.isRegex(), cfg.caseSensitive());
+        if (pattern == null) return "Error: invalid regex: " + cfg.query();
 
         List<String> results = new ArrayList<>();
-        List<MatchPosition> positions = followAgent ? new ArrayList<>() : null;
+        List<MatchPosition> positions = cfg.followAgent() ? new ArrayList<>() : null;
         AtomicInteger skippedLarge = new AtomicInteger(0);
         AtomicInteger totalOutputBytes = new AtomicInteger(0);
-        var compiledFileGlob = filePattern.isEmpty() ? null : ToolUtils.compileGlob(filePattern);
-        var params = new SearchParams(pattern, basePath, filePattern, compiledFileGlob, results, positions, skippedLarge, maxResults, offset, new AtomicInteger(0), contextLines, totalOutputBytes);
+        var compiledFileGlob = cfg.filePattern().isEmpty() ? null : ToolUtils.compileGlob(cfg.filePattern());
+        var params = new SearchParams(pattern, basePath, cfg.filePattern(), compiledFileGlob, results, positions,
+            skippedLarge, cfg.maxResults(), cfg.offset(), new AtomicInteger(0), cfg.contextLines(), totalOutputBytes);
         ProjectFileIndex.getInstance(project).iterateContent(vf -> processFile(vf, params));
 
         if (positions != null && !positions.isEmpty()) {
-            showResultsInUsageView(query, positions);
+            showResultsInUsageView(cfg.query(), positions);
         }
 
         StringBuilder sb = new StringBuilder();
         if (results.isEmpty()) {
-            sb.append("No matches found for '").append(query).append("'");
+            sb.append("No matches found for '").append(cfg.query()).append("'");
         } else {
             sb.append(results.size()).append(" matches:\n");
-            String separator = contextLines > 0 ? "\n---\n" : "\n";
+            String separator = cfg.contextLines() > 0 ? "\n---\n" : "\n";
             sb.append(String.join(separator, results));
         }
         if (skippedLarge.get() > 0) {
@@ -167,9 +176,9 @@ public final class SearchTextTool extends NavigationTool {
         if (totalOutputBytes.get() >= MAX_OUTPUT_BYTES) {
             sb.append("\n(output truncated at 256 KB — use a more specific query or file_pattern to narrow results)");
         }
-        if (results.size() >= maxResults) {
-            sb.append("\n\n(Showing ").append(maxResults).append(" results starting at offset ").append(offset)
-                .append(". Use offset=").append(offset + maxResults).append(" to see more)");
+        if (results.size() >= cfg.maxResults()) {
+            sb.append("\n\n(Showing ").append(cfg.maxResults()).append(" results starting at offset ").append(cfg.offset())
+                .append(". Use offset=").append(cfg.offset() + cfg.maxResults()).append(" to see more)");
         }
         return sb.toString();
     }


### PR DESCRIPTION
Adds `max_results` and `offset` parameters to all three navigation search tools for cursor-based pagination through large result sets.

## Changes

### NavigationTool (shared infrastructure)
- Added `PARAM_MAX_RESULTS`, `PARAM_OFFSET`, `DEFAULT_MAX_RESULTS` constants
- Added `readPaginationParams()` helper for reading pagination args
- Added `paginationFooter()` static helper for building continuation hints

### FindReferencesTool
- Replaced hard-coded 100 limit with configurable `max_results` (default: 100)
- Added `offset` parameter for skip-based pagination
- Uses efficient skip-during-iteration (not post-hoc truncation)

### SearchSymbolsTool
- Replaced hard-coded 50/200 limits with configurable `max_results` (defaults: 50 exact, 200 wildcard)
- Added `offset` parameter with subList-based pagination (since `collectSymbolsFromFile` adds directly)

### SearchTextTool
- Added `offset` parameter (`max_results` already existed)
- Removed duplicate `PARAM_MAX_RESULTS` constant (now inherited from NavigationTool)
- Uses `AtomicInteger totalSeen` counter for efficient skip-during-file-iteration

## Pagination behavior
All tools append a footer when results hit the limit:
```
(Showing 100 results starting at offset 0. Use offset=100 to see more)
```

## Usage examples
```json
{"symbol": "getProject", "max_results": 50, "offset": 0}    // first page
{"symbol": "getProject", "max_results": 50, "offset": 50}   // second page
```

---
*Written by Copilot on behalf of Henrik.*

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>