### PR TITLE
fix: show correct single turn in history context window

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/ExportUtils.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/ExportUtils.java
@@ -1,9 +1,12 @@
 package com.github.catatafishen.agentbridge.session.exporters;
 
+import com.github.catatafishen.agentbridge.settings.AgentBridgeStorageSettings;
+import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.regex.Pattern;
 
 /**
@@ -17,6 +20,9 @@ public final class ExportUtils {
     private static final String AGENTBRIDGE_DASH = "agentbridge-";
     private static final String AGENTBRIDGE_UNDERSCORE = "agentbridge_";
     private static final String AGENTBRIDGE_KIRO = "@agentbridge/";
+
+    private static final String SESSIONS_SUBDIR = "sessions";
+    private static final String LEGACY_SESSIONS_DIR = ".agent-work/sessions";
 
     private ExportUtils() {
     }
@@ -73,16 +79,49 @@ public final class ExportUtils {
     }
 
     /**
+     * Returns the project-specific v2 sessions directory using the configured storage root.
+     *
+     * <p>Uses {@link AgentBridgeStorageSettings} to resolve the storage root (e.g.
+     * {@code {project}/.agentbridge}), then appends {@code sessions/}. Falls back to the
+     * legacy {@code .agent-work/sessions/} path when the configured directory does not yet
+     * exist, ensuring backwards-compatibility with existing data.</p>
+     *
+     * <b>Prefer this overload over {@link #sessionsDir(String)} when a {@link Project} is
+     * available.</b>
+     *
+     * @param project the IntelliJ project
+     * @return the sessions directory (may not yet exist on disk)
+     */
+    @NotNull
+    public static File sessionsDir(@NotNull Project project) {
+        Path storageRoot = AgentBridgeStorageSettings.getInstance().getProjectStorageDir(project);
+        File configured = storageRoot.resolve(SESSIONS_SUBDIR).toFile();
+        if (!configured.exists() || !configured.isDirectory()) {
+            String basePath = project.getBasePath();
+            if (basePath != null) {
+                File legacy = new File(basePath, LEGACY_SESSIONS_DIR);
+                if (legacy.exists() && legacy.isDirectory()) {
+                    return legacy;
+                }
+            }
+        }
+        return configured;
+    }
+
+    /**
      * Returns the project-specific v2 sessions directory.
      *
      * @param basePath project base path (may be {@code null})
      * @return the sessions directory (may not yet exist on disk)
+     * @deprecated Prefer {@link #sessionsDir(Project)} when a {@link Project} is available;
+     *     it uses the configured storage root instead of the hardcoded legacy path.
      */
