### PR TITLE
feat: add Hermes Agent ACP client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,17 @@ See [JUNIE-TOOL-WORKAROUND.md](docs/JUNIE-TOOL-WORKAROUND.md).
 
 **Status**: ⚠️ **Experimental** (agent definitions supported via `allowedTools`, but hangs on non-allowed tool prompts)
 
+## Hermes Agent
+
+**Location**: `~/.hermes/skills/*` (skills, not agent definitions)
+**Format**: N/A — Hermes does not use ACP-side agent-definition files for tool filtering. Tool gating happens through Hermes's own toolset/skill system in `~/.hermes/config.yaml`.
+
+**Bundled Agents**: 0 (Hermes integrates as a single agent; sub-agents are spawned via its own `delegate_task` tool, not ACP-level agent definitions)
+
+**MCP Tool Prefix**: `mcp_agentbridge_` (Hermes names MCP tools as `mcp_<server>_<tool>`)
+
+**Status**: ✅ Working (HTTP MCP server injected via `session/new`; requires `hermes acp --accept-hooks` because the plugin launches Hermes without a TTY for hook prompts)
+
 ## Summary Table
 
 | Agent    | MCP Tool Prefix | Agent Definition Support         | Tool Filtering Format                                      | Permission Requests  | Bundled Agents                      | Status                     |
@@ -317,6 +328,7 @@ See [JUNIE-TOOL-WORKAROUND.md](docs/JUNIE-TOOL-WORKAROUND.md).
 | OpenCode | `agentbridge_`  | ✅ `.opencode/agent/*.md` or JSON | YAML object: `permission: {"*": "deny", "tool1": "allow"}` | ✅ Yes                | 2 (ide-general, intellij-explore)   | ✅ Working                  |
 | Junie    | `agentbridge-`  | ❌ No support                     | N/A                                                        | ❌ No (auto-executes) | 0                                   | Prompt workaround only     |
 | Kiro     | `@agentbridge/` | ✅ `.agent-work/.kiro/agents/`    | JSON: `allowedTools: ["tool1"]`                            | ⚠️ Hangs on prompts  | 1 (intellij-agent)                  | ⚠️ Experimental (hangs)    |
+| Hermes   | `mcp_agentbridge_` | ❌ No ACP-side definitions       | N/A (gating via `~/.hermes/config.yaml` toolsets/skills)   | ✅ Via `--accept-hooks` | 0 (sub-agents via `delegate_task`)  | ✅ Working                  |
 
 See [.agent-work/OPENCODE-AGENT-FINDINGS.md](.agent-work/OPENCODE-AGENT-FINDINGS.md) for detailed OpenCode
 investigation and [.agent-work/KIRO-AGENT-FINDINGS.md](.agent-work/KIRO-AGENT-FINDINGS.md) for Kiro findings.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -251,7 +251,7 @@ screen.
 Switch between AI agents without losing your conversation. AgentBridge maintains a universal
 session format that works across all supported clients — so your context travels with you.
 
-- **Seamless agent switching** — switch from GitHub Copilot to Claude, OpenCode, Junie, or Kiro
+- **Seamless agent switching** — switch from GitHub Copilot to Claude, OpenCode, Junie, Kiro, or Hermes Agent
   mid-project and pick up exactly where you left off
 - **Full context preserved** — the restored agent sees your entire conversation history: messages,
   tool calls, code edits, and reasoning
@@ -267,7 +267,7 @@ session format that works across all supported clients — so your context trave
 
 Connect any ACP-compatible agent and switch between profiles instantly.
 
-- **Agent profiles** — Built-in profiles for GitHub Copilot, opencode, and Claude Code, plus fully custom profiles
+- **Agent profiles** — Built-in profiles for GitHub Copilot, opencode, Claude Code, and Hermes Agent, plus fully custom profiles
 - **Per-profile settings** — Connection command, tool permissions, built-in tool blocking, custom instructions
 - **Agent selector** — Switch agents with one click from the connection panel
 - **Extensible** — Add new agent backends by implementing `AgentConfig` + `AgentSettings` interfaces
@@ -378,7 +378,7 @@ Choose the right model for the task and track usage in real time.
 
 ## Requirements
 
