### PR TITLE
fix: migrate SonarQube fork PR scanning to workflow_run pattern

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -72,8 +72,32 @@ jobs:
       # Intentionally checks out fork code to fuzz it. The `environment: ci` gate above
       # requires maintainer approval before this runs. The warn-fork-fuzz job posts a
       # security review reminder on the PR so approvers know to review the code first.
+      #
+      # Why this is an accepted risk rather than a fixable issue:
+      #   Fuzzing by definition requires executing the code under test. Unlike SonarQube
+      #   analysis (which only reads source and bytecode), ClusterFuzzLite must compile and
+      #   run the fuzz targets. There is no artifact-passing pattern that eliminates this
+      #   requirement. The environment gate + explicit reviewer warning is therefore the
+      #   strongest practical mitigation available.
+      #
+      #   The environment gate is a stronger safeguard than a regular PR approval because:
+      #   (a) it is a distinct, less common action that specifically prompts the reviewer
+      #   to ask "why is this requiring separate approval?", and (b) the warn-fork-fuzz
+      #   job posts an explicit security checklist before the gate can be triggered.
+      #   A maintainer who rubber-stamps the environment gate without reading that warning
+      #   is no less careful than one who merges a PR without review — and such a reviewer
+      #   would represent a process failure, not a workflow design failure.
+      #
+      #   CFLITE_STORAGE_REPO_TOKEN scope (fine-grained PAT):
+      #     Repository:   catatafishen/agentbridge-cflite-storage (only)
+      #     Permissions:  Read access to metadata
+      #                   Read and Write access to code
+      #   Even if a malicious fork PR exfiltrates this token, the blast radius is limited
+      #   to the fuzz corpus storage repository — not the main codebase.
+      #
       # NOSONAR: S7631 — mitigated by environment gate + explicit reviewer warning
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      # zizmor: ignore[pull-request-target]
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 NOSONAR
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -86,7 +110,9 @@ jobs:
           language: jvm
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sanitizer: ${{ matrix.sanitizer }}
-          # Enable storage repo for affected-fuzzer detection + corpus reuse:
+          # CFLITE_STORAGE_REPO_TOKEN: fine-grained PAT scoped to catatafishen/agentbridge-cflite-storage only.
+          # Permissions: Read access to metadata; Read and Write access to code.
+          # Blast radius if exfiltrated: write access to the fuzz corpus repo only — not the main codebase.
           storage-repo: https://${{ secrets.CFLITE_STORAGE_REPO_TOKEN }}@github.com/catatafishen/agentbridge-cflite-storage.git
           storage-repo-branch: main
           storage-repo-branch-coverage: gh-pages
@@ -100,6 +126,7 @@ jobs:
           mode: 'code-change'
           sanitizer: ${{ matrix.sanitizer }}
           output-sarif: true
+          # CFLITE_STORAGE_REPO_TOKEN: see comment above in Build Fuzzers step.
           storage-repo: https://${{ secrets.CFLITE_STORAGE_REPO_TOKEN }}@github.com/catatafishen/agentbridge-cflite-storage.git
           storage-repo-branch: main
           storage-repo-branch-coverage: gh-pages

--- a/.github/workflows/sonarqube-pr-analyze.yml
+++ b/.github/workflows/sonarqube-pr-analyze.yml
@@ -18,6 +18,9 @@ name: SonarQube PR Analyze
 #
 # See docs/CI-SECURITY.md for the full rationale.
 
+# zizmor: ignore[dangerous-triggers] — workflow_run is the GitHub-recommended pattern
+# for running privileged analysis on fork PR code without giving the fork secrets access.
+# See docs/CI-SECURITY.md for the full rationale.
 on:
   workflow_run:
     workflows: ["SonarQube PR Build"]
@@ -52,6 +55,26 @@ jobs:
         with:
           egress-policy: audit
 
+      # Look up the PR associated with this workflow run via the GitHub API.
+      # This is safer than passing metadata through the artifact (which comes from the
+      # untrusted build job) — the API returns data from GitHub itself.
+      - name: Find associated PR
+        id: pr-meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          PR_JSON=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls" \
+            --jq 'first // empty')
+          if [ -z "$PR_JSON" ]; then
+            echo "::error::No PR found for SHA $HEAD_SHA"
+            exit 1
+          fi
+          echo "number=$(echo "$PR_JSON" | jq -r '.number')" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(echo "$PR_JSON" | jq -r '.head.ref')" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$(echo "$PR_JSON" | jq -r '.base.ref')" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
       # Download the artifact bundle produced by the unprivileged build job.
       # Contains the fork's source files and pre-compiled outputs — uploaded from a
       # context with no secrets access — so this workflow never runs fork build scripts.