+    @Deprecated(since = "0.9")
     @NotNull
     public static File sessionsDir(@Nullable String basePath) {
         if (basePath == null || basePath.isEmpty()) {
-            return new File(".agent-work/sessions");
+            return new File(LEGACY_SESSIONS_DIR);
         }
-        return new File(basePath, ".agent-work/sessions");
+        return new File(basePath, LEGACY_SESSIONS_DIR);
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2.java
@@ -19,8 +19,10 @@ import com.intellij.util.concurrency.AppExecutorUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -75,6 +77,7 @@ public final class SessionStoreV2 implements Disposable {
     private static final String KEY_STATUS = "status";
     private static final String KEY_DESCRIPTION = "description";
     private static final String KEY_RESULT = "result";
+    private static final String LOG_JSONL_PARSE_FAIL = "Failed to parse v2 JSONL for session ";
 
     private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
 
@@ -437,10 +440,133 @@ public final class SessionStoreV2 implements Disposable {
         try {
             return loadEntriesFromFiles(files);
         } catch (Exception e) {
-            LOG.warn("Failed to parse v2 JSONL for session " + sessionId, e);
+            LOG.warn(LOG_JSONL_PARSE_FAIL + sessionId, e);
             return null;
         }
     }
+
+    /**
+     * A prompt entry paired with the session it belongs to and its optional turn statistics.
+     * Used by {@link #loadPromptsFromAllSessions(Project)} to build cross-session prompt lists
+     * without loading full session entry graphs into memory.
+     *
+     * @param sessionId  the UUID of the session this prompt came from
+     * @param prompt     the prompt entry
+     * @param stats      the TurnStats immediately following the prompt, or {@code null} if not present
+     */
+    public record PromptWithContext(
+        @NotNull String sessionId,
+        @NotNull EntryData.Prompt prompt,
+        @Nullable EntryData.TurnStats stats) {
+    }
+
+    /**
+     * Efficiently loads prompts and their associated turn statistics from <em>all</em> known
+     * sessions by scanning JSONL files for {@code "type":"prompt"} and {@code "type":"turnStats"}
+     * lines only.
+     *
+     * <p>Unlike {@link #loadEntries(String)} (which parses every entry), this method reads each
+     * JSONL file line-by-line and only parses the two lightweight types needed for the prompts
+     * list, making it practical even for sessions with hundreds of megabytes of tool-call data.
+     *
+     * @param project the IntelliJ project (used to resolve the configured sessions directory)
+     * @return prompts sorted chronologically (oldest first), each with its session ID
+     */
+    @NotNull
+    public List<PromptWithContext> loadPromptsFromAllSessions(@NotNull Project project) {
+        File dir = ExportUtils.sessionsDir(project);
+        List<SessionRecord> sessions = listSessions(project.getBasePath());
+        List<PromptWithContext> result = new ArrayList<>();
+        for (SessionRecord session : sessions) {
+            List<Path> files = SessionFileRotation.listAllFiles(dir, session.id());
+            result.addAll(scanPromptsFromFiles(session.id(), files));
+        }
+        result.sort(Comparator.comparing(p -> p.prompt().getTimestamp()));
+        return result;
+    }
+
+    /** Scans JSONL files for prompt + turnStats entries only (skips everything else). */
+    @NotNull
+    private List<PromptWithContext> scanPromptsFromFiles(
+        @NotNull String sessionId, @NotNull List<Path> files) {
+        List<PromptWithContext> result = new ArrayList<>();
+        EntryData.Prompt pending = null;
+        for (Path file : files) {
+            try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(Files.newInputStream(file), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.isBlank() || !line.contains("\"type\"")) continue;
+                    if (line.contains("\"type\":\"" + EntryDataJsonAdapter.TYPE_PROMPT + "\"")) {
+                        pending = tryParsePrompt(line, sessionId, result, pending);
+                    } else if (pending != null
+                        && line.contains("\"type\":\"" + EntryDataJsonAdapter.TYPE_TURN_STATS + "\"")) {
+                        pending = tryParseTurnStats(line, sessionId, result, pending);
+                    }
+                }
+            } catch (IOException e) {
+                LOG.warn("Failed to scan session file for prompts: " + file, e);
+            }
+        }
+        if (pending != null) {
+            result.add(new PromptWithContext(sessionId, pending, null));
+        }
+        return result;
+    }
+
+    @Nullable
+    private EntryData.Prompt tryParsePrompt(
+        @NotNull String line, @NotNull String sessionId,
+        @NotNull List<PromptWithContext> result, @Nullable EntryData.Prompt pending) {
+        if (pending != null) {
+            result.add(new PromptWithContext(sessionId, pending, null));
+        }
+        try {
+            JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
+            EntryData entry = EntryDataJsonAdapter.deserialize(obj);
+            return entry instanceof EntryData.Prompt p ? p : pending;
+        } catch (Exception e) {
+            LOG.warn("Failed to parse prompt line in session " + sessionId, e);
+            return pending;
+        }
+    }
+
+    @Nullable
+    private EntryData.Prompt tryParseTurnStats(
+        @NotNull String line, @NotNull String sessionId,
+        @NotNull List<PromptWithContext> result, @NotNull EntryData.Prompt pending) {
+        try {
+            JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
+            EntryData entry = EntryDataJsonAdapter.deserialize(obj);
+            if (entry instanceof EntryData.TurnStats stats) {
+                result.add(new PromptWithContext(sessionId, pending, stats));
+                return null;
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to parse turnStats line in session " + sessionId, e);
+        }
+        return pending;
+    }
+
+    /**
+     * Loads entries for a specific session by ID from V2 JSONL, using the configured sessions
+     * directory resolved from {@link ExportUtils#sessionsDir(Project)}.
+     * Returns {@code null} if no session files exist.
+     */
+    @Nullable
+    public List<EntryData> loadEntriesBySessionId(
+        @NotNull Project project, @NotNull String sessionId) {
+        File dir = ExportUtils.sessionsDir(project);
+        List<Path> files = SessionFileRotation.listAllFiles(dir, sessionId);
+        if (files.isEmpty()) return null;
+        try {
+            return loadEntriesFromFiles(files);
+        } catch (Exception e) {
+            LOG.warn(LOG_JSONL_PARSE_FAIL + sessionId, e);
+            return null;
+        }
+    }
+
 
     /**
      * Loads entries directly from V2 JSONL file(s) for the current session.
@@ -469,7 +595,7 @@ public final class SessionStoreV2 implements Disposable {
         try {
             return loadEntriesFromFiles(files);
         } catch (Exception e) {
-            LOG.warn("Failed to parse v2 JSONL for session " + sessionId, e);
+            LOG.warn(LOG_JSONL_PARSE_FAIL + sessionId, e);
             return null;
         }
     }
@@ -958,6 +1084,10 @@ public final class SessionStoreV2 implements Disposable {
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
+    // Intentional: this private helper wraps the deprecated ExportUtils.sessionsDir(String)
+    // to avoid duplicating the path logic. The deprecation is meant for external callers —
+    // internal methods that haven't migrated to the Project-based API still use this shim.
+    @SuppressWarnings("deprecation")
     @NotNull
     private static File sessionsDir(@Nullable String basePath) {
         return ExportUtils.sessionsDir(basePath);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -956,6 +956,22 @@ class ChatConsolePanel(
         )
     }
 
+    fun scrollToTop() {
+        executeJs(
+            """
+            (function attempt(n){
+                var container = document.querySelector('chat-container');
+                if (!container) {
+                    if (n > 0) { setTimeout(function(){ attempt(n-1); }, 80); }
+                    return;
+                }
+                ChatController.setAutoScroll(false);
+                container.scrollTop = 0;
+            })(15)
+            """.trimIndent()
+        )
+    }
+
     fun showLoadMore(deferredCount: Int) {
         executeJs("ChatController.showLoadMore($deferredCount)")
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/HistoryContextWindow.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/HistoryContextWindow.kt
@@ -21,7 +21,8 @@ import javax.swing.SwingConstants
 /**
  * Non-modal floating window showing conversation history centred on a specific prompt.
  *
- * Initially displays the target prompt turn plus one turn before and one turn after.
+ * Initially displays exactly the target prompt turn (user input + AI response).
+ * The window is scrolled to the top so the user prompt is immediately visible.
  * "Load more" links at the top and bottom expand by one turn at a time using
  * [ChatConsolePanel.prependEntries] and [ChatConsolePanel.appendEntries] — the JCEF
  * panel is never recreated on load-more, so there is no flash or re-scroll.
@@ -73,8 +74,8 @@ internal class HistoryContextWindow private constructor(
 
     private val turns: List<List<EntryData>> = splitIntoTurns(allEntries)
     private val targetTurnIdx: Int = findTurnIndex(turns, targetEntryId)
-    private var displayStartTurnIdx: Int = (targetTurnIdx - 1).coerceAtLeast(0)
-    private var displayEndTurnIdx: Int = (targetTurnIdx + 1).coerceAtMost(turns.size - 1)
+    private var displayStartTurnIdx: Int = targetTurnIdx
+    private var displayEndTurnIdx: Int = targetTurnIdx
 
     private val chatPanel = ChatConsolePanel(project, registerAsMain = false)
 
@@ -105,7 +106,7 @@ internal class HistoryContextWindow private constructor(
 
         chatPanel.setDomMessageLimit(100_000)
         chatPanel.appendEntries(turns.subList(displayStartTurnIdx, displayEndTurnIdx + 1).flatten())
-        chatPanel.scrollToEntry(targetEntryId)
+        chatPanel.scrollToTop()
 
         loadEarlierLabel.addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) = loadEarlier()

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/HistoryContextWindow.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/HistoryContextWindow.kt
@@ -1,7 +1,9 @@
 package com.github.catatafishen.agentbridge.ui.side
 
+import com.github.catatafishen.agentbridge.session.v2.SessionStoreV2
 import com.github.catatafishen.agentbridge.ui.ChatConsolePanel
 import com.github.catatafishen.agentbridge.ui.EntryData
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.WindowManager
@@ -22,20 +24,22 @@ import javax.swing.SwingConstants
  * Non-modal floating window showing conversation history centred on a specific prompt.
  *
  * Initially displays exactly the target prompt turn (user input + AI response).
- * The window is scrolled to the top so the user prompt is immediately visible.
  * "Load more" links at the top and bottom expand by one turn at a time using
  * [ChatConsolePanel.prependEntries] and [ChatConsolePanel.appendEntries] — the JCEF
  * panel is never recreated on load-more, so there is no flash or re-scroll.
+ *
+ * Entries are loaded asynchronously from [sessionId] so the window appears immediately
+ * while data is fetched in the background.
  */
 internal class HistoryContextWindow private constructor(
-    project: Project,
-    allEntries: List<EntryData>,
-    targetEntryId: String,
+    private val project: Project,
+    private val sessionId: String,
+    private val targetEntryId: String,
 ) : JDialog(WindowManager.getInstance().getFrame(project), "Conversation History", false) {
 
     companion object {
-        fun open(project: Project, allEntries: List<EntryData>, targetEntryId: String) {
-            val win = HistoryContextWindow(project, allEntries, targetEntryId)
+        fun open(project: Project, sessionId: String, targetEntryId: String) {
+            val win = HistoryContextWindow(project, sessionId, targetEntryId)
             win.pack()
             win.setLocationRelativeTo(WindowManager.getInstance().getFrame(project))
             win.isVisible = true
@@ -72,10 +76,9 @@ internal class HistoryContextWindow private constructor(
         }
     }
 
-    private val turns: List<List<EntryData>> = splitIntoTurns(allEntries)
-    private val targetTurnIdx: Int = findTurnIndex(turns, targetEntryId)
-    private var displayStartTurnIdx: Int = targetTurnIdx
-    private var displayEndTurnIdx: Int = targetTurnIdx
+    private var turns: List<List<EntryData>> = emptyList()
+    private var displayStartTurnIdx: Int = 0
+    private var displayEndTurnIdx: Int = 0
 
     private val chatPanel = ChatConsolePanel(project, registerAsMain = false)
 
@@ -86,11 +89,13 @@ internal class HistoryContextWindow private constructor(
         isOpaque = false
         border = JBUI.Borders.empty(4)
         add(loadEarlierLabel, BorderLayout.CENTER)
+        isVisible = false
     }
     private val bottomBar = JPanel(BorderLayout()).apply {
         isOpaque = false
         border = JBUI.Borders.empty(4)
         add(loadLaterLabel, BorderLayout.CENTER)
+        isVisible = false
     }
 
     init {
@@ -105,8 +110,6 @@ internal class HistoryContextWindow private constructor(
         isResizable = true
 
         chatPanel.setDomMessageLimit(100_000)
-        chatPanel.appendEntries(turns.subList(displayStartTurnIdx, displayEndTurnIdx + 1).flatten())
-        chatPanel.scrollToTop()
 
         loadEarlierLabel.addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) = loadEarlier()
@@ -115,11 +118,33 @@ internal class HistoryContextWindow private constructor(
             override fun mouseClicked(e: MouseEvent) = loadLater()
         })
 
-        updateBars()
-
         addWindowListener(object : WindowAdapter() {
             override fun windowClosed(e: WindowEvent) = Disposer.dispose(chatPanel)
         })
+
+        loadEntriesAsync()
+    }
+
+    private fun loadEntriesAsync() {
+        val sessionStore = SessionStoreV2.getInstance(project)
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val entries = sessionStore.loadEntriesBySessionId(project, sessionId).orEmpty()
+            ApplicationManager.getApplication().invokeLater {
+                if (!isDisplayable) return@invokeLater
+                onEntriesLoaded(entries)
+            }
+        }
+    }
+
+    private fun onEntriesLoaded(entries: List<EntryData>) {
+        turns = splitIntoTurns(entries)
+        val targetTurnIdx = findTurnIndex(turns, targetEntryId)
+        displayStartTurnIdx = targetTurnIdx
+        displayEndTurnIdx = targetTurnIdx
+        if (turns.isNotEmpty()) {
+            chatPanel.appendEntries(turns.subList(displayStartTurnIdx, displayEndTurnIdx + 1).flatten())
+        }
+        updateBars()
     }
 
     private fun loadEarlier() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/PromptsPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/PromptsPanel.kt
@@ -56,6 +56,9 @@ internal class PromptsPanel(
     @Volatile
     private var historyEntries: List<EntryData> = emptyList()
 
+    @Volatile
+    private var promptSessionMap: Map<String, String> = emptyMap()
+
     private val loadMoreLabel = JLabel("↑ Load earlier prompts").apply {
         font = JBUI.Fonts.miniFont()
         foreground = JBUI.CurrentTheme.Link.Foreground.ENABLED
@@ -91,7 +94,8 @@ internal class PromptsPanel(
                 if (chatConsole.isEntryRendered(entryId)) {
                     chatConsole.scrollToEntry(entryId)
                 } else {
-                    HistoryContextWindow.open(project, historyEntries, entryId)
+                    val sessionId = promptSessionMap[entryId] ?: return
+                    HistoryContextWindow.open(project, sessionId, entryId)
                 }
             }
         })
@@ -148,10 +152,19 @@ internal class PromptsPanel(
     private fun reloadHistoryAsync() {
         val serial = historyLoadSerial.incrementAndGet()
         ApplicationManager.getApplication().executeOnPooledThread {
-            val loaded = sessionStore.loadEntries(project.basePath).orEmpty()
+            val allPrompts = sessionStore.loadPromptsFromAllSessions(project)
+            val entries = mutableListOf<EntryData>()
+            val sessionMap = mutableMapOf<String, String>()
+            for (pwc in allPrompts) {
+                entries.add(pwc.prompt)
+                pwc.stats?.let { entries.add(it) }
+                val key = promptEntryId(pwc.prompt)
+                if (key.isNotEmpty()) sessionMap[key] = pwc.sessionId
+            }
             ApplicationManager.getApplication().invokeLater {
                 if (serial != historyLoadSerial.get()) return@invokeLater
-                historyEntries = loaded
+                historyEntries = entries
+                promptSessionMap = sessionMap
                 refresh()
             }
         }


### PR DESCRIPTION
## Summary

Clicking a prompt in the Prompts panel now opens a floating window showing **exactly that one conversation turn** — the user's prompt and the AI's response for it — regardless of which session it came from.

## Root cause

The previous implementation passed the current session's loaded entries to `HistoryContextWindow`, so prompts from older sessions couldn't be found → the window always fell back to the last turn of the current session.

## Changes

### `HistoryContextWindow.kt`
- Accepts `sessionId + targetEntryId` instead of a pre-loaded `List<EntryData>`
- Entries are loaded **asynchronously** on a background thread; window shows immediately
- Removed unnecessary `scrollToTop()` call (browser default is fine in history view)

### `PromptsPanel.kt`
- Loads prompts from **all sessions** via `SessionStoreV2.loadPromptsFromAllSessions(Project)`
- Builds a `promptSessionMap` (entryId → sessionId) used when a prompt is clicked

### `SessionStoreV2.java`
- Added `PromptWithContext` record and `loadPromptsFromAllSessions(Project)`
- Efficient line-by-line JSONL scan — only parses `prompt` and `turnStats` entries (safe even for 380MB session files)
- Added `loadEntriesBySessionId(Project, String)` using `ExportUtils.sessionsDir(Project)`
- Extracted `LOG_JSONL_PARSE_FAIL` constant (was duplicated 3×)

### `ExportUtils.java`
- `sessionsDir(String)` overload deprecated in favour of `sessionsDir(Project)` which uses `AgentBridgeStorageSettings`
