### PR TITLE
fix: migrate legacy role/parts JSONL sessions to SQLite

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/ConversationWriter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/ConversationWriter.java
@@ -92,6 +92,9 @@ public final class ConversationWriter {
         } catch (SQLException e) {
             LOG.warn("ConversationWriter: failed to record " + entries.size()
                 + " entries for session " + sessionId, e);
+        } catch (IllegalArgumentException e) {
+            LOG.error("ConversationWriter: invalid entry data for session " + sessionId
+                + " — " + e.getMessage(), e);
         }
     }
 
@@ -102,15 +105,16 @@ public final class ConversationWriter {
         @NotNull String clientId,
         @NotNull List<EntryData> entries
     ) throws SQLException {
+        String startedAt = extractStartedAt(entries);
         conn.setAutoCommit(false);
         try {
-            ensureSession(conn, sessionId, agentName, clientId);
+            ensureSession(conn, sessionId, agentName, clientId, startedAt);
             for (EntryData entry : entries) {
                 writeEntry(conn, sessionId, clientId, entry);
             }
             updateSessionEndedAt(conn, sessionId);
             conn.commit();
-        } catch (SQLException e) {
+        } catch (SQLException | IllegalArgumentException e) {
             conn.rollback();
             throw e;
         } finally {
@@ -174,14 +178,15 @@ public final class ConversationWriter {
         @NotNull Connection conn,
         @NotNull String sessionId,
         @NotNull String agentName,
-        @NotNull String clientId
+        @NotNull String clientId,
+        @NotNull String startedAt
     ) throws SQLException {
         try (PreparedStatement ps = conn.prepareStatement(
             "INSERT OR IGNORE INTO sessions (id, agent_name, client_id, started_at) VALUES (?, ?, ?, ?)")) {
             ps.setString(1, sessionId);
             ps.setString(2, agentName);
             ps.setString(3, clientId);
-            ps.setString(4, Instant.now().toString());
+            ps.setString(4, startedAt);
             ps.executeUpdate();
         }
     }
@@ -210,7 +215,11 @@ public final class ConversationWriter {
         @NotNull EntryData.Prompt prompt
     ) throws SQLException {
         String turnId = prompt.getEntryId();
-        String startedAt = nonEmpty(prompt.getTimestamp(), Instant.now().toString());
+        String startedAt = prompt.getTimestamp();
+        if (startedAt == null || startedAt.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Prompt entry has no timestamp — cannot determine turn start time: id=" + turnId);
+        }
         try (PreparedStatement ps = conn.prepareStatement(
             "INSERT OR IGNORE INTO turns (id, session_id, prompt_text, started_at) VALUES (?, ?, ?, ?)")) {
             ps.setString(1, turnId);
@@ -274,6 +283,11 @@ public final class ConversationWriter {
         @NotNull String turnId,
         @NotNull EntryData.TurnStats stats
     ) throws SQLException {
+        String endedAt = stats.getTimestamp();
+        if (endedAt == null || endedAt.isEmpty()) {
+            throw new IllegalArgumentException(
+                "TurnStats entry has no timestamp — cannot set turn end time: turnId=" + turnId);
+        }
         try (PreparedStatement ps = conn.prepareStatement("""
             UPDATE turns SET
                 ended_at        = COALESCE(?, ended_at),
@@ -288,7 +302,7 @@ public final class ConversationWriter {
                 lines_removed   = ?
             WHERE id = ?
             """)) {
-            ps.setString(1, nonEmpty(stats.getTimestamp(), Instant.now().toString()));
+            ps.setString(1, endedAt);
             ps.setString(2, emptyToNull(stats.getModel()));
             setMultiplier(ps, 3, stats.getMultiplier());
             ps.setLong(4, stats.getInputTokens());
@@ -345,6 +359,10 @@ public final class ConversationWriter {
         @NotNull String agentName,
         @NotNull String model
     ) throws SQLException {
+        if (timestamp.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Event has no timestamp: id=" + eventId + " type=" + eventType);
+        }
         SessionCursor cursor = cursors.computeIfAbsent(sessionId, k -> new SessionCursor());
         int seq = cursor.nextSequence();
         try (PreparedStatement ps = conn.prepareStatement(
@@ -361,7 +379,7 @@ public final class ConversationWriter {
             ps.setString(4, eventType);
             ps.setString(5, emptyToNull(agentName));
             ps.setString(6, emptyToNull(model));
-            ps.setString(7, nonEmpty(timestamp, Instant.now().toString()));
+            ps.setString(7, timestamp);
             ps.executeUpdate();
         }
     }
@@ -636,14 +654,27 @@ public final class ConversationWriter {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    @NotNull
-    private static String nonEmpty(@Nullable String value, @NotNull String fallback) {
-        return (value == null || value.isEmpty()) ? fallback : value;
-    }
-
     @Nullable
     private static String emptyToNull(@Nullable String value) {
         return (value == null || value.isEmpty()) ? null : value;
+    }
+
+    /**
+     * Returns the first non-null, non-empty timestamp found in {@code entries}.
+     * Throws {@link IllegalArgumentException} if no entry carries a timestamp —
+     * callers must not proceed without a real timestamp (fail fast).
+     */
+    @NotNull
+    private static String extractStartedAt(@NotNull List<EntryData> entries) {
+        for (EntryData entry : entries) {
+            String ts = entry.getTimestamp();
+            if (ts != null && !ts.isEmpty()) {
+                return ts;
+            }
+        }
+        throw new IllegalArgumentException(
+            "None of the " + entries.size() + " entries carry a timestamp"
+                + " — cannot determine session start time");
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/JsonlToSqliteMigrator.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/JsonlToSqliteMigrator.java
@@ -18,10 +18,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Imports legacy JSONL session files into {@link ConversationDatabase}.
@@ -167,17 +169,131 @@ public final class JsonlToSqliteMigrator {
         }
     }
 
+    // ── Legacy role/parts format ──────────────────────────────────────────────
+
     private static void parseOneLine(@NotNull String line, @NotNull Path file,
                                      @NotNull List<EntryData> entries) {
         try {
             JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
-            if (EntryDataJsonAdapter.isEntryFormat(line)) {
+            if (EntryDataJsonAdapter.isEntryFormat(obj)) {
                 EntryData entry = EntryDataJsonAdapter.deserialize(obj);
                 if (entry != null) entries.add(entry);
+            } else if (obj.has(LEGACY_KEY_ROLE) && obj.has(LEGACY_KEY_PARTS)) {
+                parseLegacyMessage(obj, entries);
             }
         } catch (Exception e) {
             LOG.debug("JsonlToSqliteMigrator: skipped malformed line in " + file.getFileName());
         }
+    }
+
+    private static final String LEGACY_KEY_ROLE = "role";
+    private static final String LEGACY_KEY_AGENT = "agent";
+    private static final String LEGACY_KEY_PARTS = "parts";
+    private static final String LEGACY_KEY_CREATED_AT = "createdAt";
+    private static final String LEGACY_KEY_TOOL_INVOCATION = "toolInvocation";
+    private static final String LEGACY_KEY_RESULT = "result";
+    private static final String LEGACY_KEY_STATE = "state";
+    private static final String LEGACY_KEY_TOOL_NAME = "toolName";
+
+    /**
+     * Parses a legacy role/parts format message into one or more {@link EntryData} entries.
+     *
+     * <p>The legacy format predates the type-discriminated entry format. Each message line
+     * has the structure:
+     * <pre>{@code {"id":"...","role":"user"|"assistant","parts":[{"type":"text","text":"..."},...],"createdAt":millis}}</pre>
+     *
+     * <p>Each part is mapped to the nearest {@link EntryData} equivalent:
+     * <ul>
+     *   <li>{@code user/text} → {@link EntryData.Prompt}
+     *   <li>{@code assistant/text} → {@link EntryData.Text}
+     *   <li>{@code assistant/reasoning} → {@link EntryData.Thinking}
+     *   <li>{@code assistant/tool-invocation} → {@link EntryData.ToolCall}
+     *   <li>{@code assistant/subagent} → {@link EntryData.SubAgent}
+     * </ul>
+     *
+     * <p>Parts with an unrecognised type are silently skipped.
+     */
+    static void parseLegacyMessage(@NotNull JsonObject obj, @NotNull List<EntryData> entries) {
+        String role = legacyStr(obj, LEGACY_KEY_ROLE);
+        String msgId = obj.has("id") ? obj.get("id").getAsString() : UUID.randomUUID().toString();
+        String agent = legacyStr(obj, LEGACY_KEY_AGENT);
+        long createdAt = obj.has(LEGACY_KEY_CREATED_AT) ? obj.get(LEGACY_KEY_CREATED_AT).getAsLong() : 0L;
+        String timestamp = createdAt > 0 ? Instant.ofEpochMilli(createdAt).toString() : "";
+
+        if (!obj.has(LEGACY_KEY_PARTS) || !obj.get(LEGACY_KEY_PARTS).isJsonArray()) return;
+        JsonArray parts = obj.getAsJsonArray(LEGACY_KEY_PARTS);
+
+        for (int i = 0; i < parts.size(); i++) {
+            if (!parts.get(i).isJsonObject()) continue;
+            JsonObject part = parts.get(i).getAsJsonObject();
+            // Multi-part messages get per-part entryIds derived from the message id.
+            String entryId = parts.size() == 1 ? msgId : msgId + "-p" + i;
+            EntryData entry = convertLegacyPart(role, part, entryId, timestamp, agent);
+            if (entry != null) entries.add(entry);
+        }
+    }
+
+    @Nullable
+    private static EntryData convertLegacyPart(
+        @NotNull String role,
+        @NotNull JsonObject part,
+        @NotNull String entryId,
+        @NotNull String timestamp,
+        @NotNull String agent
+    ) {
+        String partType = legacyStr(part, "type");
+        String text = legacyStr(part, "text");
+        return switch (partType) {
+            case "text" -> "user".equals(role)
+                ? new EntryData.Prompt(text, timestamp, null, "", entryId)
+                : new EntryData.Text(text, timestamp, agent, "", entryId);
+            case "reasoning" -> new EntryData.Thinking(text, timestamp, agent, "", entryId);
+            case "tool-invocation" -> convertLegacyToolInvocation(part, timestamp, agent, entryId);
+            case "subagent" -> new EntryData.SubAgent(
+                legacyStr(part, "agentType"),
+                legacyStr(part, "description"),
+                legacyStrOrNull(part, "prompt"),
+                legacyStrOrNull(part, LEGACY_KEY_RESULT),
+                legacyStrOrNull(part, "status"),
+                part.has("colorIndex") ? part.get("colorIndex").getAsInt() : 0,
+                null, false, null,
+                timestamp, agent, "", entryId);
+            default -> null;
+        };
+    }
+
+    @Nullable
+    private static EntryData.ToolCall convertLegacyToolInvocation(
+        @NotNull JsonObject part, @NotNull String timestamp,
+        @NotNull String agent, @NotNull String entryId
+    ) {
+        if (!part.has(LEGACY_KEY_TOOL_INVOCATION) || !part.get(LEGACY_KEY_TOOL_INVOCATION).isJsonObject()) {
+            return null;
+        }
+        JsonObject ti = part.getAsJsonObject(LEGACY_KEY_TOOL_INVOCATION);
+        return new EntryData.ToolCall(
+            legacyStr(ti, LEGACY_KEY_TOOL_NAME),
+            legacyStrOrNull(ti, "args"),
+            "", // kind unknown in legacy format
+            legacyStrOrNull(ti, LEGACY_KEY_RESULT),
+            legacyStrOrNull(ti, LEGACY_KEY_STATE),
+            "", null, false, null, null,
+            timestamp, agent, "", entryId);
+    }
+
+    /**
+     * Returns the string value of a field in a legacy JSON object, or {@code ""} if absent.
+     */
+    private static String legacyStr(@NotNull JsonObject obj, @NotNull String key) {
+        return obj.has(key) ? obj.get(key).getAsString() : "";
+    }
+
+    /**
+     * Returns the string value of a field in a legacy JSON object, or {@code null} if absent.
+     */
+    @Nullable
+    private static String legacyStrOrNull(@NotNull JsonObject obj, @NotNull String key) {
+        return obj.has(key) ? obj.get(key).getAsString() : null;
     }
 
     /**
@@ -225,7 +341,7 @@ public final class JsonlToSqliteMigrator {
                 JsonObject rec = elem.getAsJsonObject();
                 String id = rec.has("id") ? rec.get("id").getAsString() : null;
                 if (id == null || id.isEmpty()) continue;
-                String agent = rec.has("agent") ? rec.get("agent").getAsString() : "Unknown";
+                String agent = rec.has(LEGACY_KEY_AGENT) ? rec.get(LEGACY_KEY_AGENT).getAsString() : "Unknown";
                 result.add(new SessionInfo(id, agent));
             }
         } catch (Exception e) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/JsonlToSqliteMigrator.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/JsonlToSqliteMigrator.java
@@ -10,6 +10,7 @@ import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -18,7 +19,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -39,6 +40,7 @@ public final class JsonlToSqliteMigrator {
 
     private static final Logger LOG = Logger.getInstance(JsonlToSqliteMigrator.class);
     static final String BACKUP_DIRNAME = "sessions-backup-jsonl";
+    private static final String JSONL_EXT = ".jsonl";
     private static final String BACKUP_README = """
         This directory contains backups of your session history in the legacy JSONL format.
         They were automatically moved here after a successful migration to the SQLite database.
@@ -200,7 +202,7 @@ public final class JsonlToSqliteMigrator {
 
         // Merge: index entries take precedence (they carry the agent name).
         // Supplement with any JSONL files not listed in the index.
-        Set<String> indexIds = new HashSet<>();
+        Set<String> indexIds = new LinkedHashSet<>();
         List<SessionInfo> merged = new ArrayList<>(fromIndex);
         for (SessionInfo s : fromIndex) {
             indexIds.add(s.id());
@@ -234,19 +236,38 @@ public final class JsonlToSqliteMigrator {
 
     @NotNull
     private static List<SessionInfo> scanForSessionFiles(@NotNull Path sessionsDir) {
+        Set<String> seenIds = new LinkedHashSet<>();
         List<SessionInfo> result = new ArrayList<>();
         try (var stream = Files.list(sessionsDir)) {
-            stream.filter(p -> p.toString().endsWith(".jsonl"))
-                .filter(p -> !p.getFileName().toString().contains(".part-"))
-                .forEach(p -> {
-                    String filename = p.getFileName().toString();
-                    String id = filename.substring(0, filename.length() - ".jsonl".length());
-                    result.add(new SessionInfo(id, "Unknown"));
+            stream.filter(p -> p.toString().endsWith(JSONL_EXT))
+                .map(p -> extractSessionIdFromFilename(p.getFileName().toString()))
+                .filter(id -> id != null && !id.isEmpty())
+                .forEach(id -> {
+                    if (seenIds.add(id)) {
+                        result.add(new SessionInfo(id, "Unknown"));
+                    }
                 });
         } catch (IOException e) {
             LOG.warn("JsonlToSqliteMigrator: failed to scan sessions directory", e);
         }
         return result;
+    }
+
+    /**
+     * Extracts the session ID from a JSONL filename.
+     * Handles both the active file ({@code <id>.jsonl}) and part files
+     * ({@code <id>.part-NNN.jsonl}).  Returns {@code null} for unrecognised names.
+     */
+    @Nullable
+    static String extractSessionIdFromFilename(@NotNull String filename) {
+        int partIdx = filename.indexOf(".part-");
+        if (partIdx >= 0) {
+            return filename.substring(0, partIdx);
+        }
+        if (filename.endsWith(JSONL_EXT)) {
+            return filename.substring(0, filename.length() - JSONL_EXT.length());
+        }
+        return null;
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/v2/EntryDataJsonAdapter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/v2/EntryDataJsonAdapter.java
@@ -5,6 +5,7 @@ import com.github.catatafishen.agentbridge.ui.EntryData;
 import com.github.catatafishen.agentbridge.ui.FileRef;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -376,12 +377,28 @@ public final class EntryDataJsonAdapter {
     // ── Format detection ──────────────────────────────────────────────────────
 
     /**
-     * Returns {@code true} if the JSON line uses the entry-per-line format
-     * (has a {@code "type"} field) as opposed to the old legacy role-based
-     * format (which uses a {@code "role"} field).
+     * Returns {@code true} if the given JSON object uses the entry-per-line format
+     * (has a top-level {@code "type"} field) as opposed to the old legacy role-based
+     * format (which uses a top-level {@code "role"} field).
+     */
+    public static boolean isEntryFormat(@NotNull JsonObject json) {
+        return json.has("type");
+    }
+
+    /**
+     * String-based overload for callers that have not yet parsed the JSON.
+     *
+     * <p><b>Prefer {@link #isEntryFormat(JsonObject)}</b> when the object is already parsed.
+     * This overload parses the JSON to perform an accurate top-level check, avoiding
+     * false positives from {@code "type"} appearing inside nested objects (e.g. legacy
+     * {@code "parts"} arrays).
      */
     public static boolean isEntryFormat(@NotNull String line) {
-        return line.contains("\"type\":");
+        try {
+            return isEntryFormat(JsonParser.parseString(line).getAsJsonObject());
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/db/JsonlToSqliteMigratorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/db/JsonlToSqliteMigratorTest.java
@@ -1,6 +1,8 @@
 package com.github.catatafishen.agentbridge.session.db;
 
 import com.github.catatafishen.agentbridge.ui.EntryData;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -153,22 +156,26 @@ class JsonlToSqliteMigratorTest {
     }
 
     @Test
-    void skipsLegacyFormatLines() throws Exception {
+    void migratesLegacyFormatLines() throws Exception {
         String index = "[{\"id\": \"sess-1\", \"agent\": \"Copilot\"}]";
         Files.writeString(sessionsDir.resolve("sessions-index.json"), index);
 
-        // Legacy format has "role" key, not "type"
+        // Legacy format has "role" key instead of "type"; entries inside "parts" use "type" for
+        // the part kind — this is the exact pattern that caused isEntryFormat() to return true
+        // incorrectly (false positive from nested "type":) yet produce null from deserialize().
         String jsonl = """
-            {"type":"prompt","text":"New format","timestamp":"2026-01-01T10:00:00Z","entryId":"t1"}
-            {"role":"assistant","parts":[{"type":"text","content":"legacy response"}]}
-            """;
+                {"type":"prompt","text":"New format","timestamp":"2026-01-01T10:00:00Z","entryId":"t1"}
+                {"id":"msg-1","role":"assistant","parts":[{"type":"text","text":"legacy response"}],"createdAt":1735689601000,"agent":"Copilot"}
+                """;
         Files.writeString(sessionsDir.resolve("sess-1.jsonl"), jsonl);
 
         int count = JsonlToSqliteMigrator.migrate(sessionsDir, writer);
         assertEquals(1, count);
 
         List<EntryData> entries = reader.loadEntries("sess-1");
-        assertEquals(1, entries.size()); // Only the new-format prompt
+        assertEquals(2, entries.size()); // new-format prompt + legacy assistant text
+        assertTrue(entries.stream().anyMatch(e -> e instanceof EntryData.Prompt));
+        assertTrue(entries.stream().anyMatch(e -> e instanceof EntryData.Text));
     }
 
     @Test
@@ -493,5 +500,175 @@ class JsonlToSqliteMigratorTest {
         assertNull(
             JsonlToSqliteMigrator.extractSessionIdFromFilename("README.txt"),
             "Non-JSONL file should return null");
+    }
+
+    // ── Legacy role/parts format tests ────────────────────────────────────────
+
+    /**
+     * Regression test for the root bug: a JSONL file whose lines are entirely in the legacy
+     * role/parts format was never migrated because isEntryFormat() had a false positive
+     * (matched the "type" string nested inside "parts") while deserialize() returned null
+     * (no top-level "type" key), leaving entries empty and skipping the session entirely.
+     */
+    @Test
+    void migratesFileWithOnlyLegacyEntries() throws Exception {
+        // No sessions-index.json — session discovered via file scan
+        String jsonl = """
+                {"id":"user-1","role":"user","parts":[{"type":"text","text":"Fix the bug"}],"createdAt":1735689601000}
+                {"id":"asst-1","role":"assistant","parts":[{"type":"reasoning","text":"Let me look..."},{"type":"text","text":"Here is the fix"}],"createdAt":1735689602000,"agent":"Copilot"}
+                """;
+        Files.writeString(sessionsDir.resolve("abc-session.jsonl"), jsonl);
+
+        int count = JsonlToSqliteMigrator.migrate(sessionsDir, writer);
+        assertEquals(1, count); // session must be migrated, not skipped
+
+        assertTrue(reader.sessionExists("abc-session"));
+        List<EntryData> entries = reader.loadEntries("abc-session");
+        // user message → Prompt; assistant reasoning → Thinking; assistant text → Text
+        assertEquals(3, entries.size());
+        assertTrue(entries.stream().anyMatch(e -> e instanceof EntryData.Prompt));
+        assertTrue(entries.stream().anyMatch(e -> e instanceof EntryData.Thinking));
+        assertTrue(entries.stream().anyMatch(e -> e instanceof EntryData.Text));
+    }
+
+    @Test
+    void parsesLegacyUserMessageAsPrompt() {
+        JsonObject obj = JsonParser.parseString(
+            "{\"id\":\"msg-1\",\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"text\":\"Hello\"}],\"createdAt\":1735689601000}"
+        ).getAsJsonObject();
+
+        List<EntryData> entries = new ArrayList<>();
+        JsonlToSqliteMigrator.parseLegacyMessage(obj, entries);
+
+        assertEquals(1, entries.size());
+        assertInstanceOf(EntryData.Prompt.class, entries.getFirst());
+        assertEquals("Hello", ((EntryData.Prompt) entries.getFirst()).getText());
+        assertEquals("2025-01-01T00:00:01Z", entries.getFirst().getTimestamp());
+    }
+
+    @Test
+    void parsesLegacyAssistantTextAsText() {
+        JsonObject obj = JsonParser.parseString(
+            "{\"id\":\"msg-1\",\"role\":\"assistant\",\"parts\":[{\"type\":\"text\",\"text\":\"response\"}],\"createdAt\":1735689601000,\"agent\":\"Copilot\"}"
+        ).getAsJsonObject();
+
+        List<EntryData> entries = new ArrayList<>();
+        JsonlToSqliteMigrator.parseLegacyMessage(obj, entries);
+
+        assertEquals(1, entries.size());
+        assertInstanceOf(EntryData.Text.class, entries.getFirst());
+        EntryData.Text text = (EntryData.Text) entries.getFirst();
+        assertEquals("response", text.getRaw());
+        assertEquals("Copilot", text.getAgent());
+    }
+
+    @Test
+    void parsesLegacyReasoningAsThinking() {
+        JsonObject obj = JsonParser.parseString(
+            "{\"id\":\"msg-1\",\"role\":\"assistant\",\"parts\":[{\"type\":\"reasoning\",\"text\":\"hmm...\"}],\"createdAt\":1735689601000,\"agent\":\"Copilot\"}"
+        ).getAsJsonObject();
+
+        List<EntryData> entries = new ArrayList<>();
+        JsonlToSqliteMigrator.parseLegacyMessage(obj, entries);
+
+        assertEquals(1, entries.size());
+        assertInstanceOf(EntryData.Thinking.class, entries.getFirst());
+        assertEquals("hmm...", ((EntryData.Thinking) entries.getFirst()).getRaw());
+    }
+
+    @Test
+    void parsesLegacyToolInvocationAsToolCall() {
+        JsonObject obj = JsonParser.parseString(
+            "{\"id\":\"msg-1\",\"role\":\"assistant\",\"parts\":[{\"type\":\"tool-invocation\",\"toolInvocation\":{\"toolName\":\"read_file\",\"args\":\"{}\",\"result\":\"contents\",\"state\":\"result\"}}],\"createdAt\":1735689601000,\"agent\":\"Copilot\"}"
+        ).getAsJsonObject();
+
+        List<EntryData> entries = new ArrayList<>();
+        JsonlToSqliteMigrator.parseLegacyMessage(obj, entries);
+
+        assertEquals(1, entries.size());
+        assertInstanceOf(EntryData.ToolCall.class, entries.getFirst());
+        EntryData.ToolCall tc = (EntryData.ToolCall) entries.getFirst();
+        assertEquals("read_file", tc.getTitle());
+        assertEquals("{}", tc.getArguments());
+        assertEquals("contents", tc.getResult());
+        assertEquals("result", tc.getStatus());
+    }
+
+    @Test
+    void parsesLegacySubagentAsSubAgent() {
+        JsonObject obj = JsonParser.parseString(
+            "{\"id\":\"msg-1\",\"role\":\"assistant\",\"parts\":[{\"type\":\"subagent\",\"agentType\":\"intellij-explore\",\"description\":\"Find auth\",\"prompt\":\"Find the auth module\",\"result\":\"Found it\",\"status\":\"completed\",\"colorIndex\":2}],\"createdAt\":1735689601000,\"agent\":\"Copilot\"}"
+        ).getAsJsonObject();
+
+        List<EntryData> entries = new ArrayList<>();
+        JsonlToSqliteMigrator.parseLegacyMessage(obj, entries);
+
+        assertEquals(1, entries.size());
+        assertInstanceOf(EntryData.SubAgent.class, entries.getFirst());
+        EntryData.SubAgent sa = (EntryData.SubAgent) entries.getFirst();
+        assertEquals("intellij-explore", sa.getAgentType());
+        assertEquals("Find auth", sa.getDescription());
+        assertEquals("Find the auth module", sa.getPrompt());
+        assertEquals("Found it", sa.getResult());
+        assertEquals("completed", sa.getStatus());
+        assertEquals(2, sa.getColorIndex());
+    }
+
+    @Test
+    void parsesLegacyMultiPartMessageGeneratesMultipleEntries() {
+        // A single assistant message with reasoning + text produces two separate entries,
+        // each with a unique entryId derived from the message id.
+        JsonObject obj = JsonParser.parseString(
+            "{\"id\":\"msg-abc\",\"role\":\"assistant\",\"parts\":[{\"type\":\"reasoning\",\"text\":\"thinking\"},{\"type\":\"text\",\"text\":\"answer\"}],\"createdAt\":1735689601000,\"agent\":\"Copilot\"}"
+        ).getAsJsonObject();
+
+        List<EntryData> entries = new ArrayList<>();
+        JsonlToSqliteMigrator.parseLegacyMessage(obj, entries);
+
+        assertEquals(2, entries.size());
+        assertInstanceOf(EntryData.Thinking.class, entries.get(0));
+        assertInstanceOf(EntryData.Text.class, entries.get(1));
+        // Each part gets a distinct entryId
+        assertNotEquals(entries.get(0).getEntryId(), entries.get(1).getEntryId());
+    }
+
+    @Test
+    void parsesLegacyTimestampFromCreatedAt() {
+        // createdAt in milliseconds should be converted to ISO-8601 timestamp
+        JsonObject obj = JsonParser.parseString(
+            "{\"id\":\"msg-1\",\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"text\":\"hi\"}],\"createdAt\":1735689601000}"
+        ).getAsJsonObject();
+
+        List<EntryData> entries = new ArrayList<>();
+        JsonlToSqliteMigrator.parseLegacyMessage(obj, entries);
+
+        assertEquals(1, entries.size());
+        assertEquals("2025-01-01T00:00:01Z", entries.getFirst().getTimestamp());
+    }
+
+    @Test
+    void parsesLegacyMissingCreatedAtUsesEmptyTimestamp() {
+        JsonObject obj = JsonParser.parseString(
+            "{\"id\":\"msg-1\",\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"text\":\"hi\"}]}"
+        ).getAsJsonObject();
+
+        List<EntryData> entries = new ArrayList<>();
+        JsonlToSqliteMigrator.parseLegacyMessage(obj, entries);
+
+        assertEquals(1, entries.size());
+        assertEquals("", entries.getFirst().getTimestamp());
+    }
+
+    @Test
+    void parsesLegacyUnknownPartTypeSkipped() {
+        // Parts with types we don't know about should not cause failures or produce entries.
+        JsonObject obj = JsonParser.parseString(
+            "{\"id\":\"msg-1\",\"role\":\"assistant\",\"parts\":[{\"type\":\"unknown-future-type\",\"data\":\"x\"}],\"createdAt\":1735689601000}"
+        ).getAsJsonObject();
+
+        List<EntryData> entries = new ArrayList<>();
+        JsonlToSqliteMigrator.parseLegacyMessage(obj, entries);
+
+        assertEquals(0, entries.size());
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/db/JsonlToSqliteMigratorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/db/JsonlToSqliteMigratorTest.java
@@ -12,11 +12,14 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -269,7 +272,8 @@ class JsonlToSqliteMigratorTest {
     void discoverSessionsFallsBackToFileScan() throws Exception {
         Files.writeString(sessionsDir.resolve("session-abc.jsonl"), "");
         Files.writeString(sessionsDir.resolve("session-def.jsonl"), "");
-        Files.writeString(sessionsDir.resolve("session-abc.part-001.jsonl"), ""); // Should be excluded
+        // Part file for session-abc — contributes the same session ID, deduplicated.
+        Files.writeString(sessionsDir.resolve("session-abc.part-001.jsonl"), "");
 
         List<JsonlToSqliteMigrator.SessionInfo> sessions =
             JsonlToSqliteMigrator.discoverSessions(sessionsDir);
@@ -318,5 +322,176 @@ class JsonlToSqliteMigratorTest {
 
         int count = JsonlToSqliteMigrator.migrate(sessionsDir, writer);
         assertEquals(0, count); // Empty file = no entries = not migrated
+    }
+
+    // ── Regression tests for the bugs fixed in feat/sqlite-only-storage ───────
+
+    /**
+     * sessions.started_at must equal the timestamp from the first JSONL entry,
+     * never the migration wall-clock time.
+     */
+    @Test
+    void sessionStartedAtMatchesFirstEntryTimestamp() throws Exception {
+        Files.writeString(sessionsDir.resolve("sessions-index.json"),
+            "[{\"id\": \"sess-ts\", \"agent\": \"Copilot\"}]");
+        Files.writeString(sessionsDir.resolve("sess-ts.jsonl"), """
+            {"type":"prompt","text":"Hi","timestamp":"2025-03-10T08:30:00Z","entryId":"t1"}
+            {"type":"turnStats","turnId":"t1","durationMs":1000,"inputTokens":10,"outputTokens":20,"costUsd":0.0,"toolCallCount":0,"linesAdded":0,"linesRemoved":0,"model":"gpt-4","timestamp":"2025-03-10T08:30:01Z","entryId":"s1"}
+            """);
+
+        JsonlToSqliteMigrator.migrate(sessionsDir, writer);
+
+        List<ConversationReader.SessionRecord> sessions = reader.listSessions();
+        assertEquals(1, sessions.size());
+        String startedAt = sessions.getFirst().startedAt();
+        assertEquals("2025-03-10T08:30:00Z", startedAt,
+            "started_at must come from the JSONL entry, not Instant.now()");
+    }
+
+    /**
+     * Multiple sessions must each be migrated as their own distinct session row with
+     * the correct number of turns.
+     */
+    @Test
+    void multipleSessionsAllMigratedWithCorrectTurnCounts() throws Exception {
+        String index = """
+            [
+              {"id": "session-a", "agent": "Copilot"},
+              {"id": "session-b", "agent": "Claude"},
+              {"id": "session-c", "agent": "Gemini"}
+            ]
+            """;
+        Files.writeString(sessionsDir.resolve("sessions-index.json"), index);
+
+        // session-a: 3 turns
+        Files.writeString(sessionsDir.resolve("session-a.jsonl"), """
+            {"type":"prompt","text":"P1","timestamp":"2025-01-01T10:00:00Z","entryId":"a-t1"}
+            {"type":"turnStats","turnId":"a-t1","durationMs":1000,"inputTokens":5,"outputTokens":10,"costUsd":0.0,"toolCallCount":0,"linesAdded":0,"linesRemoved":0,"model":"m","timestamp":"2025-01-01T10:01:00Z","entryId":"a-s1"}
+            {"type":"prompt","text":"P2","timestamp":"2025-01-01T10:02:00Z","entryId":"a-t2"}
+            {"type":"turnStats","turnId":"a-t2","durationMs":500,"inputTokens":3,"outputTokens":6,"costUsd":0.0,"toolCallCount":0,"linesAdded":0,"linesRemoved":0,"model":"m","timestamp":"2025-01-01T10:03:00Z","entryId":"a-s2"}
+            {"type":"prompt","text":"P3","timestamp":"2025-01-01T10:04:00Z","entryId":"a-t3"}
+            {"type":"turnStats","turnId":"a-t3","durationMs":200,"inputTokens":2,"outputTokens":4,"costUsd":0.0,"toolCallCount":0,"linesAdded":0,"linesRemoved":0,"model":"m","timestamp":"2025-01-01T10:05:00Z","entryId":"a-s3"}
+            """);
+
+        // session-b: 1 turn
+        Files.writeString(sessionsDir.resolve("session-b.jsonl"), """
+            {"type":"prompt","text":"Q1","timestamp":"2025-01-02T09:00:00Z","entryId":"b-t1"}
+            {"type":"turnStats","turnId":"b-t1","durationMs":800,"inputTokens":8,"outputTokens":16,"costUsd":0.0,"toolCallCount":0,"linesAdded":0,"linesRemoved":0,"model":"m","timestamp":"2025-01-02T09:01:00Z","entryId":"b-s1"}
+            """);
+
+        // session-c: 2 turns
+        Files.writeString(sessionsDir.resolve("session-c.jsonl"), """
+            {"type":"prompt","text":"R1","timestamp":"2025-01-03T11:00:00Z","entryId":"c-t1"}
+            {"type":"turnStats","turnId":"c-t1","durationMs":300,"inputTokens":1,"outputTokens":2,"costUsd":0.0,"toolCallCount":0,"linesAdded":0,"linesRemoved":0,"model":"m","timestamp":"2025-01-03T11:01:00Z","entryId":"c-s1"}
+            {"type":"prompt","text":"R2","timestamp":"2025-01-03T11:02:00Z","entryId":"c-t2"}
+            {"type":"turnStats","turnId":"c-t2","durationMs":400,"inputTokens":2,"outputTokens":4,"costUsd":0.0,"toolCallCount":0,"linesAdded":0,"linesRemoved":0,"model":"m","timestamp":"2025-01-03T11:03:00Z","entryId":"c-s2"}
+            """);
+
+        int count = JsonlToSqliteMigrator.migrate(sessionsDir, writer);
+        assertEquals(3, count);
+
+        List<ConversationReader.SessionRecord> sessions = reader.listSessions();
+        assertEquals(3, sessions.size(), "All three sessions must appear in SQLite");
+
+        Map<String, Integer> turnCounts = new HashMap<>();
+        for (ConversationReader.SessionRecord s : sessions) {
+            turnCounts.put(s.id(), s.turnCount());
+        }
+        assertEquals(3, turnCounts.get("session-a"), "session-a must have 3 turns");
+        assertEquals(1, turnCounts.get("session-b"), "session-b must have 1 turn");
+        assertEquals(2, turnCounts.get("session-c"), "session-c must have 2 turns");
+    }
+
+    /**
+     * A session that has only .part-NNN.jsonl files (no active .jsonl) must be
+     * discovered and migrated.  This is the root cause of "single session with all turns".
+     */
+    @Test
+    void sessionWithOnlyPartFilesIsDiscoveredAndMigrated() throws Exception {
+        // No sessions-index.json — rely solely on directory scan.
+        // The session has been fully rotated: only part files remain.
+        Files.writeString(sessionsDir.resolve("rotated-sess.part-001.jsonl"), """
+            {"type":"prompt","text":"OldPrompt","timestamp":"2024-12-01T08:00:00Z","entryId":"rp1"}
+            {"type":"turnStats","turnId":"rp1","durationMs":1000,"inputTokens":10,"outputTokens":20,"costUsd":0.0,"toolCallCount":0,"linesAdded":0,"linesRemoved":0,"model":"gpt-4","timestamp":"2024-12-01T08:01:00Z","entryId":"rs1"}
+            """);
+        Files.writeString(sessionsDir.resolve("rotated-sess.part-002.jsonl"), """
+            {"type":"prompt","text":"NewerPrompt","timestamp":"2024-12-02T09:00:00Z","entryId":"rp2"}
+            {"type":"turnStats","turnId":"rp2","durationMs":500,"inputTokens":5,"outputTokens":10,"costUsd":0.0,"toolCallCount":0,"linesAdded":0,"linesRemoved":0,"model":"gpt-4","timestamp":"2024-12-02T09:01:00Z","entryId":"rs2"}
+            """);
+        // No "rotated-sess.jsonl" base file exists.
+
+        int count = JsonlToSqliteMigrator.migrate(sessionsDir, writer);
+        assertEquals(1, count, "Part-only session must be migrated");
+
+        assertTrue(reader.sessionExists("rotated-sess"),
+            "rotated-sess must exist in SQLite");
+        List<ConversationReader.SessionRecord> sessions = reader.listSessions();
+        assertEquals(1, sessions.size());
+        assertEquals(2, sessions.getFirst().turnCount(),
+            "Both turns from both part files must be migrated");
+        assertEquals("2024-12-01T08:00:00Z", sessions.getFirst().startedAt(),
+            "started_at must come from the oldest part file entry");
+    }
+
+    /**
+     * Each session must receive only its own turns — entries from session A must never
+     * appear under session B.
+     */
+    @Test
+    void eachSessionReceivesOnlyItsOwnEntries() throws Exception {
+        String index = """
+            [
+              {"id": "alpha", "agent": "Copilot"},
+              {"id": "beta",  "agent": "Claude"}
+            ]
+            """;
+        Files.writeString(sessionsDir.resolve("sessions-index.json"), index);
+
+        Files.writeString(sessionsDir.resolve("alpha.jsonl"), """
+            {"type":"prompt","text":"Alpha question","timestamp":"2025-06-01T10:00:00Z","entryId":"alpha-t1"}
+            {"type":"text","raw":"Alpha answer","timestamp":"2025-06-01T10:00:01Z","agent":"assistant","model":"m","entryId":"alpha-e1"}
+            {"type":"turnStats","turnId":"alpha-t1","durationMs":100,"inputTokens":1,"outputTokens":2,"costUsd":0.0,"toolCallCount":0,"linesAdded":0,"linesRemoved":0,"model":"m","timestamp":"2025-06-01T10:00:02Z","entryId":"alpha-s1"}
+            """);
+
+        Files.writeString(sessionsDir.resolve("beta.jsonl"), """
+            {"type":"prompt","text":"Beta question","timestamp":"2025-06-02T10:00:00Z","entryId":"beta-t1"}
+            {"type":"text","raw":"Beta answer","timestamp":"2025-06-02T10:00:01Z","agent":"assistant","model":"m","entryId":"beta-e1"}
+            {"type":"turnStats","turnId":"beta-t1","durationMs":100,"inputTokens":1,"outputTokens":2,"costUsd":0.0,"toolCallCount":0,"linesAdded":0,"linesRemoved":0,"model":"m","timestamp":"2025-06-02T10:00:02Z","entryId":"beta-s1"}
+            """);
+
+        JsonlToSqliteMigrator.migrate(sessionsDir, writer);
+
+        List<EntryData> alphaEntries = reader.loadEntries("alpha");
+        List<EntryData> betaEntries = reader.loadEntries("beta");
+
+        assertTrue(alphaEntries.stream().anyMatch(e ->
+            e instanceof EntryData.Prompt p && "Alpha question".equals(p.getText())));
+        assertTrue(betaEntries.stream().anyMatch(e ->
+            e instanceof EntryData.Prompt p && "Beta question".equals(p.getText())));
+
+        // Cross-contamination check: alpha must not contain beta's entries and vice versa.
+        assertFalse(alphaEntries.stream().anyMatch(e ->
+                e instanceof EntryData.Prompt p && "Beta question".equals(p.getText())),
+            "Alpha session must not contain Beta's prompt");
+        assertFalse(betaEntries.stream().anyMatch(e ->
+                e instanceof EntryData.Prompt p && "Alpha question".equals(p.getText())),
+            "Beta session must not contain Alpha's prompt");
+    }
+
+    /**
+     * extractSessionIdFromFilename must correctly strip both the active extension
+     * and part-file extensions.
+     */
+    @Test
+    void extractSessionIdFromFilenameHandlesBothFileTypes() {
+        assertEquals("my-session",
+            JsonlToSqliteMigrator.extractSessionIdFromFilename("my-session.jsonl"));
+        assertEquals("my-session",
+            JsonlToSqliteMigrator.extractSessionIdFromFilename("my-session.part-001.jsonl"));
+        assertEquals("my-session",
+            JsonlToSqliteMigrator.extractSessionIdFromFilename("my-session.part-099.jsonl"));
+        assertNull(
+            JsonlToSqliteMigrator.extractSessionIdFromFilename("README.txt"),
+            "Non-JSONL file should return null");
     }
 }


### PR DESCRIPTION
## Problem

Nearly all legacy JSONL sessions were silently skipped during migration. Only sessions already in the new `type`-discriminated format were migrated; the old `role`/`parts` format was never handled.

## Root Cause

Two compounding bugs:

**Bug 1 — false positive in `EntryDataJsonAdapter.isEntryFormat(String)`**

Used `line.contains("\"type\":")` which returned `true` for legacy lines because `"type":` appears *nested* inside `"parts":[{"type":"text",...}]`.

**Bug 2 — silent null from `deserialize()`**

Called with a legacy object (has `"role"`, not top-level `"type"`), the switch hit `default` → returned `null`. All entries → null → `entries.isEmpty()` → session not migrated, not moved to backup. Zero errors logged — completely silent.

## Fix

- **`EntryDataJsonAdapter.isEntryFormat()`**: Added `JsonObject` overload that checks `json.has("type")`; the `String` overload now parses JSON and delegates (not a substring match)
- **`JsonlToSqliteMigrator.parseOneLine()`**: Uses the object-based check and routes legacy lines (`role`+`parts`) to new `parseLegacyMessage()`
- **`parseLegacyMessage()`** maps the legacy format:
  - `role:user + parts[type:text]` → `EntryData.Prompt`
  - `role:assistant + parts[type:text]` → `EntryData.Text`
  - `role:assistant + parts[type:reasoning]` → `EntryData.Thinking`
  - `role:assistant + parts[type:tool-invocation]` → `EntryData.ToolCall`
  - `role:assistant + parts[type:subagent]` → `EntryData.SubAgent`
  - Multi-part messages → one entry per part with `-p{N}` id suffix

## Tests

Renamed `skipsLegacyFormatLines` → `migratesLegacyFormatLines` (regression test) + 9 new tests:
- `migratesFileWithOnlyLegacyEntries` — primary regression test for the root bug
- `parsesLegacyUserMessageAsPrompt`
- `parsesLegacyAssistantTextAsText`
- `parsesLegacyReasoningAsThinking`
- `parsesLegacyToolInvocationAsToolCall`
- `parsesLegacySubagentAsSubAgent`
- `parsesLegacyMultiPartMessageGeneratesMultipleEntries`
- `parsesLegacyTimestampFromCreatedAt`
- `parsesLegacyMissingCreatedAtUsesEmptyTimestamp`
- `parsesLegacyUnknownPartTypeSkipped`

All 31 tests pass.