@@ -62,15 +85,6 @@ jobs:
           path: ${{ runner.temp }}/sonar-artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
-
-      - name: Read PR metadata
-        id: pr-meta
-        run: |
-          tar -xzf "${{ runner.temp }}/sonar-artifacts/sonar-artifacts.tar.gz" pr-metadata.json
-          echo "number=$(jq -r .number pr-metadata.json)" >> "$GITHUB_OUTPUT"
-          echo "head_ref=$(jq -r .head_ref pr-metadata.json)" >> "$GITHUB_OUTPUT"
-          echo "base_ref=$(jq -r .base_ref pr-metadata.json)" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$(jq -r .head_sha pr-metadata.json)" >> "$GITHUB_OUTPUT"
 
       # Check out the BASE repository (our trusted code) to get the Gradle wrapper
       # and build configuration. The fork's source files and compiled outputs are
@@ -87,8 +101,7 @@ jobs:
       # The fork's code is read-only from this point — no build scripts are executed.
       - name: Restore analysis artifacts
         run: |
-          tar -xzf "${{ runner.temp }}/sonar-artifacts/sonar-artifacts.tar.gz" \
-            --exclude=pr-metadata.json
+          tar -xzf "${{ runner.temp }}/sonar-artifacts/sonar-artifacts.tar.gz"
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
@@ -148,12 +161,19 @@ jobs:
       # Run SonarQube using our trusted Gradle scripts (from the base checkout).
       # Tests and JaCoCo reports are skipped because they are already in the artifact.
       # The chat-ui build is skipped because the JS coverage (lcov.info) is in the artifact.
+      #
+      # PR metadata is passed via env vars (not ${{ }} template expansion in the run
+      # block) to prevent code injection — even though the values come from the GitHub
+      # API, this follows the principle of least surprise for security scanners.
       - name: Run SonarQube analysis
         if: steps.sonar-auto-analysis.outputs.enabled != 'true'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_PROJECT_VERSION: ${{ steps.sonar-version.outputs.version }}
+          PR_NUMBER: ${{ steps.pr-meta.outputs.number }}
+          PR_HEAD_REF: ${{ steps.pr-meta.outputs.head_ref }}
+          PR_BASE_REF: ${{ steps.pr-meta.outputs.base_ref }}
         run: |
           gradle sonar \
             --no-daemon --quiet \
@@ -166,9 +186,9 @@ jobs:
             "-Dsonar.projectVersion=$SONAR_PROJECT_VERSION" \
             "-Dsonar.qualitygate.wait=true" \
             "-Dsonar.qualitygate.timeout=300" \
-            "-Dsonar.pullrequest.key=${{ steps.pr-meta.outputs.number }}" \
-            "-Dsonar.pullrequest.branch=${{ steps.pr-meta.outputs.head_ref }}" \
-            "-Dsonar.pullrequest.base=${{ steps.pr-meta.outputs.base_ref }}"
+            "-Dsonar.pullrequest.key=$PR_NUMBER" \
+            "-Dsonar.pullrequest.branch=$PR_HEAD_REF" \
+            "-Dsonar.pullrequest.base=$PR_BASE_REF"
 
       - name: Warn when SonarCloud Automatic Analysis is enabled
         if: steps.sonar-auto-analysis.outputs.enabled == 'true'

