### PR TITLE
feat: move current session files to Plan tab and remove Shared section

### DIFF
--- a/.idea/sonarlint.xml
+++ b/.idea/sonarlint.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="SonarLintProjectSettings">
+    <option name="bindingEnabled" value="true" />
     <option name="fileExclusions">
       <list>
         <option value="DIRECTORY:build" />
@@ -12,5 +13,7 @@
         <option value="GLOB:.*/**" />
       </list>
     </option>
+    <option name="projectKey" value="catatafishen_agentbridge" />
+    <option name="serverId" value="sonarcloud" />
   </component>
 </project>

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.fileTypes.UnknownFileType;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.JBColor;
 import com.intellij.ui.treeStructure.Tree;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,26 +31,32 @@ import java.util.List;
 /**
  * Tree view of project agent-definition / instruction files.
  * <p>
- * Mirrors the former title-bar "Project Files" dropdown. Sections:
+ * In normal mode, shows sections for each supported agent client (Copilot CLI, OpenCode,
+ * Junie, Kiro). In session-only mode (used by the Plan tab), shows only the
+ * "Current Session" section with files from the active agent's session directory.
  * <ul>
- *   <li>Shared — {@code AGENTS.md} and the agent task-list file, created on first click if missing</li>
  *   <li>Copilot CLI — {@code .agent-work/copilot/{agents,skills,instructions}}</li>
  *   <li>OpenCode — {@code .agent-work/opencode/agent/*.md}</li>
  *   <li>Junie — {@code .agent-work/junie/{guidelines.md, agents/*.md}}</li>
  *   <li>Kiro — {@code .agent-work/kiro/{agents/*.json, skills/SKILL.md}}</li>
  * </ul>
- * Missing "shared" files render with a dim bulb icon and are created empty on click.
  */
 final class ProjectFilesPanel extends JPanel {
 
     private final transient Project project;
+    private final boolean sessionOnly;
     private final DefaultMutableTreeNode root = new DefaultMutableTreeNode("Project Files");
     private final DefaultTreeModel treeModel = new DefaultTreeModel(root);
     private final Tree tree = new Tree(treeModel);
 
     ProjectFilesPanel(@NotNull Project project) {
+        this(project, false);
+    }
+
+    ProjectFilesPanel(@NotNull Project project, boolean sessionOnly) {
         super(new BorderLayout());
         this.project = project;
+        this.sessionOnly = sessionOnly;
         setOpaque(false);
 
         tree.setRootVisible(false);
@@ -67,7 +74,7 @@ final class ProjectFilesPanel extends JPanel {
         // Let the parent's background show through so dark mode doesn't
         // paint a gray rectangle behind the file rows.
         tree.setOpaque(false);
-        tree.setBackground(new Color(0, 0, 0, 0));
+        tree.setBackground(new JBColor(new Color(0, 0, 0, 0), new Color(0, 0, 0, 0)));
         tree.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
@@ -94,33 +101,30 @@ final class ProjectFilesPanel extends JPanel {
             return;
         }
 
-        addSection("Shared", List.of(
-            new FileNode(base, "TODO.md", "TODO", true),
-            new FileNode(base, "AGENTS.md", "AGENTS", true)
-        ));
+        if (sessionOnly) {
+            addSessionSection();
+        } else {
+            List<FileNode> copilot = new ArrayList<>();
+            copilot.addAll(glob(base, ".agent-work/copilot/agents", "*.md"));
+            copilot.addAll(glob(base, ".agent-work/copilot/skills", "*/SKILL.md"));
+            copilot.addAll(glob(base, ".agent-work/copilot/instructions", "*.instructions.md"));
+            addSection("Copilot CLI", copilot);
 
-        List<FileNode> copilot = new ArrayList<>();
-        copilot.addAll(glob(base, ".agent-work/copilot/agents", "*.md"));
-        copilot.addAll(glob(base, ".agent-work/copilot/skills", "*/SKILL.md"));
-        copilot.addAll(glob(base, ".agent-work/copilot/instructions", "*.instructions.md"));
-        addSection("Copilot CLI", copilot);
+            addSection("OpenCode", glob(base, ".agent-work/opencode/agent", "*.md"));
 
-        addSection("OpenCode", glob(base, ".agent-work/opencode/agent", "*.md"));
+            List<FileNode> junie = new ArrayList<>();
+            File junieGuidelines = new File(base, ".agent-work/junie/guidelines.md");
+            if (junieGuidelines.exists()) {
+                junie.add(new FileNode(base, ".agent-work/junie/guidelines.md", "guidelines.md", false));
+            }
+            junie.addAll(glob(base, ".agent-work/junie/agents", "*.md"));
+            addSection("Junie", junie);
 
-        List<FileNode> junie = new ArrayList<>();
-        File junieGuidelines = new File(base, ".agent-work/junie/guidelines.md");
-        if (junieGuidelines.exists()) {
-            junie.add(new FileNode(base, ".agent-work/junie/guidelines.md", "guidelines.md", false));
+            List<FileNode> kiro = new ArrayList<>();
+            kiro.addAll(glob(base, ".agent-work/kiro/agents", "*.json"));
+            kiro.addAll(glob(base, ".agent-work/kiro/skills", "*/SKILL.md"));
+            addSection("Kiro", kiro);
         }
-        junie.addAll(glob(base, ".agent-work/junie/agents", "*.md"));
-        addSection("Junie", junie);
-
-        List<FileNode> kiro = new ArrayList<>();
-        kiro.addAll(glob(base, ".agent-work/kiro/agents", "*.json"));
-        kiro.addAll(glob(base, ".agent-work/kiro/skills", "*/SKILL.md"));
-        addSection("Kiro", kiro);
-
-        addSessionSection();
 
         treeModel.reload();
         for (int i = 0; i < tree.getRowCount(); i++) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SidePanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SidePanel.java
@@ -19,9 +19,9 @@ import java.awt.*;
  *   <li><b>Diff</b> — the existing {@link DiffPanel} with pending agent edits.</li>
  *   <li><b>Plan</b> — rendered view of the active agent session's {@code plan.md},
  *       with a {@code (done/total)} badge in the tab title when checkbox-style task items exist.</li>
- *   <li><b>Tools</b> — live list of MCP tool calls with timestamps, categories, and expandable I/O.</li>
- *   <li><b>Search</b> — searchable list of user prompts across the current conversation history, click to scroll.</li>
- *   <li><b>Session</b> — session statistics, billing info, and a project-files tree.</li>
+ *   <li><b>MCP</b> — live list of MCP tool calls with timestamps, categories, and expandable I/O.</li>
+ *   <li><b>Prompt DB</b> — searchable list of user prompts across the current conversation history, click to scroll.</li>
+ *   <li><b>Stats</b> — session statistics, billing info, and a project-files tree.</li>
  * </ol>
  * Tab order is deliberate: review is the most time-sensitive and sits first.
  */
@@ -50,15 +50,15 @@ public final class SidePanel extends JPanel implements Disposable {
 
         tabsPanel = PlatformApiCompat.createJBTabsPanel(project, this);
         tabsPanel.addTab(reviewPanel, "Diff");
-        tabsPanel.addTab(todoPanel, "Todo");
-        tabsPanel.addTab(toolCallPanel, "Tools");
-        tabsPanel.addTab(promptsPanel, "Search");
-        tabsPanel.addTab(sessionStatsPanel, "Session");
+        tabsPanel.addTab(todoPanel, "Plan");
+        tabsPanel.addTab(toolCallPanel, "MCP");
+        tabsPanel.addTab(promptsPanel, "Prompt DB");
+        tabsPanel.addTab(sessionStatsPanel, "Stats");
 
         todoPanel.setOnProgressChanged(() -> {
             int total = todoPanel.getTotal();
             int done = todoPanel.getDone();
-            String title = total > 0 ? "Todo (" + done + "/" + total + ")" : "Todo";
+            String title = total > 0 ? "Plan (" + done + "/" + total + ")" : "Plan";
             tabsPanel.setTabTitle(TAB_TODOS, title);
         });
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/TodoPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/TodoPanel.java
@@ -62,6 +62,8 @@ final class TodoPanel extends JPanel implements Disposable {
     private final transient Timer pollTimer;
     private transient @Nullable Runnable onProgressChanged;
     private boolean splitVisible;
+    private final JPanel body;
+    private final ProjectFilesPanel sessionFilesPanel;
 
     /**
      * Last observed (path, mtime, done, total) so the poll timer can skip work when nothing changed.
@@ -98,10 +100,19 @@ final class TodoPanel extends JPanel implements Disposable {
 
         databasePanel = new TodoDatabasePanel();
 
-        JPanel body = new JPanel(new BorderLayout());
+        body = new JPanel(new BorderLayout());
         body.add(headerLabel, BorderLayout.NORTH);
         body.add(markdownContentPanel, BorderLayout.CENTER);
         add(body, BorderLayout.CENTER);
+
+        sessionFilesPanel = new ProjectFilesPanel(project, true);
+        JPanel sessionSection = new JPanel(new BorderLayout());
+        JBLabel sessionHeader = new JBLabel("Current Session");
+        sessionHeader.setFont(UIUtil.getLabelFont().deriveFont(Font.BOLD, 11f));
+        sessionHeader.setBorder(JBUI.Borders.empty(8, 8, 4, 8));
+        sessionSection.add(sessionHeader, BorderLayout.NORTH);
+        sessionSection.add(sessionFilesPanel, BorderLayout.CENTER);
+        add(sessionSection, BorderLayout.SOUTH);
 
         pollTimer = new Timer(POLL_INTERVAL_MS, e -> pollIfVisible());
         pollTimer.setRepeats(true);
@@ -172,6 +183,7 @@ final class TodoPanel extends JPanel implements Disposable {
      * Re-reads the plan file and repaints if anything changed. Safe to call from the EDT.
      */
     void refresh() {
+        sessionFilesPanel.refresh();
         Path sessionDir = resolveSessionDir();
         updateDatabasePanel(sessionDir);
 
@@ -251,12 +263,11 @@ final class TodoPanel extends JPanel implements Disposable {
      * Returns the JPanel containing headerLabel + markdownContentPanel.
      */
     private @Nullable Component getMainBody() {
-        if (getComponentCount() == 0) return null;
-        Component c = getComponent(0);
-        if (c instanceof JSplitPane split) {
-            return split.getTopComponent();
-        }
-        return c;
+        if (!splitVisible) return body;
+        // When the split is visible, body is the top component of the JSplitPane at CENTER.
+        Container center = (Container) ((BorderLayout) getLayout()).getLayoutComponent(BorderLayout.CENTER);
+        if (center instanceof JSplitPane split) return split.getTopComponent();
+        return body;
     }
 
     private void renderEmpty() {


### PR DESCRIPTION
## Changes

- **ProjectFilesPanel**: Added `sessionOnly` constructor. In session-only mode shows only the "Current Session" section. Removed the "Shared" section (TODO.md, AGENTS.md) from the normal agent-config view.
- **TodoPanel**: Promoted `body` to class field; added `ProjectFilesPanel(project, true)` as a "Current Session" section at SOUTH; fixed `getMainBody()` to return the `body` field directly (instead of fragile `getComponent(0)`) so split/unsplit continues working correctly; calls `sessionFilesPanel.refresh()` on every poll cycle.

Closes #458 (if applicable).