### PR TITLE
fix: skip SonarQube analysis on fork PRs

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -25,6 +25,8 @@ env:
 jobs:
   analyze:
     name: SonarQube analysis
+    # Skip on fork PRs: SONAR_TOKEN secret is unavailable, causing "Project not found" errors.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: ci
     steps:


### PR DESCRIPTION
Fork PRs don't have access to the `SONAR_TOKEN` secret, causing `Project not found` errors during Sonar analysis.

This adds the same guard pattern used by ClusterFuzz Lite:
```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

Fixes the recurring SonarQube failures on external contributor PRs (e.g. #500).