-- **An ACP-compatible agent CLI** (e.g., GitHub Copilot CLI, opencode, Claude Code
+- **An ACP-compatible agent CLI** (e.g., GitHub Copilot CLI, opencode, Hermes Agent, Claude Code
   via [claude-code-acp](https://www.npmjs.com/package/@zed-industries/claude-code-acp))
 - **IntelliJ IDEA 2025.3** or later (compatible with any JetBrains IDE)
 - **Java 21+** runtime

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -267,7 +267,7 @@ session format that works across all supported clients — so your context trave
 
 Connect any ACP-compatible agent and switch between profiles instantly.
 
-- **Agent profiles** — Built-in profiles for GitHub Copilot, opencode, Claude Code, and Hermes Agent, plus fully custom profiles
+- **Agent profiles** — Built-in profiles for every supported agent (Copilot, Claude Code, Codex, Junie, Kiro, OpenCode, Hermes Agent), plus fully custom profiles
 - **Per-profile settings** — Connection command, tool permissions, built-in tool blocking, custom instructions
 - **Agent selector** — Switch agents with one click from the connection panel
 - **Extensible** — Add new agent backends by implementing `AgentConfig` + `AgentSettings` interfaces

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -4,7 +4,7 @@
 
 - IntelliJ IDEA 2025.1 or later (any JetBrains IDE)
 - Java 21 installed
-- An ACP-compatible agent CLI (e.g., GitHub Copilot CLI, OpenCode, Junie, Kiro)
+- An ACP-compatible agent CLI (e.g., GitHub Copilot CLI, OpenCode, Junie, Kiro, Hermes Agent)
 
 ## Installation Steps
 

--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -85,7 +85,7 @@ restarting.
 
 - **92 MCP tools** — File I/O, PSI analysis, refactoring, git, testing, terminal, documentation
 - **ACP protocol** — Direct integration with ACP-compatible agent CLIs
-- **Multi-agent support** — Switch between Copilot, OpenCode, Junie, Kiro, or custom profiles
+- **Multi-agent support** — Switch between Copilot, OpenCode, Junie, Kiro, Hermes Agent, or custom profiles
 - **Permission routing** — File edits routed through IntelliJ Document API with auto-format
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for full architecture and debugging guide.

--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 1. **JDK 21** — Install via your package manager or SDKMAN
-2. **An ACP-compatible agent CLI** — e.g., GitHub Copilot CLI (`copilot auth`), OpenCode, Junie, or Kiro
+2. **An ACP-compatible agent CLI** — e.g., GitHub Copilot CLI (`copilot auth`), OpenCode, Junie, Kiro, or Hermes Agent
 3. **IntelliJ IDEA 2025.1+** — Any JetBrains IDE (Ultimate, Community, WebStorm, PyCharm, etc.)
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or generating diffs in isolation.
 
 **Key highlights:**
 
-- **6 agents** — Copilot, Claude Code, Codex, Kiro, Junie, OpenCode. Switch with one click.
+- **7 agents** — Copilot, Claude Code, Codex, Kiro, Junie, OpenCode, Hermes Agent. Switch with one click.
 - **120+ MCP tools** — code navigation, refactoring, testing, debugging, git, project management,
   and more — all through native IntelliJ APIs.
 - **Cross-client session resume** — switch agents without losing conversation history.
@@ -197,7 +197,7 @@ graph TD
             APM["AgentProfileManager"]
         end
         subgraph clients["Agent Clients"]
-            AC["AcpClient — Copilot, Junie, Kiro, OpenCode"]
+            AC["AcpClient — Copilot, Junie, Kiro, OpenCode, Hermes Agent"]
             CC["ClaudeCliClient — Claude Code"]
             XC["CodexAppServerClient — Codex"]
         end
@@ -218,7 +218,7 @@ graph TD
 **Three layers:**
 
 - **UI** — JCEF-based chat panel, model selector, context management. Agent-agnostic.
-- **Clients** — `AcpClient` (shared by Copilot, Junie, Kiro, OpenCode), `ClaudeCliClient`,
+- **Clients** — `AcpClient` (shared by Copilot, Junie, Kiro, OpenCode, Hermes Agent), `ClaudeCliClient`,
   `CodexAppServerClient`. Each wraps its agent CLI's stdin/stdout protocol.
 - **MCP** — 120+ tools implemented against IntelliJ's PSI, VFS, and platform APIs. Exposed
   via an HTTP bridge to a bundled MCP stdio server (JAR).

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ a plugin with no reviews.
 | **Kiro**                       | ACP (stdin/stdout)         | Amazon auth                   |
 | **Junie**                      | ACP (stdin/stdout)         | JetBrains auth                |
 | **OpenCode**                   | ACP (stdin/stdout)         | Configurable (multi-provider) |
+| **Hermes Agent**               | ACP (stdin/stdout)         | Configurable (multi-provider) |
 
 Switch between agents with one click. Each agent has its own connection settings,
 tool permissions, and custom instructions.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,7 +96,7 @@ public final class ActiveAgentManager implements Disposable {
 
 Manages the collection of available agent profiles:
 
-- Built-in profiles: GitHub Copilot, OpenCode, Junie, Kiro, Claude Code
+- Built-in profiles: GitHub Copilot, OpenCode, Junie, Kiro, Claude Code, Hermes Agent
 - Custom user-defined profiles
 - Profile persistence and serialization
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/HermesClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/HermesClient.java
@@ -76,8 +76,8 @@ public final class HermesClient extends AcpClient {
     /**
      * Adds the {@code mcpServers} array to session/new params.
      * <p>
-     * Uses the ACP-standard {@link com.github.catatafishen.agentbridge.acp.schema.McpServerHttp}
-     * shape: {@code {"name": "agentbridge", "url": "...", "headers": []}}.
+     * Uses the ACP-standard HTTP MCP server shape:
+     * {@code {"type": "http", "name": "agentbridge", "url": "...", "headers": []}}.
      * Hermes reads this list and registers the HTTP MCP server for the session.
      */
     static void addMcpServerConfig(int mcpPort, JsonObject params) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/HermesClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/HermesClient.java
@@ -1,0 +1,142 @@
+package com.github.catatafishen.agentbridge.acp.client;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Hermes Agent ACP client.
+ * <p>
+ * Command: {@code hermes acp --accept-hooks}
+ * Tool prefix: {@code mcp_agentbridge_read_file} → strip {@code mcp_agentbridge_}
+ * MCP: HTTP via {@code mcpServers} in {@code session/new}
+ * References: requires inline (no ACP resource blocks)
+ * <p>
+ * Hermes Agent is an open-source AI agent framework by Nous Research.
+ * It supports any LLM provider via configuration in {@code ~/.hermes/config.yaml}.
+ * Install: <a href="https://github.com/NousResearch/hermes-agent">github.com/NousResearch/hermes-agent</a>
+ * <p>
+ * The {@code --accept-hooks} flag auto-approves any shell hooks that would otherwise
+ * require a TTY prompt, which is necessary since the plugin launches Hermes without
+ * a terminal attached.
+ */
+public final class HermesClient extends AcpClient {
+
+    public static final String AGENT_ID = "hermes";
+    /**
+     * Hermes names MCP tools as {@code mcp_<server>_<tool>}, e.g. {@code mcp_agentbridge_read_file}.
+     * The prefix to strip is {@code mcp_agentbridge_}.
+     */
+    private static final String TOOL_PREFIX = "mcp_agentbridge_";
+    private static final String KEY_MCP_SERVERS = "mcpServers";
+
+    public HermesClient(Project project) {
+        super(project);
+    }
+
+    @Override
+    public String agentId() {
+        return AGENT_ID;
+    }
+
+    @Override
+    public String displayName() {
+        return "Hermes Agent";
+    }
+
+    @Override
+    protected List<String> buildCommand(String cwd, int mcpPort) {
+        // --accept-hooks auto-approves shell hooks that would otherwise prompt
+        // on a TTY we don't have when launched from the IDE plugin.
+        return List.of("hermes", "acp", "--accept-hooks");
+    }
+
+    @Override
+    protected Map<String, String> buildEnvironment(int mcpPort, String cwd) {
+        // Hermes reads its config from ~/.hermes/config.yaml and ~/.hermes/.env.
+        // No extra env vars needed — the MCP server is injected via session/new.
+        return Map.of();
+    }
+
+    /**
+     * Injects the agentbridge MCP server into {@code session/new} so Hermes
+     * can call IDE tools without any manual configuration.
+     */
+    @Override
+    protected void customizeNewSession(String cwd, int mcpPort, JsonObject params) {
+        addMcpServerConfig(mcpPort, params);
+    }
+
+    /**
+     * Adds the {@code mcpServers} array to session/new params.
+     * <p>
+     * Uses the ACP-standard {@link com.github.catatafishen.agentbridge.acp.schema.McpServerHttp}
+     * shape: {@code {"name": "agentbridge", "url": "...", "headers": []}}.
+     * Hermes reads this list and registers the HTTP MCP server for the session.
+     */
+    static void addMcpServerConfig(int mcpPort, JsonObject params) {
+        JsonObject server = new JsonObject();
+        server.addProperty("type", "http");   // required discriminator for HttpMcpServer
+        server.addProperty("name", "agentbridge");
+        // Use 127.0.0.1 explicitly: on some systems "localhost" resolves to IPv6 (::1)
+        // while the MCP server binds to IPv4, causing connection failures.
+        server.addProperty("url", "http://127.0.0.1:" + mcpPort + "/mcp");
+        server.add("headers", new JsonArray());
+
+        JsonArray servers = new JsonArray();
+        servers.add(server);
+        params.add(KEY_MCP_SERVERS, servers);
+    }
+
+    @Override
+    protected String loadSession(String cwd, String sessionId)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        String result = sendLoadSessionRequest("session/resume", cwd, sessionId);
+        markSessionHistoryLoadedInternally();
+        return result;
+    }
+
+    /**
+     * Hermes names MCP tools as {@code mcp_<server>_<tool>},
+     * e.g. {@code mcp_agentbridge_read_file}. Strip that prefix to get the bare tool ID.
+     */
+    @Override
+    protected String resolveToolId(String protocolTitle) {
+        return stripToolPrefix(protocolTitle);
+    }
+
+    @Override
+    protected boolean isMcpToolTitle(@NotNull String protocolTitle) {
+        return hasToolPrefix(protocolTitle);
+    }
+
+    /**
+     * Strips the {@code mcp_agentbridge_} prefix from a Hermes MCP tool title.
+     */
+    static String stripToolPrefix(String protocolTitle) {
+        return protocolTitle.replaceFirst("^" + TOOL_PREFIX, "");
+    }
+
+    /**
+     * Returns {@code true} if the title carries the agentbridge MCP prefix.
+     */
+    static boolean hasToolPrefix(String protocolTitle) {
+        return protocolTitle.startsWith(TOOL_PREFIX);
+    }
+
+    @Override
+    public boolean requiresInlineReferences() {
+        return true;
+    }
+
+    @Override
+    protected boolean supportsAuthenticate() {
+        return false;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/model/NewSessionResponseDeserializer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/model/NewSessionResponseDeserializer.java
@@ -15,7 +15,7 @@ import java.util.Map;
 /**
  * Normalises the various {@code session/new} response wire formats from different ACP agents.
  * <p>
- * All agents (Copilot, Junie, Kiro, OpenCode) wrap models and modes in a container object:
+ * All agents (Copilot, Junie, Kiro, OpenCode, Hermes Agent) wrap models and modes in a container object:
  * <pre>
  *   "models": { "availableModels": [{modelId, name, description, _meta}, ...], "currentModelId": "..." }
  *   "modes":  { "availableModes": [{id, name, description}, ...], "currentModeId": "..." }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/AbstractAgentClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/AbstractAgentClient.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 /**
- * Unified abstract base class for all agent types: ACP-based (Copilot, Junie, Kiro, OpenCode)
+ * Unified abstract base class for all agent types: ACP-based (Copilot, Junie, Kiro, OpenCode, Hermes Agent)
  * and non-ACP (Claude CLI, Anthropic Direct).
  * <p>
  * Replaces the {@link AgentConnector} interface and {@code bridge.AgentClient} interface.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/AgentRegistry.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/AgentRegistry.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.agent;
 
 import com.github.catatafishen.agentbridge.acp.client.CopilotClient;
+import com.github.catatafishen.agentbridge.acp.client.HermesClient;
 import com.github.catatafishen.agentbridge.acp.client.JunieClient;
 import com.github.catatafishen.agentbridge.acp.client.KiroClient;
 import com.github.catatafishen.agentbridge.acp.client.OpenCodeClient;
@@ -34,6 +35,7 @@ public final class AgentRegistry {
         register("junie", "Junie", JunieClient::new);
         register("kiro", "Kiro", KiroClient::new);
         register("opencode", "OpenCode", OpenCodeClient::new);
+        register("hermes", "Hermes Agent", HermesClient::new);
         // Claude clients are registered once they support a single-arg Project constructor.
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfileManager.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfileManager.java
@@ -304,7 +304,7 @@ public final class AgentProfileManager implements PersistentStateComponent<Agent
         p.setBuiltIn(true);
         p.setTransportType(TransportType.ACP);
         p.setBinaryName("hermes");
-        p.setInstallHint("Install with: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash");
+        p.setInstallHint("See install instructions at https://github.com/NousResearch/hermes-agent#installation");
         p.setInstallUrl("https://github.com/NousResearch/hermes-agent");
         return p;
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfileManager.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfileManager.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.services;
 
+import com.github.catatafishen.agentbridge.acp.client.HermesClient;
 import com.github.catatafishen.agentbridge.agent.claude.ClaudeCliClient;
 import com.github.catatafishen.agentbridge.agent.codex.CodexAppServerClient;
 import com.github.catatafishen.agentbridge.bridge.TransportType;
@@ -36,6 +37,7 @@ public final class AgentProfileManager implements PersistentStateComponent<Agent
     public static final String JUNIE_PROFILE_ID = "junie";
     public static final String KIRO_PROFILE_ID = "kiro";
     public static final String CODEX_PROFILE_ID = CodexAppServerClient.PROFILE_ID;
+    public static final String HERMES_PROFILE_ID = HermesClient.AGENT_ID;
 
     private final Map<String, AgentProfile> profiles = new LinkedHashMap<>();
     private PersistedState persistedState = new PersistedState();
@@ -210,7 +212,8 @@ public final class AgentProfileManager implements PersistentStateComponent<Agent
 
     private void ensureDefaults() {
         for (String id : List.of(COPILOT_PROFILE_ID, OPENCODE_PROFILE_ID,
-            CLAUDE_CLI_PROFILE_ID, JUNIE_PROFILE_ID, KIRO_PROFILE_ID, CODEX_PROFILE_ID)) {
+            CLAUDE_CLI_PROFILE_ID, JUNIE_PROFILE_ID, KIRO_PROFILE_ID, CODEX_PROFILE_ID,
+            HERMES_PROFILE_ID)) {
             if (!profiles.containsKey(id)) {
                 AgentProfile profile = createDefaultProfile(id);
                 if (profile != null) profiles.put(id, profile);
@@ -227,6 +230,7 @@ public final class AgentProfileManager implements PersistentStateComponent<Agent
             case JUNIE_PROFILE_ID -> buildJunieProfile();
             case KIRO_PROFILE_ID -> buildKiroProfile();
             case CODEX_PROFILE_ID -> CodexAppServerClient.createDefaultProfile();
+            case HERMES_PROFILE_ID -> buildHermesProfile();
             default -> null;
         };
     }
@@ -290,6 +294,18 @@ public final class AgentProfileManager implements PersistentStateComponent<Agent
         p.setBinaryName(OPENCODE_PROFILE_ID);
         p.setInstallHint("Install with: npm i -g opencode-ai");
         p.setInstallUrl("https://opencode.ai/docs");
+        return p;
+    }
+
+    private static AgentProfile buildHermesProfile() {
+        AgentProfile p = new AgentProfile();
+        p.setId(HERMES_PROFILE_ID);
+        p.setDisplayName("Hermes Agent");
+        p.setBuiltIn(true);
+        p.setTransportType(TransportType.ACP);
+        p.setBinaryName("hermes");
+        p.setInstallHint("Install with: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash");
+        p.setInstallUrl("https://github.com/NousResearch/hermes-agent");
         return p;
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/HermesClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/HermesClientConfigurable.kt
@@ -1,0 +1,95 @@
+package com.github.catatafishen.agentbridge.settings
+
+import com.github.catatafishen.agentbridge.acp.client.AcpClient
+import com.github.catatafishen.agentbridge.acp.client.HermesClient
+import com.github.catatafishen.agentbridge.services.AgentProfileManager
+import com.github.catatafishen.agentbridge.ui.ThemeColor
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.options.BoundConfigurable
+import com.intellij.openapi.options.SearchableConfigurable
+import com.intellij.openapi.project.Project
+import com.intellij.ui.HyperlinkLabel
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.bindItem
+import com.intellij.ui.dsl.builder.bindText
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.util.ui.UIUtil
+import javax.swing.SwingUtilities
+
+@Suppress("unused")
+class HermesClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
+    BoundConfigurable("Hermes Agent"),
+    SearchableConfigurable {
+
+    private val statusLabel = JBLabel()
+
+    override fun getId(): String = ID
+
+    override fun createPanel() = panel {
+        row("Status:") { cell(statusLabel) }
+        row {
+            val note = JBLabel(
+                "<html>Ensure <code>hermes</code> is installed and available on your PATH. " +
+                    "Run <code>hermes setup</code> to configure a model and provider.</html>"
+            )
+            note.foreground = UIUtil.getContextHelpForeground()
+            cell(note)
+        }
+        row {
+            val link = HyperlinkLabel("Hermes Agent on GitHub (NousResearch/hermes-agent)")
+            link.setHyperlinkTarget("https://github.com/NousResearch/hermes-agent")
+            cell(link)
+        }
+        separator()
+        row("Hermes binary:") {
+            textField()
+                .align(AlignX.FILL)
+                .resizableColumn()
+                .applyToComponent { emptyText.text = "Auto-detect (leave empty)" }
+                .comment("Leave empty to auto-detect on PATH. Override if hermes is not on PATH.")
+                .bindText(
+                    { AgentProfileManager.getInstance().loadBinaryPath(AGENT_ID).orEmpty() },
+                    { AgentProfileManager.getInstance().saveBinaryPath(AGENT_ID, it.trim()) }
+                )
+        }
+        row("Bubble color:") {
+            cell(ThemeColorComboBox())
+                .comment("Choose a theme-aware accent color for Hermes message bubbles.")
+                .bindItem(
+                    { ThemeColor.fromKey(AcpClient.loadAgentBubbleColorKey(AGENT_ID)) },
+                    // SonarQube S6619 falsely reports `?.` as useless: bindItem setter receives ThemeColor?
+                    @Suppress("kotlin:S6619")
+                    { AcpClient.saveAgentBubbleColorKey(AGENT_ID, it?.name) }
+                )
+        }
+    }
+
+    override fun reset() {
+        super<BoundConfigurable>.reset()
+        refreshStatusAsync()
+    }
+
+    private fun refreshStatusAsync() {
+        statusLabel.text = "Checking..."
+        statusLabel.foreground = UIUtil.getLabelForeground()
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val version = AcpClientBinaryResolver(AGENT_ID, "hermes").detectVersion()
+            SwingUtilities.invokeLater {
+                if (version != null) {
+                    statusLabel.text = "✓ Hermes found — $version"
+                    statusLabel.foreground = JBColor(0x008000, 0x4EC94E)
+                } else {
+                    statusLabel.text = "hermes not found on PATH — install from github.com/NousResearch/hermes-agent"
+                    statusLabel.foreground = JBColor.RED
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val ID = "com.github.catatafishen.agentbridge.client.hermes"
+        private const val AGENT_ID = HermesClient.AGENT_ID
+    }
+}

--- a/plugin-core/src/main/resources/META-INF/plugin.xml
+++ b/plugin-core/src/main/resources/META-INF/plugin.xml
@@ -27,7 +27,7 @@
 <p>This leads to more stable and maintainable code over longer sessions.</p>
 
 <p><b>Supported agents</b><br>
-GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and OpenCode</p>
+GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, OpenCode, and Hermes Agent</p>
 
 <p><b>Modes</b></p>
 <ul>
@@ -242,6 +242,12 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and Ope
       instance="com.github.catatafishen.agentbridge.settings.KiroClientConfigurable"
       id="com.github.catatafishen.agentbridge.clientAgents.kiro"
       displayName="Kiro"/>
+
+    <projectConfigurable
+      parentId="com.github.catatafishen.agentbridge.clientAgents"
+      instance="com.github.catatafishen.agentbridge.settings.HermesClientConfigurable"
+      id="com.github.catatafishen.agentbridge.clientAgents.hermes"
+      displayName="Hermes Agent"/>
 
     <projectConfigurable
       parentId="com.github.catatafishen.agentbridge.clientAgents"

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/HermesClientStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/HermesClientStaticMethodsTest.java
@@ -1,0 +1,128 @@
+package com.github.catatafishen.agentbridge.acp.client;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the static helpers in {@link HermesClient}.
+ */
+class HermesClientStaticMethodsTest {
+
+    // ── stripToolPrefix ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("stripToolPrefix")
+    class StripToolPrefix {
+
+        @Test
+        @DisplayName("strips mcp_agentbridge_ prefix")
+        void stripsPrefix() {
+            assertEquals("read_file", HermesClient.stripToolPrefix("mcp_agentbridge_read_file"));
+        }
+
+        @Test
+        @DisplayName("strips prefix leaving empty string")
+        void stripsPrefixLeavingEmpty() {
+            assertEquals("", HermesClient.stripToolPrefix("mcp_agentbridge_"));
+        }
+
+        @Test
+        @DisplayName("no prefix returns unchanged")
+        void noPrefixUnchanged() {
+            assertEquals("read_file", HermesClient.stripToolPrefix("read_file"));
+        }
+
+        @Test
+        @DisplayName("empty string returns empty")
+        void emptyString() {
+            assertEquals("", HermesClient.stripToolPrefix(""));
+        }
+
+        @Test
+        @DisplayName("partial prefix not stripped")
+        void partialPrefixNotStripped() {
+            assertEquals("mcp_agentbridge", HermesClient.stripToolPrefix("mcp_agentbridge"));
+        }
+    }
+
+    // ── hasToolPrefix ────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("hasToolPrefix")
+    class HasToolPrefix {
+
+        @Test
+        @DisplayName("returns true for mcp_agentbridge_ prefix")
+        void trueWithPrefix() {
+            assertTrue(HermesClient.hasToolPrefix("mcp_agentbridge_read_file"));
+        }
+
+        @Test
+        @DisplayName("returns false without prefix")
+        void falseWithoutPrefix() {
+            assertFalse(HermesClient.hasToolPrefix("read_file"));
+        }
+
+        @Test
+        @DisplayName("returns true for prefix-only string")
+        void trueForPrefixOnly() {
+            assertTrue(HermesClient.hasToolPrefix("mcp_agentbridge_"));
+        }
+
+        @Test
+        @DisplayName("returns false for empty string")
+        void falseForEmpty() {
+            assertFalse(HermesClient.hasToolPrefix(""));
+        }
+
+        @Test
+        @DisplayName("returns false for agentbridge_ without mcp_ prefix (OpenCode format)")
+        void falseForOpenCodePrefix() {
+            assertFalse(HermesClient.hasToolPrefix("agentbridge_read_file"));
+        }
+    }
+
+    // ── addMcpServerConfig ───────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("addMcpServerConfig")
+    class AddMcpServerConfig {
+
+        @Test
+        @DisplayName("adds mcpServers array with correct ACP-spec server entry for port 3000")
+        void port3000() {
+            JsonObject params = new JsonObject();
+
+            HermesClient.addMcpServerConfig(3000, params);
+
+            assertTrue(params.has("mcpServers"));
+            JsonArray servers = params.getAsJsonArray("mcpServers");
+            assertEquals(1, servers.size());
+
+            JsonObject server = servers.get(0).getAsJsonObject();
+            assertEquals("http", server.get("type").getAsString());
+            assertEquals("agentbridge", server.get("name").getAsString());
+            assertEquals("http://127.0.0.1:3000/mcp", server.get("url").getAsString());
+            assertTrue(server.has("headers"));
+            assertEquals(0, server.getAsJsonArray("headers").size());
+        }
+
+        @Test
+        @DisplayName("uses different port in URL")
+        void port8080() {
+            JsonObject params = new JsonObject();
+
+            HermesClient.addMcpServerConfig(8080, params);
+
+            JsonObject server = params.getAsJsonArray("mcpServers").get(0).getAsJsonObject();
+            assertEquals("http://127.0.0.1:8080/mcp", server.get("url").getAsString());
+        }
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/AgentRegistryTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/AgentRegistryTest.java
@@ -11,16 +11,17 @@ import static org.junit.jupiter.api.Assertions.*;
 class AgentRegistryTest {
 
     @Test
-    @DisplayName("contains all four ACP agents")
+    @DisplayName("contains all five ACP agents")
     void containsAllAgents() {
         List<AgentRegistry.AgentDescriptor> all = AgentRegistry.getAll();
-        assertEquals(4, all.size());
+        assertEquals(5, all.size());
 
         List<String> ids = all.stream().map(AgentRegistry.AgentDescriptor::id).toList();
         assertTrue(ids.contains("copilot"));
         assertTrue(ids.contains("junie"));
         assertTrue(ids.contains("kiro"));
         assertTrue(ids.contains("opencode"));
+        assertTrue(ids.contains("hermes"));
     }
 
     @Test
@@ -31,6 +32,7 @@ class AgentRegistryTest {
         assertEquals("junie", all.get(1).id());
         assertEquals("kiro", all.get(2).id());
         assertEquals("opencode", all.get(3).id());
+        assertEquals("hermes", all.get(4).id());
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentProfileManagerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentProfileManagerTest.java
@@ -32,10 +32,10 @@ class AgentProfileManagerTest {
     // ── Default profiles ─────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("getAllProfiles returns 6 built-in profiles")
+    @DisplayName("getAllProfiles returns 7 built-in profiles")
     void getAllProfilesReturnsDefaults() {
         List<AgentProfile> profiles = manager.getAllProfiles();
-        assertEquals(6, profiles.size());
+        assertEquals(7, profiles.size());
     }
 
     @Test
@@ -56,7 +56,8 @@ class AgentProfileManagerTest {
             AgentProfileManager.CLAUDE_CLI_PROFILE_ID,
             AgentProfileManager.JUNIE_PROFILE_ID,
             AgentProfileManager.KIRO_PROFILE_ID,
-            AgentProfileManager.CODEX_PROFILE_ID)) {
+            AgentProfileManager.CODEX_PROFILE_ID,
+            AgentProfileManager.HERMES_PROFILE_ID)) {
             assertNotNull(manager.getProfile(id), "Profile not found: " + id);
         }
     }


### PR DESCRIPTION
Adds Nous Research's [Hermes Agent](https://github.com/NousResearch/hermes-agent)
as a built-in ACP client.

**Commit 1** — `HermesClient` extends `AcpClient`. Launches
`hermes acp --accept-hooks` (auto-approves shell hooks; without it Hermes
blocks on a TTY the plugin can't provide). Injects the agentbridge HTTP
MCP server via `session/new` at `127.0.0.1` (matches `OpenCodeClient`,
dodges IPv6 `::1`). Strips the `mcp_agentbridge_` tool prefix. Resumes
via `session/resume`. Settings panel mirrors `OpenCodeClientConfigurable`.
Wired into both `AgentRegistry` and `AgentProfileManager`;
`HERMES_PROFILE_ID = HermesClient.AGENT_ID` keeps the ID in one place
(same as `CODEX_PROFILE_ID`). Unit tests cover the prefix helpers and
MCP server config shape.

**Commit 2** — Adds Hermes to every supported-agents list: plugin
description, README, INSTALLATION, QUICK-START, FEATURES, ROADMAP,
ARCHITECTURE, AGENTS.md (new section + summary-table row), and the
javadoc enumerations in `AbstractAgentClient` and
`NewSessionResponseDeserializer`.

Smoke-tested locally: `session/new` carries `mcpServers`, Hermes
connects to the bridge on the assigned port, `mcp_agentbridge_*` calls
round-trip. First contribution from this fork.

AI Disclosure:

PR largely created with Claude Opus 4.7 with Hermes as the harness. Tested manually and reviewed by me, open to feedback and discussions! 😄
