### PR TITLE
fix: wire shouldAutoDenyBuiltInTool into permission handler

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
@@ -757,18 +757,6 @@ public abstract class AcpClient extends AbstractAgentClient {
     }
 
     /**
-     * Hook called when a non-allowed built-in tool is approved. Subclasses may
-     * override to track tool misuse for corrective guidance. Default: no-op.
-     *
-     * @param toolId       the tool that was approved
-     * @param userApproved {@code true} if the user explicitly approved via a prompt;
-     *                     {@code false} if the plugin auto-approved without asking
-     */
-    protected void onBuiltInToolApproved(String toolId, boolean userApproved) {
-        // no-op — subclasses like CopilotClient may track for reprimand
-    }
-
-    /**
      * Called in the finally block after {@code sendPrompt} completes (success or failure).
      * Default: clears {@code updateConsumer}. Override to retain it (e.g. Kiro sends
      * thought chunks asynchronously after the prompt response).
@@ -1643,8 +1631,8 @@ public abstract class AcpClient extends AbstractAgentClient {
         if (!toolId.isEmpty() && isToolBlocked(protocolTitle, toolId)) {
             chosenOption = handleBlockedTool(toolId, toolCallId, params);
         } else if (isBuiltInTool(protocolTitle)) {
-            if (isAllowedBuiltInTool(toolId)) {
-                LOG.info(displayName() + ": auto-approving built-in web tool '" + toolId + "' — no MCP alternative exists");
+            if (shouldAutoDenyBuiltInTool(toolId)) {
+                chosenOption = handleAutoDeniedBuiltInTool(toolId, toolCallId, params);
             } else {
                 LOG.warn(displayName() + ": auto-approving built-in tool '" + toolId
                     + "' — should use MCP tools instead");
@@ -1653,10 +1641,10 @@ public abstract class AcpClient extends AbstractAgentClient {
                 if (!restoringHistory) {
                     onBuiltInToolApproved(toolId, false);
                 }
-            }
-            chosenOption = findOptionByKind(params, VALUE_ALLOW_ONCE);
-            if (chosenOption == null) {
-                chosenOption = findFirstOption(params);
+                chosenOption = findOptionByKind(params, VALUE_ALLOW_ONCE);
+                if (chosenOption == null) {
+                    chosenOption = findFirstOption(params);
+                }
             }
             // Copilot CLI does not send tool_call_update completion events for approved built-in
             // tools. Synthesize one so the tool chip clears its spinner immediately.
@@ -1695,6 +1683,40 @@ public abstract class AcpClient extends AbstractAgentClient {
         return findDenyOption(params);
     }
 
+    private @Nullable JsonObject handleAutoDeniedBuiltInTool(String toolId, String toolCallId, @Nullable JsonObject params) {
+        String reason = "Native tool '" + toolId + "' is blocked — use " + mcpAlternative(toolId)
+            + " instead. All agentbridge-* MCP tools are available.";
+        LOG.warn(displayName() + ": auto-denying native tool '" + toolId + "'");
+
+        Consumer<SessionUpdate> consumer = updateConsumer;
+        if (consumer != null && !toolCallId.isEmpty()) {
+            consumer.accept(new SessionUpdate.ToolCallUpdate(
+                toolCallId,
+                SessionUpdate.ToolCallStatus.FAILED,
+                null,
+                "Auto-denied: " + reason,
+                null,
+                true,
+                reason
+            ));
+        }
+        return findDenyOption(params);
+    }
+
+    static String mcpAlternative(String builtInTool) {
+        return switch (builtInTool) {
+            case "bash" -> "agentbridge-run_command or agentbridge-run_in_terminal";
+            case "edit" -> "agentbridge-edit_text or agentbridge-replace_symbol_body";
+            case "create" -> "agentbridge-create_file";
+            case "view" -> "agentbridge-read_file";
+            case "glob" -> "agentbridge-list_project_files";
+            case "grep" -> "agentbridge-search_text";
+            case "task" -> "agentbridge-run_command (for shell tasks)";
+            case "report_intent" -> "(not needed — IDE tracks intent automatically)";
+            default -> "the corresponding agentbridge-* tool";
+        };
+    }
+
     private void sendPermissionResponse(JsonElement id, String requestKey, @Nullable JsonObject chosenOption) {
         String optionId = chosenOption != null && chosenOption.has(KEY_OPTION_ID)
             ? chosenOption.get(KEY_OPTION_ID).getAsString()
@@ -1706,9 +1728,11 @@ public abstract class AcpClient extends AbstractAgentClient {
     }
 
     /**
-     * Whether this agent should block all built-in (non-MCP) tool calls,
-     * forcing the model to use agentbridge tools exclusively.
-     * Override in subclasses that require exclusive agentbridge usage.
+     * Whether to also block the small set of allowed built-in tools ({@code web_fetch},
+     * {@code web_search}, {@code task_complete}). By default, non-allowed built-in tools
+     * (e.g. {@code bash}, {@code edit}, {@code grep}) are always auto-denied via
+     * {@link #shouldAutoDenyBuiltInTool}. Override to return {@code true} to additionally
+     * block the allowed web tools in agents that require exclusive agentbridge usage.
      */
     protected boolean excludeBuiltInTools() {
         return false;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
@@ -1703,6 +1703,18 @@ public abstract class AcpClient extends AbstractAgentClient {
         return findDenyOption(params);
     }
 
+    /**
+     * Called when a built-in tool request is processed (approved or auto-denied).
+     * Subclasses may override to react — e.g. injecting a reprimand notice.
+     *
+     * @param toolId       the built-in tool name
+     * @param userApproved {@code true} if the user explicitly approved, {@code false} if
+     *                     the tool was auto-approved without user interaction
+     */
+    protected void onBuiltInToolApproved(String toolId, boolean userApproved) {
+        // no-op by default
+    }
+
     static String mcpAlternative(String builtInTool) {
         return switch (builtInTool) {
             case "bash" -> "agentbridge-run_command or agentbridge-run_in_terminal";

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -115,12 +115,6 @@ public final class CopilotClient extends AcpClient {
         "web_fetch", "web_search", "task_complete", "sql", "skill"
     );
 
-    /**
-     * Tracks built-in tools that were auto-approved but should have used MCP alternatives.
-     * Consumed and cleared on the next {@code session/prompt} via {@link #beforeSendPrompt}.
-     */
-    private final java.util.Set<String> misusedBuiltInTools = java.util.concurrent.ConcurrentHashMap.newKeySet();
-
     // ─── Lifecycle ───────────────────────────────────
 
     public CopilotClient(Project project) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -578,21 +578,7 @@ public final class CopilotClient extends AcpClient {
     private static String buildSingleToolReprimand(String toolId) {
         return "[System notice] You used the following built-in tools which duplicate our MCP tools. "
             + "Do NOT use these again — use the MCP alternatives instead:\n"
-            + "  • " + toolId + " → use " + mcpAlternative(toolId) + "\n"
+            + "  • " + toolId + " → use " + AcpClient.mcpAlternative(toolId) + "\n"
             + "All agentbridge-* MCP tools are available. Never use built-in tools when an MCP equivalent exists.";
-    }
-
-    private static String mcpAlternative(String builtInTool) {
-        return switch (builtInTool) {
-            case "bash" -> "agentbridge-run_command or agentbridge-run_in_terminal";
-            case "edit" -> "agentbridge-edit_text or agentbridge-replace_symbol_body";
-            case "create" -> "agentbridge-create_file";
-            case "view" -> "agentbridge-read_file";
-            case "glob" -> "agentbridge-list_project_files";
-            case "grep" -> "agentbridge-search_text";
-            case "task" -> "agentbridge-run_command (for shell tasks)";
-            case "report_intent" -> "(not needed — IDE tracks intent automatically)";
-            default -> "the corresponding agentbridge-* tool";
-        };
     }
 }


### PR DESCRIPTION
## Problem

`shouldAutoDenyBuiltInTool("bash")` correctly returns `true` and has tests proving it — but it was **never called** in production code. The `handlePermissionRequest()` built-in-tool branch always auto-approved with just a warning, so `bash` (and `edit`, `view`, `grep`) went through unchecked.

## Fix

- Wires `shouldAutoDenyBuiltInTool()` into `handlePermissionRequest()`
- Non-allowed tools now receive an ACP **deny** response with a tool-specific message naming the correct agentbridge-* alternative
- Allowed tools (web_fetch, web_search, task_complete) are still approved

## Cleanup

Removed the `CopilotClient` reprimand workaround (~80 lines) — it was compensating for the missing denial. Moved `mcpAlternative()` to `AcpClient` for use in denial messages.