--- a/.github/workflows/sonarqube-pr-analyze.yml
+++ b/.github/workflows/sonarqube-pr-analyze.yml
@@ -1,0 +1,178 @@
+name: SonarQube PR Analyze
+
+# Privileged half of the fork-PR SonarQube pipeline.
+#
+# Security model:
+#   This workflow is triggered by the completion of sonarqube-pr-build.yml and runs
+#   with full access to repository secrets (SONAR_TOKEN). It NEVER executes code from
+#   the fork. Instead it:
+#     1. Downloads pre-built artifacts produced in the unprivileged build job.
+#     2. Checks out the BASE repository (our trusted code) for build scripts.
+#     3. Overlays the fork's source files and compiled outputs from the artifact.
+#     4. Runs sonar analysis using OUR Gradle scripts — fork code is only READ,
+#        never executed.
+#
+# No environment gate is required here because no untrusted code runs in this
+# workflow. Contrast with cflite_pr.yml, which must execute the fork code to fuzz
+# it and therefore requires maintainer approval via the `environment: ci` gate.
+#
+# See docs/CI-SECURITY.md for the full rationale.
+
+on:
+  workflow_run:
+    workflows: ["SonarQube PR Build"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read  # required to download artifacts from the triggering workflow run
+
+concurrency:
+  group: sonarqube-analyze-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY || 'catatafishen_agentbridge' }}
+  SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION || 'catatafishen' }}
+  SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+
+jobs:
+  analyze:
+    name: SonarQube analysis
+    runs-on: ubuntu-latest
+    # Only analyze successful PR builds (not branch pushes or failed runs).
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: audit
+
+      # Download the artifact bundle produced by the unprivileged build job.
+      # Contains the fork's source files and pre-compiled outputs — uploaded from a
+      # context with no secrets access — so this workflow never runs fork build scripts.
+      - name: Download analysis artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          name: sonar-analysis-artifacts
+          path: ${{ runner.temp }}/sonar-artifacts
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR metadata
+        id: pr-meta
+        run: |
+          tar -xzf "${{ runner.temp }}/sonar-artifacts/sonar-artifacts.tar.gz" pr-metadata.json
+          echo "number=$(jq -r .number pr-metadata.json)" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(jq -r .head_ref pr-metadata.json)" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$(jq -r .base_ref pr-metadata.json)" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(jq -r .head_sha pr-metadata.json)" >> "$GITHUB_OUTPUT"
+
+      # Check out the BASE repository (our trusted code) to get the Gradle wrapper
+      # and build configuration. The fork's source files and compiled outputs are
+      # restored from the artifact in the next step.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Overlay the fork's source files and pre-built outputs onto the base checkout.
+      # tar -x merges files: build.gradle.kts, gradlew, and all other base-repo files
+      # not in the archive are preserved. Only the paths included in the artifact
+      # (src/, build/reports/, build/classes/, js-tests/, chat-ui/src/) are replaced.
+      # The fork's code is read-only from this point — no build scripts are executed.
+      - name: Restore analysis artifacts
+        run: |
+          tar -xzf "${{ runner.temp }}/sonar-artifacts/sonar-artifacts.tar.gz" \
+            --exclude=pr-metadata.json
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e  # v6.1.0
+        with:
+          gradle-version: 'wrapper'
+          cache-disabled: true
+
+      - name: Determine Sonar project version
+        id: sonar-version
+        env:
+          HEAD_SHA: ${{ steps.pr-meta.outputs.head_sha }}
+        run: |
+          SHORT_SHA="${HEAD_SHA:0:8}"
+          LATEST_TAG="$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || true)"
+          if [ -n "$LATEST_TAG" ]; then
+            VERSION="${LATEST_TAG#v}-dev-${SHORT_SHA}"
+          else
+            VERSION="0.0.0-dev-${SHORT_SHA}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check SonarCloud Automatic Analysis
+        id: sonar-auto-analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import base64
+          import json
+          import os
+          import urllib.request
+
+          host = os.environ["SONAR_HOST_URL"].rstrip("/")
+          project = os.environ["SONAR_PROJECT_KEY"]
+          url = f"{host}/api/settings/values?component={project}&keys=sonar.autoscan.enabled"
+          request = urllib.request.Request(url)
+          token = os.environ.get("SONAR_TOKEN")
+          if token:
+              auth = base64.b64encode(f"{token}:".encode()).decode()
+              request.add_header("Authorization", f"Basic {auth}")
+          with urllib.request.urlopen(request) as response:
+              settings = json.load(response).get("settings", [])
+          enabled = any(
+              setting.get("key") == "sonar.autoscan.enabled"
+              and setting.get("value", "").lower() == "true"
+              for setting in settings
+          )
+          print(f"enabled={'true' if enabled else 'false'}")
+          PY
+
+      # Run SonarQube using our trusted Gradle scripts (from the base checkout).
+      # Tests and JaCoCo reports are skipped because they are already in the artifact.
+      # The chat-ui build is skipped because the JS coverage (lcov.info) is in the artifact.
+      - name: Run SonarQube analysis
+        if: steps.sonar-auto-analysis.outputs.enabled != 'true'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_PROJECT_VERSION: ${{ steps.sonar-version.outputs.version }}
+        run: |
+          gradle sonar \
+            --no-daemon --quiet \
+            -x test \
+            -x jacocoTestReport \
+            -x buildChatUi \
+            "-Dsonar.projectKey=$SONAR_PROJECT_KEY" \
+            "-Dsonar.organization=$SONAR_ORGANIZATION" \
+            "-Dsonar.host.url=$SONAR_HOST_URL" \
+            "-Dsonar.projectVersion=$SONAR_PROJECT_VERSION" \
+            "-Dsonar.qualitygate.wait=true" \
+            "-Dsonar.qualitygate.timeout=300" \
+            "-Dsonar.pullrequest.key=${{ steps.pr-meta.outputs.number }}" \
+            "-Dsonar.pullrequest.branch=${{ steps.pr-meta.outputs.head_ref }}" \
+            "-Dsonar.pullrequest.base=${{ steps.pr-meta.outputs.base_ref }}"
+
+      - name: Warn when SonarCloud Automatic Analysis is enabled
+        if: steps.sonar-auto-analysis.outputs.enabled == 'true'
+        run: |
+          echo "::warning::SonarCloud Automatic Analysis is enabled for $SONAR_PROJECT_KEY."
+          echo "::warning::Disable it in SonarCloud: Project Settings > Analysis Method > Automatic Analysis to use CI coverage and projectVersion."
+          echo "::warning::Skipping CI-based SonarQube analysis because SonarCloud would reject it while Automatic Analysis is enabled."

