### PR TITLE
fix: tool stats backfill treats "complete" status as success

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfill.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfill.java
@@ -150,7 +150,6 @@ public final class ToolCallStatisticsBackfill {
         return EntryResult.INSERTED;
     }
 
-    @Nullable
     private static ToolCallRecord parseToolEntry(@NotNull String line,
                                                  @NotNull String clientId) {
         JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
@@ -162,18 +161,10 @@ public final class ToolCallStatisticsBackfill {
         // (e.g. "Tail full log", "Run summary"). Each call gets a unique non-deterministic
         // string, which makes aggregation worthless. Use the canonical MCP tool id from
         // the "pluginTool" field instead. Skip entries that aren't MCP tool calls.
-        String pluginTool = getStr(obj, "pluginTool");
         String displayName = getStr(obj, "title");
-        if (pluginTool.isEmpty()) {
-            // Legacy entries with mcpHandled=true but no explicit pluginTool: title was the bare id.
-            boolean mcpHandled = obj.has(MCP_HANDLED) && !obj.get(MCP_HANDLED).isJsonNull()
-                && obj.get(MCP_HANDLED).getAsBoolean();
-            if (mcpHandled && !displayName.isEmpty()) {
-                pluginTool = displayName;
-            } else {
-                return null;
-            }
-        }
+        String pluginTool = resolvePluginTool(obj, displayName);
+        if (pluginTool.isEmpty()) return null;
+
         String toolName = stripMcpPrefix(pluginTool);
         if (toolName.isEmpty()) return null;
 
@@ -183,7 +174,9 @@ public final class ToolCallStatisticsBackfill {
         Instant timestamp = Instant.parse(timestampStr);
 
         String status = getStr(obj, "status");
-        boolean success = "completed".equals(status);
+        // "complete" is the canonical value written by ChipStatus.COMPLETE since the refactor
+        // to MessageFormatter constants. "completed" is the legacy value from earlier sessions.
+        boolean success = "complete".equals(status) || "completed".equals(status);
 
         String arguments = getStr(obj, "arguments");
         String result = getStr(obj, "result");
@@ -206,6 +199,27 @@ public final class ToolCallStatisticsBackfill {
             toolName, category, inputSize, outputSize,
             0, // durationMs not available in JSONL entries
             success, errorMessage, clientId, timestamp, displayForDb);
+    }
+
+    /**
+     * Returns the canonical plugin tool id from the entry, or an empty string if the entry
+     * should be skipped (not an MCP tool call).
+     *
+     * <p>Two formats are handled:
+     * <ul>
+     *   <li>Current: {@code pluginTool} field contains the bare or prefixed tool id.</li>
+     *   <li>Legacy: {@code pluginTool} is absent but {@code mcpHandled=true}; the display
+     *       {@code title} was used as the bare id.</li>
+     * </ul>
+     */
+    @NotNull
+    private static String resolvePluginTool(@NotNull JsonObject obj, @NotNull String displayName) {
+        String pluginTool = getStr(obj, "pluginTool");
+        if (!pluginTool.isEmpty()) return pluginTool;
+        // Legacy entries: mcpHandled=true but no explicit pluginTool; title was the bare id.
+        boolean mcpHandled = obj.has(MCP_HANDLED) && !obj.get(MCP_HANDLED).isJsonNull()
+            && obj.get(MCP_HANDLED).getAsBoolean();
+        return (mcpHandled && !displayName.isEmpty()) ? displayName : "";
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -185,6 +185,8 @@ public final class ToolCallStatisticsService implements Disposable {
             migrateAddErrorMessageColumn(stmt);
             // Migration: add display_name column to preserve agent-supplied chip titles for debugging
             migrateAddDisplayNameColumn(stmt);
+            // Data repair: records backfilled when ChipStatus "complete" was wrongly treated as failure
+            migrateRepairWronglyFailedRecords(stmt);
 
             stmt.execute("""
                 CREATE TABLE IF NOT EXISTS turn_stats (
@@ -234,6 +236,34 @@ public final class ToolCallStatisticsService implements Disposable {
                 LOG.warn("Unexpected error migrating tool_calls schema (display_name column)", e);
             }
             // else: duplicate column — expected for databases that have already been migrated
+        }
+    }
+
+    /**
+     * Repairs records that were backfilled with {@code success = 0} incorrectly.
+     *
+     * <p>Root cause: before {@code ToolCallStatisticsBackfill} was updated to recognise
+     * {@code ChipStatus.COMPLETE = "complete"}, only {@code "completed"} was treated as success.
+     * Sessions saved after the rename stored {@code status = "complete"}, so the backfill
+     * inserted all those tool calls as errors, inflating the error rate to ~100% for many tools.
+     *
+     * <p>Heuristic: every genuine error recorded by the live path sets {@code error_message}
+     * to a string starting with {@code "Error"} (plugin convention). Backfill-wrongly-failed
+     * successes have an {@code error_message} that contains the tool's normal output, which
+     * never starts with {@code "Error"}. So any record where {@code success = 0} and
+     * {@code error_message IS NOT NULL AND NOT LIKE 'Error%'} is a false positive — repair it.
+     * This update is idempotent and runs on every startup at near-zero cost.</p>
+     */
+    private void migrateRepairWronglyFailedRecords(java.sql.Statement stmt) {
+        try {
+            int repaired = stmt.executeUpdate(
+                "UPDATE tool_calls SET success = 1, error_message = NULL "
+                    + "WHERE success = 0 AND error_message IS NOT NULL AND error_message NOT LIKE 'Error%'");
+            if (repaired > 0) {
+                LOG.info("Repaired " + repaired + " tool_calls records wrongly marked as errors by backfill");
+            }
+        } catch (SQLException e) {
+            LOG.warn("Failed to run tool_calls error-rate repair migration", e);
         }
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfillTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfillTest.java
@@ -51,9 +51,9 @@ class ToolCallStatisticsBackfillTest {
         String basePath = tempDir.toString();
         createSessionIndex(basePath, "session-1", "GitHub Copilot");
         createSessionJsonl(basePath, "session-1",
-            toolEntry("read_file", "completed", "2025-01-15T10:00:00Z",
+            toolEntry("read_file", "complete", "2025-01-15T10:00:00Z",
                 "{\"path\":\"test.java\"}", "file contents here"),
-            toolEntry("search_text", "completed", "2025-01-15T10:01:00Z",
+            toolEntry("search_text", "complete", "2025-01-15T10:01:00Z",
                 "{\"query\":\"foo\"}", "3 matches found"));
 
         ToolCallStatisticsBackfill.BackfillResult result =
@@ -71,7 +71,7 @@ class ToolCallStatisticsBackfillTest {
         String basePath = tempDir.toString();
         createSessionIndex(basePath, "session-1", "GitHub Copilot");
         createSessionJsonl(basePath, "session-1",
-            toolEntry("read_file", "completed", "2025-01-15T10:00:00Z",
+            toolEntry("read_file", "complete", "2025-01-15T10:00:00Z",
                 "{}", "ok"));
 
         ToolCallStatisticsBackfill.backfill(service, basePath);
@@ -89,7 +89,7 @@ class ToolCallStatisticsBackfillTest {
         String basePath = tempDir.toString();
         createSessionIndex(basePath, "session-1", "Claude Code");
         createSessionJsonl(basePath, "session-1",
-            toolEntry("edit_file", "completed", "2025-01-15T10:00:00Z",
+            toolEntry("edit_file", "complete", "2025-01-15T10:00:00Z",
                 "{}", "done"));
 
         ToolCallStatisticsBackfill.backfill(service, basePath);
@@ -127,7 +127,7 @@ class ToolCallStatisticsBackfillTest {
             {"type":"thinking","content":"hmm","timestamp":"2025-01-15T10:00:01Z"}""";
         createSessionJsonl(basePath, "session-1",
             textEntry, thinkingEntry,
-            toolEntry("read_file", "completed", "2025-01-15T10:00:02Z", "{}", "ok"));
+            toolEntry("read_file", "complete", "2025-01-15T10:00:02Z", "{}", "ok"));
 
         ToolCallStatisticsBackfill.BackfillResult result =
             ToolCallStatisticsBackfill.backfill(service, basePath);
@@ -178,9 +178,9 @@ class ToolCallStatisticsBackfillTest {
             new String[]{"session-1", "GitHub Copilot"},
             new String[]{"session-2", "Claude Code"});
         createSessionJsonl(basePath, "session-1",
-            toolEntry("read_file", "completed", "2025-01-15T10:00:00Z", "{}", "ok"));
+            toolEntry("read_file", "complete", "2025-01-15T10:00:00Z", "{}", "ok"));
         createSessionJsonl(basePath, "session-2",
-            toolEntry("edit_file", "completed", "2025-01-15T11:00:00Z", "{}", "done"));
+            toolEntry("edit_file", "complete", "2025-01-15T11:00:00Z", "{}", "done"));
 
         ToolCallStatisticsBackfill.BackfillResult result =
             ToolCallStatisticsBackfill.backfill(service, basePath);
@@ -198,7 +198,7 @@ class ToolCallStatisticsBackfillTest {
         createSessionIndex(basePath, "session-1", "GitHub Copilot");
         // Entry has a non-empty but unparseable timestamp → Instant.parse() throws
         createSessionJsonl(basePath, "session-1",
-            toolEntry("read_file", "completed", "NOT-AN-ISO-DATE", "{}", "ok"));
+            toolEntry("read_file", "complete", "NOT-AN-ISO-DATE", "{}", "ok"));
 
         ToolCallStatisticsBackfill.BackfillResult result =
             ToolCallStatisticsBackfill.backfill(service, basePath);
@@ -213,7 +213,7 @@ class ToolCallStatisticsBackfillTest {
         String basePath = tempDir.toString();
         createSessionIndex(basePath, "session-1", "GitHub Copilot");
         createSessionJsonl(basePath, "session-1",
-            toolEntry("", "completed", "2025-01-15T10:00:00Z", "{}", "ok"));
+            toolEntry("", "complete", "2025-01-15T10:00:00Z", "{}", "ok"));
 
         ToolCallStatisticsBackfill.BackfillResult result =
             ToolCallStatisticsBackfill.backfill(service, basePath);
@@ -229,7 +229,7 @@ class ToolCallStatisticsBackfillTest {
         String basePath = tempDir.toString();
         createSessionIndex(basePath, "session-1", "GitHub Copilot");
         createSessionJsonl(basePath, "session-1",
-            toolEntry("read_file", "completed", "", "{}", "ok"));
+            toolEntry("read_file", "complete", "", "{}", "ok"));
 
         ToolCallStatisticsBackfill.BackfillResult result =
             ToolCallStatisticsBackfill.backfill(service, basePath);
@@ -247,7 +247,7 @@ class ToolCallStatisticsBackfillTest {
         String entryWithKind = "{\"type\":\"tool\",\"pluginTool\":\"read_file\","
             + "\"title\":\"read_file\","
             + "\"kind\":\"FILE\","
-            + "\"timestamp\":\"2025-01-15T10:00:00Z\",\"status\":\"completed\","
+            + "\"timestamp\":\"2025-01-15T10:00:00Z\",\"status\":\"complete\","
             + "\"arguments\":\"{}\",\"result\":\"file contents\"}";
         createSessionJsonl(basePath, "session-1", entryWithKind);
 
@@ -265,7 +265,7 @@ class ToolCallStatisticsBackfillTest {
         createSessionIndex(basePath, "session-1", "GitHub Copilot");
         // No pluginTool, no mcpHandled — this is a non-MCP tool call (e.g. agent's built-in)
         String nonMcpEntry = "{\"type\":\"tool\",\"title\":\"Some agent tool\","
-            + "\"timestamp\":\"2025-01-15T10:00:00Z\",\"status\":\"completed\","
+            + "\"timestamp\":\"2025-01-15T10:00:00Z\",\"status\":\"complete\","
             + "\"arguments\":\"{}\",\"result\":\"ok\"}";
         createSessionJsonl(basePath, "session-1", nonMcpEntry);
 
@@ -284,7 +284,7 @@ class ToolCallStatisticsBackfillTest {
         createSessionIndex(basePath, "session-1", "GitHub Copilot");
         String legacyEntry = "{\"type\":\"tool\",\"title\":\"read_file\","
             + "\"mcpHandled\":true,"
-            + "\"timestamp\":\"2025-01-15T10:00:00Z\",\"status\":\"completed\","
+            + "\"timestamp\":\"2025-01-15T10:00:00Z\",\"status\":\"complete\","
             + "\"arguments\":\"{}\",\"result\":\"ok\"}";
         createSessionJsonl(basePath, "session-1", legacyEntry);
 
@@ -302,15 +302,15 @@ class ToolCallStatisticsBackfillTest {
         // Different agents prefix the MCP id differently
         String copilotEntry = "{\"type\":\"tool\",\"pluginTool\":\"agentbridge-read_file\","
             + "\"title\":\"Read source\","
-            + "\"timestamp\":\"2025-01-15T10:00:00Z\",\"status\":\"completed\","
+            + "\"timestamp\":\"2025-01-15T10:00:00Z\",\"status\":\"complete\","
             + "\"arguments\":\"{}\",\"result\":\"ok\"}";
         String opencodeEntry = "{\"type\":\"tool\",\"pluginTool\":\"agentbridge_search_text\","
             + "\"title\":\"grep\","
-            + "\"timestamp\":\"2025-01-15T10:01:00Z\",\"status\":\"completed\","
+            + "\"timestamp\":\"2025-01-15T10:01:00Z\",\"status\":\"complete\","
             + "\"arguments\":\"{}\",\"result\":\"ok\"}";
         String kiroEntry = "{\"type\":\"tool\",\"pluginTool\":\"@agentbridge/git_status\","
             + "\"title\":\"git status\","
-            + "\"timestamp\":\"2025-01-15T10:02:00Z\",\"status\":\"completed\","
+            + "\"timestamp\":\"2025-01-15T10:02:00Z\",\"status\":\"complete\","
             + "\"arguments\":\"{}\",\"result\":\"clean\"}";
         createSessionJsonl(basePath, "session-1", copilotEntry, opencodeEntry, kiroEntry);
 
@@ -416,6 +416,23 @@ class ToolCallStatisticsBackfillTest {
         ToolCallStatisticsBackfill.BackfillResult result =
             new ToolCallStatisticsBackfill.BackfillResult(5, 3, 1);
         assertEquals("BackfillResult{inserted=5, skipped=3, errors=1}", result.toString());
+    }
+
+    @Test
+    @DisplayName("legacy 'completed' status (pre-refactor) is still recognised as success")
+    void legacyCompletedStatusIsRecognisedAsSuccess() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        // Old sessions written before ChipStatus.COMPLETE was renamed from "completed" to "complete"
+        createSessionJsonl(basePath, "session-1",
+            toolEntry("read_file", "completed", "2025-01-15T10:00:00Z", "{}", "ok"));
+
+        ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        var stats = service.queryAggregates(null, null);
+        assertEquals(1, stats.size());
+        assertEquals(0, stats.getFirst().errorCount(),
+            "Legacy 'completed' status must be treated as success, got: " + stats.getFirst());
     }
 
     @Test


### PR DESCRIPTION
## Problem

The Tool Statistics view showed \~100% error rates for many tools, which is clearly wrong.

## Root Cause

`PromptOrchestrator` was refactored to write `ChipStatus.COMPLETE = "complete"` (no trailing 'd') into JSONL session files via `MessageFormatter` constants. But `ToolCallStatisticsBackfill.parseToolEntry` still checked only for the legacy `"completed"` value.

Result: every tool call backfilled from sessions recorded *after* that refactor was inserted with `success=0`, inflating error rates to ~100% for any tool used recently.

## Fixes

- **Backfill logic**: accept `"complete"` OR `"completed"` (backward compat for old sessions)
- **Startup migration**: `migrateRepairWronglyFailedRecords()` repairs already-corrupted DB rows on first startup after this fix — safe heuristic: `success=0` records whose `error_message` does not start with `"Error"` are false positives, flipped to `success=1`
- **Cognitive complexity**: extracted `resolvePluginTool()` helper from `parseToolEntry` to bring complexity below the 15-limit
- **Tests**: all fixtures updated to use canonical `"complete"` status; new backward-compat test for `"completed"`

## Verification

All 23 `ToolCallStatisticsBackfillTest` tests pass.