### PR TITLE
fix: address review feedback on OAuth PKCE implementation

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/oauth/McpOAuthCallbackServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/oauth/McpOAuthCallbackServer.java
@@ -68,7 +68,7 @@ public final class McpOAuthCallbackServer implements AutoCloseable {
      * @throws IOException if the server cannot bind
      */
     public void start() throws IOException {
-        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
         server.createContext(CALLBACK_PATH, this::handleCallback);
         server.setExecutor(null);
         server.start();
@@ -114,6 +114,7 @@ public final class McpOAuthCallbackServer implements AutoCloseable {
 
     @Override
     public void close() {
+        latch.countDown();
         if (server != null) {
             server.stop(0);
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/oauth/McpOAuthFlow.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/oauth/McpOAuthFlow.java
@@ -71,7 +71,7 @@ public final class McpOAuthFlow {
             callbackServer.start();
             String redirectUri = callbackServer.getCallbackUri();
 
-            String authUrl = buildAuthUrl(meta.authorizationEndpoint(), redirectUri, pkce.challenge(), state);
+            String authUrl = buildAuthUrl(meta.authorizationEndpoint(), redirectUri, pkce.challenge(), state, meta.scope());
             LOG.info("Opening browser for OAuth authorization: " + authUrl);
             BrowserUtil.browse(authUrl);
 
@@ -176,16 +176,21 @@ public final class McpOAuthFlow {
         @NotNull String authEndpoint,
         @NotNull String redirectUri,
         @NotNull String codeChallenge,
-        @NotNull String state
+        @NotNull String state,
+        @Nullable String scope
     ) throws IOException {
         try {
-            return authEndpoint
+            String url = authEndpoint
                 + "?response_type=code"
                 + "&client_id=" + encode(CLIENT_ID)
                 + "&redirect_uri=" + encode(redirectUri)
                 + "&code_challenge=" + encode(codeChallenge)
                 + "&code_challenge_method=S256"
                 + "&state=" + encode(state);
+            if (scope != null && !scope.isBlank()) {
+                url += "&scope=" + encode(scope);
+            }
+            return url;
         } catch (Exception e) {
             throw new IOException("Failed to build authorization URL", e);
         }
@@ -248,7 +253,7 @@ public final class McpOAuthFlow {
     }
 
     @NotNull
-    private static McpOAuthTokens parseTokenResponse(@NotNull String json) throws IOException {
+    static McpOAuthTokens parseTokenResponse(@NotNull String json) throws IOException {
         try {
             JsonObject obj = JsonParser.parseString(json).getAsJsonObject();
             String accessToken = required(obj, "access_token", json);

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/oauth/McpOAuthCallbackServerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/oauth/McpOAuthCallbackServerTest.java
@@ -55,6 +55,79 @@ class McpOAuthCallbackServerTest {
     }
 
     @Test
+    void waitForCallback_errorParameter_returnsNull() throws IOException, InterruptedException {
+        try (McpOAuthCallbackServer srv = new McpOAuthCallbackServer()) {
+            srv.start();
+            String callbackUri = srv.getCallbackUri() + "?error=access_denied";
+
+            Thread browser = new Thread(() -> {
+                try {
+                    HttpURLConnection conn = (HttpURLConnection) URI.create(callbackUri).toURL().openConnection();
+                    conn.setConnectTimeout(5_000);
+                    conn.setReadTimeout(5_000);
+                    conn.getInputStream().readAllBytes();
+                    conn.disconnect();
+                } catch (IOException ignored) {
+                }
+            });
+            browser.setDaemon(true);
+            browser.start();
+
+            McpOAuthCallbackServer.Result result = srv.waitForCallback(10, TimeUnit.SECONDS);
+            assertNull(result, "error redirect should return null");
+        }
+    }
+
+    @Test
+    void waitForCallback_errorWithDescription_returnsNull() throws IOException, InterruptedException {
+        try (McpOAuthCallbackServer srv = new McpOAuthCallbackServer()) {
+            srv.start();
+            String callbackUri = srv.getCallbackUri() + "?error=access_denied&error_description=User+denied+the+request";
+
+            Thread browser = new Thread(() -> {
+                try {
+                    HttpURLConnection conn = (HttpURLConnection) URI.create(callbackUri).toURL().openConnection();
+                    conn.setConnectTimeout(5_000);
+                    conn.setReadTimeout(5_000);
+                    conn.getInputStream().readAllBytes();
+                    conn.disconnect();
+                } catch (IOException ignored) {
+                }
+            });
+            browser.setDaemon(true);
+            browser.start();
+
+            McpOAuthCallbackServer.Result result = srv.waitForCallback(10, TimeUnit.SECONDS);
+            assertNull(result, "error with description should return null");
+        }
+    }
+
+    @Test
+    void waitForCallback_missingCode_returnsNull() throws IOException, InterruptedException {
+        try (McpOAuthCallbackServer srv = new McpOAuthCallbackServer()) {
+            srv.start();
+            // Redirect has state but no code parameter.
+            String callbackUri = srv.getCallbackUri() + "?state=mystate";
+
+            Thread browser = new Thread(() -> {
+                try {
+                    HttpURLConnection conn = (HttpURLConnection) URI.create(callbackUri).toURL().openConnection();
+                    conn.setConnectTimeout(5_000);
+                    conn.setReadTimeout(5_000);
+                    conn.getInputStream().readAllBytes();
+                    conn.disconnect();
+                } catch (IOException ignored) {
+                }
+            });
+            browser.setDaemon(true);
+            browser.start();
+
+            McpOAuthCallbackServer.Result result = srv.waitForCallback(10, TimeUnit.SECONDS);
+            assertNull(result, "missing code should return null");
+        }
+    }
+
+    @Test
     void getCallbackUri_usesLocalhostAndBoundPort() throws IOException {
         try (McpOAuthCallbackServer srv = new McpOAuthCallbackServer()) {
             srv.start();

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/oauth/McpOAuthFlowTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/oauth/McpOAuthFlowTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -93,6 +94,88 @@ class McpOAuthFlowTest {
         assertThrows(IOException.class, () -> McpOAuthFlow.parseMetadata("not json"));
     }
 
+    // ── parseTokenResponse ────────────────────────────────────────────────────
+
+    @Test
+    void parseTokenResponse_fullResponse_parsesAllFields() throws IOException {
+        String json = """
+            {
+              "access_token": "eyJhbGciOi...",
+              "refresh_token": "rt-abc123",
+              "token_type": "Bearer",
+              "expires_in": 3600
+            }
+            """;
+        McpOAuthTokens tokens = McpOAuthFlow.parseTokenResponse(json);
+        assertTrue("eyJhbGciOi...".equals(tokens.accessToken()));
+        assertTrue("rt-abc123".equals(tokens.refreshToken()));
+        // expiresAtEpochMs should be roughly now + 3600s; allow 5s clock drift.
+        long expected = System.currentTimeMillis() + 3_600_000;
+        assertTrue(Math.abs(tokens.expiresAtEpochMs() - expected) < 5_000,
+            "expiry should be ~now + 1h");
+        assertFalse(tokens.isExpired());
+    }
+
+    @Test
+    void parseTokenResponse_noRefreshToken_returnsNullRefreshToken() throws IOException {
+        String json = """
+            {
+              "access_token": "at-only",
+              "token_type": "Bearer",
+              "expires_in": 60
+            }
+            """;
+        McpOAuthTokens tokens = McpOAuthFlow.parseTokenResponse(json);
+        assertTrue("at-only".equals(tokens.accessToken()));
+        assertTrue(tokens.refreshToken() == null);
+    }
+
+    @Test
+    void parseTokenResponse_noExpiresIn_setsZeroExpiry() throws IOException {
+        String json = """
+            {
+              "access_token": "at-no-expiry",
+              "token_type": "Bearer"
+            }
+            """;
+        McpOAuthTokens tokens = McpOAuthFlow.parseTokenResponse(json);
+        assertTrue("at-no-expiry".equals(tokens.accessToken()));
+        assertTrue(0 == tokens.expiresAtEpochMs());
+        assertFalse(tokens.isExpired());
+    }
+
+    @Test
+    void parseTokenResponse_missingAccessToken_throwsIOException() {
+        String json = """
+            {
+              "token_type": "Bearer",
+              "expires_in": 3600
+            }
+            """;
+        assertThrows(IOException.class, () -> McpOAuthFlow.parseTokenResponse(json));
+    }
+
+    @Test
+    void parseTokenResponse_nullAccessToken_throwsIOException() {
+        String json = """
+            {
+              "access_token": null,
+              "token_type": "Bearer"
+            }
+            """;
+        assertThrows(IOException.class, () -> McpOAuthFlow.parseTokenResponse(json));
+    }
+
+    @Test
+    void parseTokenResponse_invalidJson_throwsIOException() {
+        assertThrows(IOException.class, () -> McpOAuthFlow.parseTokenResponse("not json"));
+    }
+
+    @Test
+    void parseTokenResponse_emptyObject_throwsIOException() {
+        assertThrows(IOException.class, () -> McpOAuthFlow.parseTokenResponse("{}"));
+    }
+
     // ── buildAuthUrl ─────────────────────────────────────────────────────────
 
     @Test
@@ -102,7 +185,7 @@ class McpOAuthFlowTest {
         String challenge = McpOAuthPkce.generate().challenge();
         String state = McpOAuthPkce.generateState();
 
-        String url = McpOAuthFlow.buildAuthUrl(authEndpoint, redirectUri, challenge, state);
+        String url = McpOAuthFlow.buildAuthUrl(authEndpoint, redirectUri, challenge, state, null);
 
         assertTrue(url.startsWith(authEndpoint + "?"), "should start with auth endpoint");
         assertTrue(url.contains("response_type=code"), "should contain response_type=code");
@@ -111,5 +194,29 @@ class McpOAuthFlowTest {
         assertTrue(url.contains("code_challenge="), "should contain code_challenge");
         assertTrue(url.contains("redirect_uri="), "should contain redirect_uri");
         assertTrue(url.contains("state="), "should contain state");
+    }
+
+    @Test
+    void buildAuthUrl_includesScopeWhenProvided() throws IOException {
+        String url = McpOAuthFlow.buildAuthUrl(
+            "https://auth.example.com/authorize",
+            "http://127.0.0.1:54321/callback",
+            McpOAuthPkce.generate().challenge(),
+            McpOAuthPkce.generateState(),
+            "read write"
+        );
+        assertTrue(url.contains("scope=read+write"), "should contain scope parameter");
+    }
+
+    @Test
+    void buildAuthUrl_omitsScopeWhenNull() throws IOException {
+        String url = McpOAuthFlow.buildAuthUrl(
+            "https://auth.example.com/authorize",
+            "http://127.0.0.1:54321/callback",
+            McpOAuthPkce.generate().challenge(),
+            McpOAuthPkce.generateState(),
+            null
+        );
+        org.junit.jupiter.api.Assertions.assertFalse(url.contains("scope="), "should not contain scope param when null");
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/oauth/McpOAuthTokensTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/oauth/McpOAuthTokensTest.java
@@ -1,0 +1,90 @@
+package com.github.catatafishen.agentbridge.custommcp.oauth;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class McpOAuthTokensTest {
+
+    @Test
+    void isExpired_zeroExpiry_returnsFalse() {
+        // expiresAtEpochMs == 0 means unknown expiry — never considered expired.
+        McpOAuthTokens tokens = new McpOAuthTokens("at", null, 0);
+        assertFalse(tokens.isExpired());
+    }
+
+    @Test
+    void isExpired_negativeExpiry_returnsFalse() {
+        // Negative value treated same as zero (unknown expiry).
+        McpOAuthTokens tokens = new McpOAuthTokens("at", null, -1);
+        assertFalse(tokens.isExpired());
+    }
+
+    @Test
+    void isExpired_farFuture_returnsFalse() {
+        long future = System.currentTimeMillis() + 3_600_000; // 1 hour from now
+        McpOAuthTokens tokens = new McpOAuthTokens("at", null, future);
+        assertFalse(tokens.isExpired());
+    }
+
+    @Test
+    void isExpired_farPast_returnsTrue() {
+        long past = System.currentTimeMillis() - 3_600_000; // 1 hour ago
+        McpOAuthTokens tokens = new McpOAuthTokens("at", null, past);
+        assertTrue(tokens.isExpired());
+    }
+
+    @Test
+    void isExpired_withinGracePeriod_returnsTrue() {
+        // Token expires in 15 seconds → within 30s grace → considered expired.
+        long nearFuture = System.currentTimeMillis() + 15_000;
+        McpOAuthTokens tokens = new McpOAuthTokens("at", null, nearFuture);
+        assertTrue(tokens.isExpired());
+    }
+
+    @Test
+    void isExpired_outsideGracePeriod_returnsFalse() {
+        // Token expires in 31 seconds → outside 30s grace → still valid.
+        long justOutside = System.currentTimeMillis() + 31_000;
+        McpOAuthTokens tokens = new McpOAuthTokens("at", null, justOutside);
+        assertFalse(tokens.isExpired());
+    }
+
+    @Test
+    void isExpired_atGraceBoundary_returnsTrue() {
+        // Token expires in exactly 30 seconds → at grace boundary → expired.
+        long atBoundary = System.currentTimeMillis() + 30_000;
+        McpOAuthTokens tokens = new McpOAuthTokens("at", null, atBoundary);
+        assertTrue(tokens.isExpired());
+    }
+
+    @Test
+    void isExpired_withRefreshToken_stillChecksAccessTokenExpiry() {
+        // Having a refresh token should not affect isExpired() logic.
+        long past = System.currentTimeMillis() - 60_000;
+        McpOAuthTokens tokens = new McpOAuthTokens("at", "rt", past);
+        assertTrue(tokens.isExpired());
+
+        long future = System.currentTimeMillis() + 60_000;
+        tokens = new McpOAuthTokens("at", "rt", future);
+        assertFalse(tokens.isExpired());
+    }
+
+    @Test
+    void constructor_allFieldsPersisted() {
+        long expiry = System.currentTimeMillis() + 3600_000;
+        McpOAuthTokens tokens = new McpOAuthTokens("access", "refresh", expiry);
+        assertTrue("access".equals(tokens.accessToken()));
+        assertTrue("refresh".equals(tokens.refreshToken()));
+        assertTrue(expiry == tokens.expiresAtEpochMs());
+    }
+
+    @Test
+    void constructor_nullRefreshToken_persisted() {
+        McpOAuthTokens tokens = new McpOAuthTokens("access", null, 12345);
+        assertTrue("access".equals(tokens.accessToken()));
+        assertTrue(tokens.refreshToken() == null);
+        assertTrue(12345 == tokens.expiresAtEpochMs());
+    }
+}


### PR DESCRIPTION
Improving tests, fixing minor issues.

- McpOAuthCallbackServer: bind to localhost (not 127.0.0.1) to match getCallbackUri()
- McpOAuthCallbackServer: count down latch in close() to unblock waitForCallback
- McpOAuthFlow: pass scope from AS metadata to authorization URL
- McpOAuthFlow: make parseTokenResponse package-private (visible for testing)
- Add McpOAuthTokensTest (10 tests): isExpired edge cases and constructor
- Add parseTokenResponse tests to McpOAuthFlowTest (7 tests)
- Add error-path tests to McpOAuthCallbackServerTest (3 tests: error, description, missing code)