--- a/.github/workflows/sonarqube-pr-build.yml
+++ b/.github/workflows/sonarqube-pr-build.yml
@@ -84,22 +84,11 @@ jobs:
             :plugin-core:test :plugin-core:jacocoTestReport \
             --no-daemon --quiet --build-cache
 
-      - name: Save PR metadata
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          printf '{"number":%s,"head_ref":"%s","base_ref":"%s","head_sha":"%s"}\n' \
-            "$PR_NUMBER" "$HEAD_REF" "$BASE_REF" "$HEAD_SHA" > pr-metadata.json
-
       - name: Package analysis artifacts
         run: |
           tar -czf sonar-artifacts.tar.gz \
             --exclude='*/node_modules' \
             --exclude='*/lcov-report' \
-            pr-metadata.json \
             plugin-core/src \
             plugin-core/build/reports/jacoco \
             plugin-core/build/classes \

--- a/.github/workflows/sonarqube-pr-build.yml
+++ b/.github/workflows/sonarqube-pr-build.yml
@@ -1,0 +1,121 @@
+name: SonarQube PR Build
+
+# Unprivileged half of the fork-PR SonarQube pipeline.
+#
+# Security model:
+#   pull_request events for fork PRs have NO access to repository secrets.
+#   It is therefore safe to check out and build untrusted fork code here.
+#   The compiled classes, coverage reports, and source files are bundled
+#   into an artifact and consumed by the companion sonarqube-pr-analyze.yml
+#   workflow, which runs in a privileged context but never executes fork code.
+#
+# See docs/CI-SECURITY.md for the full rationale.
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sonarqube-build-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+        with:
+          egress-policy: audit
+
+      # Checks out the fork's actual head commit (not the merge commit) so the
+      # SonarQube analysis covers exactly the code in the PR. Safe here because
+      # pull_request events have no access to repository secrets.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: |
+            plugin-core/chat-ui/package-lock.json
+            plugin-core/js-tests/package-lock.json
+
+      - name: Install chat-ui dependencies
+        run: npm ci --silent --ignore-scripts
+        working-directory: plugin-core/chat-ui
+
+      - name: Install JS test dependencies
+        run: npm ci --silent --ignore-scripts
+        working-directory: plugin-core/js-tests
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e  # v6.1.0
+        with:
+          gradle-version: 'wrapper'
+          cache-disabled: true
+
+      - name: Run tests with coverage
+        run: |
+          npm run test:coverage --prefix plugin-core/js-tests
+          npm run build --prefix plugin-core/chat-ui
+          gradle :mcp-server:test :mcp-server:jacocoTestReport \
+            :plugin-experimental:test :plugin-experimental:jacocoTestReport \
+            :plugin-core:test :plugin-core:jacocoTestReport \
+            --no-daemon --quiet --build-cache
+
+      - name: Save PR metadata
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          printf '{"number":%s,"head_ref":"%s","base_ref":"%s","head_sha":"%s"}\n' \
+            "$PR_NUMBER" "$HEAD_REF" "$BASE_REF" "$HEAD_SHA" > pr-metadata.json
+
+      - name: Package analysis artifacts
+        run: |
+          tar -czf sonar-artifacts.tar.gz \
+            --exclude='*/node_modules' \
+            --exclude='*/lcov-report' \
+            pr-metadata.json \
+            plugin-core/src \
+            plugin-core/build/reports/jacoco \
+            plugin-core/build/classes \
+            plugin-core/chat-ui/src \
+            plugin-core/js-tests \
+            mcp-server/src \
+            mcp-server/build/reports/jacoco \
+            mcp-server/build/classes \
+            plugin-experimental/src \
+            plugin-experimental/build/reports/jacoco \
+            plugin-experimental/build/classes
+
+      - name: Upload analysis artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: sonar-analysis-artifacts
+          path: sonar-artifacts.tar.gz
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,19 +1,19 @@
 name: SonarQube
 
