### PR TITLE
fix: resolve SonarCloud hotspots + add Branch Comparison tab

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           JAZZER_VERSION: '0.22.0'
         run: |
-          curl -sSfL -o jazzer.tar.gz \
+          curl --proto "=https" -sSfL -o jazzer.tar.gz \
             "https://github.com/CodeIntelligenceTesting/jazzer/releases/download/v${JAZZER_VERSION}/jazzer-linux.tar.gz"
           mkdir -p jazzer-bin
           tar xzf jazzer.tar.gz -C jazzer-bin

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
@@ -530,6 +530,24 @@ public abstract class FileTool extends Tool {
     }
 
     /**
+     * Resolves the git executable to an absolute path by probing well-known locations.
+     * Falls back to the bare {@code "git"} command only as a last resort (PATH lookup).
+     */
+    private static String resolveGitExecutable() {
+        for (String candidate : List.of(
+            "/usr/bin/git",
+            "/usr/local/bin/git",
+            "/opt/homebrew/bin/git",
+            "/opt/local/bin/git"
+        )) {
+            if (new java.io.File(candidate).canExecute()) {
+                return candidate;
+            }
+        }
+        return "git";
+    }
+
+    /**
      * Returns a short git status annotation for a file, e.g. "[git: modified, not staged]".
      * Runs a single git command via ProcessBuilder. Returns empty string on any error
      * or if the file is not in a git repo.
@@ -539,7 +557,8 @@ public abstract class FileTool extends Tool {
         if (basePath == null) return "";
 
         try {
-            ProcessBuilder pb = new ProcessBuilder("git", "--no-pager", "status", "--porcelain", "--", pathStr);
+            ProcessBuilder pb = new ProcessBuilder(
+                resolveGitExecutable(), "--no-pager", "status", "--porcelain", "--", pathStr);
             pb.directory(new java.io.File(basePath));
             pb.redirectErrorStream(true);
             pb.environment().put("GIT_TERMINAL_PROMPT", "0");

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/BranchComparisonChart.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/BranchComparisonChart.java
@@ -6,17 +6,8 @@ import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBPanel;
 import com.intellij.util.ui.JBUI;
 
-import javax.swing.BorderFactory;
-import javax.swing.JPanel;
-import javax.swing.SwingConstants;
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontMetrics;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
+import javax.swing.*;
+import java.awt.*;
 import java.util.List;
 
 /**
@@ -38,9 +29,9 @@ final class BranchComparisonChart extends JBPanel<BranchComparisonChart> {
     private static final int CANVAS_PADDING = JBUI.scale(8);
 
     private static final Color BAR_TRACK_COLOR = new JBColor(
-        new Color(235, 235, 235), new Color(60, 60, 60));
+        com.intellij.ui.Gray._235, com.intellij.ui.Gray._60);
     private static final Color LABEL_COLOR = new JBColor(
-        new Color(60, 60, 60), new Color(190, 190, 190));
+        com.intellij.ui.Gray._60, com.intellij.ui.Gray._190);
 
     private final UsageStatisticsData.Metric metric;
     private final BarCanvas canvas;
@@ -51,6 +42,7 @@ final class BranchComparisonChart extends JBPanel<BranchComparisonChart> {
         this.metric = metric;
 
         setPreferredSize(new Dimension(JBUI.scale(350), JBUI.scale(220)));
+        setMinimumSize(new Dimension(JBUI.scale(200), JBUI.scale(120)));
 
         JBLabel titleLabel = new JBLabel(title);
         titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD));

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/BranchComparisonPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/BranchComparisonPanel.java
@@ -1,0 +1,122 @@
+package com.github.catatafishen.agentbridge.ui.statistics;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ComboBox;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBPanel;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.util.ui.JBUI;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Dedicated panel for branch-comparison charts. Each metric chart is rendered
+ * at full container width and expands vertically to fit all branch bars.
+ * The entire view scrolls vertically when the charts exceed the viewport.
+ *
+ * <p>This panel lives in its own tab (separate from the agent time-series
+ * charts) so that long branch lists and long branch names are fully visible.
+ */
+class BranchComparisonPanel extends JBPanel<BranchComparisonPanel> {
+
+    private static final Logger LOG = Logger.getInstance(BranchComparisonPanel.class);
+
+    private final transient Project project;
+    private final ComboBox<UsageStatisticsData.TimeRange> rangeCombo;
+    private final Map<UsageStatisticsData.Metric, BranchComparisonChart> charts =
+        new EnumMap<>(UsageStatisticsData.Metric.class);
+    private final JBLabel hintLabel;
+
+    BranchComparisonPanel(Project project) {
+        super(new BorderLayout());
+        this.project = project;
+        setBorder(JBUI.Borders.empty(12));
+
+        // --- NORTH: period selector ---
+        JPanel toolbar = new JPanel();
+        toolbar.setLayout(new BoxLayout(toolbar, BoxLayout.X_AXIS));
+        toolbar.add(new JBLabel("Period:"));
+        toolbar.add(Box.createHorizontalStrut(JBUI.scale(6)));
+        rangeCombo = StatisticsComboFactory.createLabeledCombo(
+            UsageStatisticsData.TimeRange.values(),
+            UsageStatisticsData.TimeRange.MONTH_30,
+            UsageStatisticsData.TimeRange::label);
+        rangeCombo.addActionListener(e -> reload());
+        toolbar.add(rangeCombo);
+        add(toolbar, BorderLayout.NORTH);
+
+        // --- CENTER: scrollable vertical list of charts ---
+        JPanel chartsPanel = new JPanel();
+        chartsPanel.setLayout(new BoxLayout(chartsPanel, BoxLayout.Y_AXIS));
+
+        for (UsageStatisticsData.Metric metric : UsageStatisticsData.Metric.values()) {
+            BranchComparisonChart chart = new BranchComparisonChart(metric.displayName(), metric);
+            chart.setPreferredSize(null);
+            chart.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+            chart.setAlignmentX(Component.LEFT_ALIGNMENT);
+            charts.put(metric, chart);
+            if (chartsPanel.getComponentCount() > 0) {
+                chartsPanel.add(Box.createVerticalStrut(JBUI.scale(16)));
+            }
+            chartsPanel.add(chart);
+        }
+
+        hintLabel = new JBLabel(" ");
+        hintLabel.setBorder(JBUI.Borders.emptyTop(8));
+        hintLabel.setForeground(JBColor.GRAY);
+        hintLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        chartsPanel.add(Box.createVerticalStrut(JBUI.scale(8)));
+        chartsPanel.add(hintLabel);
+
+        JBScrollPane scrollPane = new JBScrollPane(chartsPanel);
+        scrollPane.setBorder(JBUI.Borders.empty());
+        scrollPane.getVerticalScrollBar().setUnitIncrement(JBUI.scale(16));
+        add(scrollPane, BorderLayout.CENTER);
+
+        reload();
+    }
+
+    private void reload() {
+        UsageStatisticsData.TimeRange range =
+            (UsageStatisticsData.TimeRange) rangeCombo.getSelectedItem();
+        if (range == null) return;
+
+        ModalityState modality = ModalityState.any();
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                UsageStatisticsData.BranchSnapshot snapshot =
+                    UsageStatisticsLoader.loadBranches(project, range);
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    if (project.isDisposed()) return;
+                    updateCharts(snapshot);
+                }, modality);
+            } catch (Exception e) {
+                LOG.error("Branch comparison panel: failed to load data for range " + range, e);
+            }
+        });
+    }
+
+    private void updateCharts(UsageStatisticsData.BranchSnapshot snapshot) {
+        for (BranchComparisonChart chart : charts.values()) {
+            chart.update(snapshot);
+        }
+
+        if (snapshot.unattributed() > 0) {
+            hintLabel.setText(snapshot.unattributed()
+                + " turn(s) in this period have no branch attribution"
+                + " (recorded before per-branch tracking, or git was unavailable).");
+        } else if (snapshot.branches().isEmpty()) {
+            hintLabel.setText("No branch data yet. Submit a prompt while on a feature"
+                + " branch to start tracking per-branch usage.");
+        } else {
+            hintLabel.setText(" ");
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/StatisticsComboFactory.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/StatisticsComboFactory.java
@@ -1,0 +1,43 @@
+package com.github.catatafishen.agentbridge.ui.statistics;
+
+import com.intellij.openapi.ui.ComboBox;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.function.Function;
+
+/**
+ * Factory for creating labelled combo boxes used across statistics panels.
+ * Eliminates duplicated renderer boilerplate.
+ */
+final class StatisticsComboFactory {
+
+    private StatisticsComboFactory() {
+    }
+
+    /**
+     * Creates a combo box that renders enum items via a label function.
+     *
+     * @param values   enum constants to populate the combo
+     * @param selected initial selection
+     * @param labeler  extracts display text from each enum value
+     */
+    static <E extends Enum<E>> ComboBox<E> createLabeledCombo(E[] values, E selected,
+                                                               Function<E, String> labeler) {
+        ComboBox<E> combo = new ComboBox<>(values);
+        combo.setSelectedItem(selected);
+        combo.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            @SuppressWarnings("unchecked") // safe: combo only contains E values
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index,
+                                                          boolean isSelected, boolean cellHasFocus) {
+                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                if (value != null) {
+                    setText(labeler.apply((E) value));
+                }
+                return this;
+            }
+        });
+        return combo;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsDialog.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsDialog.java
@@ -29,7 +29,8 @@ public class UsageStatisticsDialog extends DialogWrapper {
     @Override
     protected @Nullable JComponent createCenterPanel() {
         JBTabbedPane tabs = new JBTabbedPane();
-        tabs.addTab("Charts", new UsageStatisticsPanel(project));
+        tabs.addTab("Usage Trends", new UsageStatisticsPanel(project));
+        tabs.addTab("Branch Comparison", new BranchComparisonPanel(project));
         tabs.addTab("Tool Statistics", new ToolStatisticsPanel(project));
         return tabs;
     }
@@ -41,7 +42,7 @@ public class UsageStatisticsDialog extends DialogWrapper {
 
     @Override
     public Dimension getPreferredSize() {
-        return JBUI.size(900, 600);
+        return new Dimension(JBUI.scale(1000), JBUI.scale(650));
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsPanel.java
@@ -28,18 +28,17 @@ import java.util.Map;
  *       charts (one per metric) so users can compare per-feature spend.
  *       Bar charts are used instead of time-series because branches are
  *       discrete categories — a stacked or multi-line time chart over many
- *       branches becomes unreadable and "total spend per branch" is the
- *       actual question being answered.</li>
+ *       short-lived branches is unreadable.</li>
  * </ul>
  */
-class UsageStatisticsPanel extends JBPanel<UsageStatisticsPanel> {
+public class UsageStatisticsPanel extends JBPanel<UsageStatisticsPanel> {
 
     private static final Logger LOG = Logger.getInstance(UsageStatisticsPanel.class);
-
-    private static final String CARD_AGENT = "agent";
-    private static final String CARD_BRANCH = "branch";
+    private static final String CARD_AGENT = "AGENT";
+    private static final String CARD_BRANCH = "BRANCH";
 
     private final transient Project project;
+
     private final ComboBox<UsageStatisticsData.TimeRange> rangeCombo;
     private final ComboBox<UsageStatisticsData.GroupBy> groupByCombo;
 
@@ -47,14 +46,14 @@ class UsageStatisticsPanel extends JBPanel<UsageStatisticsPanel> {
         new EnumMap<>(UsageStatisticsData.Metric.class);
     private final Map<UsageStatisticsData.Metric, BranchComparisonChart> branchCharts =
         new EnumMap<>(UsageStatisticsData.Metric.class);
-
     private final JPanel legendContainer;
-    private final JPanel cardPanel;
-    private final CardLayout cardLayout;
     private final JBLabel branchHintLabel;
 
-    UsageStatisticsPanel(Project project) {
-        super(new BorderLayout());
+    private final CardLayout cardLayout;
+    private final JPanel cardPanel;
+
+    public UsageStatisticsPanel(Project project) {
+        super(new BorderLayout(0, JBUI.scale(8)));
         this.project = project;
         setBorder(JBUI.Borders.empty(12));
 
@@ -66,38 +65,20 @@ class UsageStatisticsPanel extends JBPanel<UsageStatisticsPanel> {
 
         selectorPanel.add(new JBLabel("Period:"));
         selectorPanel.add(Box.createHorizontalStrut(JBUI.scale(6)));
-        rangeCombo = new ComboBox<>(UsageStatisticsData.TimeRange.values());
-        rangeCombo.setSelectedItem(UsageStatisticsData.TimeRange.MONTH_30);
-        rangeCombo.setRenderer(new DefaultListCellRenderer() {
-            @Override
-            public Component getListCellRendererComponent(JList<?> list, Object value, int index,
-                                                          boolean isSelected, boolean cellHasFocus) {
-                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-                if (value instanceof UsageStatisticsData.TimeRange timeRange) {
-                    setText(timeRange.label());
-                }
-                return this;
-            }
-        });
+        rangeCombo = StatisticsComboFactory.createLabeledCombo(
+            UsageStatisticsData.TimeRange.values(),
+            UsageStatisticsData.TimeRange.MONTH_30,
+            UsageStatisticsData.TimeRange::label);
         rangeCombo.addActionListener(e -> reload());
         selectorPanel.add(rangeCombo);
 
         selectorPanel.add(Box.createHorizontalStrut(JBUI.scale(16)));
         selectorPanel.add(new JBLabel("Group by:"));
         selectorPanel.add(Box.createHorizontalStrut(JBUI.scale(6)));
-        groupByCombo = new ComboBox<>(UsageStatisticsData.GroupBy.values());
-        groupByCombo.setSelectedItem(UsageStatisticsData.GroupBy.AGENT);
-        groupByCombo.setRenderer(new DefaultListCellRenderer() {
-            @Override
-            public Component getListCellRendererComponent(JList<?> list, Object value, int index,
-                                                          boolean isSelected, boolean cellHasFocus) {
-                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-                if (value instanceof UsageStatisticsData.GroupBy groupBy) {
-                    setText(groupBy.label());
-                }
-                return this;
-            }
-        });
+        groupByCombo = StatisticsComboFactory.createLabeledCombo(
+            UsageStatisticsData.GroupBy.values(),
+            UsageStatisticsData.GroupBy.AGENT,
+            UsageStatisticsData.GroupBy::label);
         groupByCombo.addActionListener(e -> reload());
         selectorPanel.add(groupByCombo);
 


### PR DESCRIPTION
## Changes

### SonarCloud Security Hotspots
- **fuzz.yml (S6506)**: Added `--proto "=https"` to curl command to prevent HTTP downgrade on redirects
- **FileTool.java (S4036)**: Resolve git executable to absolute path by probing well-known locations instead of bare `"git"` PATH lookup

### Not fixed (too complex):
- **web-app.ts (S1523)**: The `eval()` is fundamental to the SSE event protocol — the entire chat UI receives JS snippets via SSE. Replacing requires protocol redesign.
- **Gradle (S6474)**: Adding `verification-metadata.xml` requires verifying all dependency keys — complex setup with ongoing maintenance.

### Branch Comparison Tab
- New `BranchComparisonPanel` with full-width charts stacked vertically in a scroll pane
- Each chart expands to show all branch bars (no more squished 2×3 grid)
- Tab titles updated: "Usage Trends", "Branch Comparison", "Tool Statistics"
- Fixed pre-existing Gray color warnings in BranchComparisonChart

## Testing
- Build passes with no new errors