+# Push-to-master and tag analysis only.
+# For PR analysis (including fork PRs), see sonarqube-pr-build.yml + sonarqube-pr-analyze.yml.
+
 on:
   push:
     branches: [ master ]
     tags: [ 'v*' ]
-  pull_request_target:
-    branches: [ master ]
-    types: [ opened, synchronize, reopened ]
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  group: sonarqube-${{ github.head_ref || github.ref }}
+  group: sonarqube-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -37,8 +37,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-          repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
@@ -80,13 +78,11 @@ jobs:
 
       - name: Determine Sonar project version
         id: sonar-version
-        env:
-          HEAD_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
         run: |
           if [ "${GITHUB_REF_TYPE}" = "tag" ] && [[ "${GITHUB_REF_NAME}" == v* ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
           else
-            SHORT_SHA="${HEAD_SHA:0:8}"
+            SHORT_SHA="${GITHUB_SHA:0:8}"
             LATEST_TAG="$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || true)"
             if [ -n "$LATEST_TAG" ]; then
               VERSION="${LATEST_TAG#v}-dev-${SHORT_SHA}"
@@ -132,23 +128,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_PROJECT_VERSION: ${{ steps.sonar-version.outputs.version }}
         run: |
-          SONAR_BASE_ARGS=(
-            --no-daemon --quiet
-            "-Dsonar.projectKey=$SONAR_PROJECT_KEY"
-            "-Dsonar.organization=$SONAR_ORGANIZATION"
-            "-Dsonar.host.url=$SONAR_HOST_URL"
-            "-Dsonar.projectVersion=$SONAR_PROJECT_VERSION"
-            "-Dsonar.qualitygate.wait=true"
+          gradle sonar --no-daemon --quiet \
+            "-Dsonar.projectKey=$SONAR_PROJECT_KEY" \
+            "-Dsonar.organization=$SONAR_ORGANIZATION" \
+            "-Dsonar.host.url=$SONAR_HOST_URL" \
+            "-Dsonar.projectVersion=$SONAR_PROJECT_VERSION" \
+            "-Dsonar.qualitygate.wait=true" \
             "-Dsonar.qualitygate.timeout=300"
-          )
-          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
-            gradle sonar "${SONAR_BASE_ARGS[@]}" \
-              "-Dsonar.pullrequest.key=${{ github.event.pull_request.number }}" \
-              "-Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}" \
-              "-Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}"
-          else
-            gradle sonar "${SONAR_BASE_ARGS[@]}"
-          fi
 
       - name: Warn when SonarCloud Automatic Analysis is enabled
         if: steps.sonar-auto-analysis.outputs.enabled == 'true'

--- a/docs/CI-SECURITY.md
+++ b/docs/CI-SECURITY.md
@@ -1,0 +1,124 @@
+# CI Security: Fork PR Scanning
+
+This document explains the security design for running SonarQube and ClusterFuzzLite
+analysis on pull requests from forked repositories.
+
+## Why Scan Fork PRs At All?
+
+Scanning code from external contributors *before* it is merged is the whole point.
+Disabling scanners on fork PRs — the default suggestion from some security tools — is
+the wrong trade-off: it removes the check at exactly the moment it is most needed
+(before untrusted code enters the main branch). The question is therefore not *whether*
+to scan fork PRs, but *how* to do it securely.
+
+---
+
+## SonarQube: The `workflow_run` Two-Workflow Pattern
+
+### The Problem with `pull_request_target`
+
+The `pull_request_target` trigger runs in the context of the *base* repository, meaning
+it has write permissions and access to repository secrets (e.g. `SONAR_TOKEN`). If you
+also check out the fork's code in that context, a malicious contributor could embed
+shell commands in `build.gradle.kts`, a Makefile, or a test script that runs during the
+build and exfiltrates `SONAR_TOKEN`.
+
+The critical failure mode is: a maintainer clicks "Approve" on the environment gate to
+*get* the CI results, intending to review the code *after* seeing them — but the
+malicious build script runs first.
+
+### Solution: Split Into Two Workflows
+
+**`sonarqube-pr-build.yml`** — `pull_request` trigger (unprivileged):
+
+- Triggered automatically on every PR push, including from forks.
+- The `pull_request` event has **no access to repository secrets** for fork PRs. This
+  is a GitHub platform guarantee — even if the fork's build scripts run, they cannot
+  read `SONAR_TOKEN`.
+- Checks out the fork's actual head commit, builds, runs tests with JaCoCo coverage,
+  then bundles source files + compiled classes + coverage reports into an artifact.
+- No approval gate required — the platform enforces the secret isolation.
+
+**`sonarqube-pr-analyze.yml`** — `workflow_run` trigger (privileged):
+
+- Triggered when the build workflow completes successfully.
+- Has access to `SONAR_TOKEN`.
+- Downloads the artifact produced by the build job.
+- Checks out the **base repository** (our trusted code) to get the Gradle wrapper and
+  `build.gradle.kts`.
+- Overlays the fork's source files and pre-compiled outputs from the artifact on top of
+  the base checkout. This gives the sonar scanner the actual PR code to annotate issues
+  against, while the Gradle scripts being executed are entirely ours.
+- Runs `gradle sonar` skipping test/coverage tasks (already in artifact). Fork code is
+  **read** by the sonar scanner; it is never **executed**.
+
+### Why This Is Safe
+
+The sonar scanner performs static analysis: it reads `.java`/`.kt`/`.ts` source files
+and compiled `.class` bytecode but does not execute them. Even if a fork contains
+malicious Java source code, the scanner cannot use that to exfiltrate a secret —
+it would require a vulnerability in the sonar scanner itself, not just malicious user
+code.
+
+The Gradle scripts driving the analysis (`build.gradle.kts`, `gradlew`) are always from
+the base repository. Any custom annotation processors or code-gen plugins configured in
+those scripts are our own and pre-vetted.
+
+---
+
+## ClusterFuzzLite: Accepted Risk with Maximum Mitigation
+
+### Why the `workflow_run` Pattern Does Not Apply
+
+Fuzzing by definition requires **executing** the code under test. ClusterFuzzLite must
+compile the fork's fuzz targets and run them to discover bugs. There is no artifact
+passing pattern that can separate "run this code" from "run this code in a privileged
+context" — the run itself *is* the privileged operation.
+
+The `pull_request_target` + fork code execution is therefore an inherent requirement of
+fuzzing external contributions, not a design choice that can be avoided.
+
+### Mitigations in Place
+
+**`environment: ci` gate** — The `PR` job requires maintainer approval before it runs.
+No CI secret is accessed until a human explicitly approves.
+
+**`warn-fork-fuzz` job** — A companion job runs automatically (no gate, no secrets) and
+posts a security reminder on the PR *before* the gate can be triggered. The comment
+names the specific secrets at risk and asks reviewers to verify the code before
+approving the gate.
+
+**Why the environment gate is a *stronger* safeguard than a regular PR review:**
+
+A regular PR approval and an environment gate approval are different acts. The
+environment gate is a distinct, less common action that specifically prompts the
+reviewer to ask: "why does this require separate approval?" The warn-fork-fuzz comment
+answers that question with an explicit security checklist. A maintainer who approves the
+gate without reading that comment is no less careful than one who merges a PR without
+review — in both cases the failure is a process failure, not a workflow design failure.
+
+**Minimized token scope** — `CFLITE_STORAGE_REPO_TOKEN` is a fine-grained PAT scoped
+exclusively to `catatafishen/agentbridge-cflite-storage`:
+
+- Read access to metadata
+- Read and Write access to code
+
+Even if a fork PR successfully exfiltrates this token, the blast radius is limited to
+the fuzz corpus storage repository. The main codebase, secrets, and release pipeline
+are unaffected.
+
+### OpenSSF Scorecard Finding
+
+OpenSSF Scorecard's `Dangerous-Workflow` check performs static analysis of the workflow
+YAML. It flags the `pull_request_target` + checkout-of-fork-code pattern regardless of
+environment protection settings, because the static analyzer cannot verify that the
+protection exists or is correctly configured.
+
+This finding accurately describes a real risk that we have mitigated as thoroughly as
+the fuzzing use-case allows. It will continue to appear in the scorecard report as an
+accepted risk. The rationale documented here and in `cflite_pr.yml` serves as the
+reference for future re-evaluation.
+
+The SonarQube finding for `sonarqube.yml` / `sonarqube-pr-analyze.yml` should no longer
+appear after the migration to `workflow_run`, since those workflows no longer execute
+fork code.

--- a/docs/CI-SECURITY.md
+++ b/docs/CI-SECURITY.md
@@ -43,6 +43,8 @@ malicious build script runs first.
 
 - Triggered when the build workflow completes successfully.
 - Has access to `SONAR_TOKEN`.
+- Looks up the associated PR via the GitHub API (`commits/{sha}/pulls`) — PR metadata
+  is never read from the untrusted artifact to prevent code injection.
 - Downloads the artifact produced by the build job.
 - Checks out the **base repository** (our trusted code) to get the Gradle wrapper and
   `build.gradle.kts`.
@@ -51,6 +53,9 @@ malicious build script runs first.
   against, while the Gradle scripts being executed are entirely ours.
 - Runs `gradle sonar` skipping test/coverage tasks (already in artifact). Fork code is
   **read** by the sonar scanner; it is never **executed**.
+- PR metadata values are passed to the `run:` block via `env:` variables (shell
+  expansion), not `${{ }}` template expansion, to prevent code injection even if the
+  API returned attacker-controlled data.
 
 ### Why This Is Safe
 


### PR DESCRIPTION
## Summary

Fixes the OpenSSF Scorecard `Dangerous-Workflow` finding for SonarQube by migrating from `pull_request_target` + fork-checkout to the two-workflow `workflow_run` pattern.

## Changes

### SonarQube — fully fixed

Split into three workflows:

- **`sonarqube-pr-build.yml`** (`pull_request`, unprivileged): builds the fork, runs tests with coverage, bundles source + compiled classes + reports as an artifact. GitHub platform guarantees **no secret access** for fork PRs on this trigger.
- **`sonarqube-pr-analyze.yml`** (`workflow_run`, privileged): downloads the artifact, checks out **our** base repo for Gradle scripts, overlays fork source/classes, runs `gradle sonar` using our trusted scripts. Fork code is **read** by the scanner, never executed. No environment gate needed.
- **`sonarqube.yml`**: now push-to-master/tags only; `pull_request_target` trigger removed.

### ClusterFuzzLite — documented accepted risk

Fuzzing requires executing the fork's code — there is no artifact-passing equivalent. The existing environment gate is the strongest practical mitigation. Added:
- `CFLITE_STORAGE_REPO_TOKEN` scope documentation (scoped to `agentbridge-cflite-storage` only; limited blast radius)
- `zizmor: ignore[pull-request-target]` suppression with full in-workflow rationale
- Expanded reasoning for why the environment gate is a *stronger* review prompt than a regular PR approval

### Documentation
- Added `docs/CI-SECURITY.md` with the full security design, rationale for the accepted risk in cflite, and the two-workflow pattern explanation.

## Security improvement

| Workflow | Before | After |
|---|---|---|
| SonarQube PR | `pull_request_target` + fork checkout (flagged) | `workflow_run`, no fork code execution ✅ |
| ClusterFuzzLite PR | Environment gate (flagged, accepted) | Environment gate + documented rationale ✅ |