### PR TITLE
fix: remaining OSR screen tearing — nav 2-rAF + render-pending scroll retry (Fix 11)

### DIFF
--- a/docs/bugs/SCREEN-TEARING-BUG.md
+++ b/docs/bugs/SCREEN-TEARING-BUG.md
@@ -470,17 +470,80 @@ bridge-initiated toggle, go through the two-rAF deferral pattern.
 
 **All scroll-to-bottom paths now deferred**:
 
-| Trigger                   | Method                        | Deferral                    |
-|---------------------------|-------------------------------|-----------------------------|
-| DOM mutation              | MutationObserver              | `_scheduleDeferredScroll()` |
-| Resize                    | ResizeObserver                | `_scheduleDeferredScroll()` |
-| User message append       | `scheduleForceScroll()`       | `_scheduleDeferredScroll()` |
-| Nudge/queued message      | `scheduleScrollIfNeeded()`    | `_scheduleDeferredScroll()` |
-| Markdown finalize         | `scheduleScrollIfNeeded()`    | `_scheduleDeferredScroll()` |
-| Bridge `setAutoScroll()`  | `set autoScroll`              | `_scheduleDeferredScroll()` |
-| First tool chip insertion | MutationObserver (implicit)   | `_scheduleDeferredScroll()` |
-| Chip-strip horizontal     | `MessageMeta._scrollToEnd()`  | Two-rAF inline              |
-| History restore final     | `restoreBatchFinal()` → rAF×2 | Two-rAF wrapper             |
+| Trigger                   | Method                            | Deferral                    |
+|---------------------------|-----------------------------------|-----------------------------|
+| DOM mutation              | MutationObserver                  | `_scheduleDeferredScroll()` |
+| Resize                    | ResizeObserver                    | `_scheduleDeferredScroll()` |
+| User message append       | `scheduleForceScroll()`           | `_scheduleDeferredScroll()` |
+| Nudge/queued message      | `scheduleScrollIfNeeded()`        | `_scheduleDeferredScroll()` |
+| Markdown finalize         | `scheduleScrollIfNeeded()`        | `_scheduleDeferredScroll()` |
+| Bridge `setAutoScroll()`  | `set autoScroll`                  | `_scheduleDeferredScroll()` |
+| First tool chip insertion | MutationObserver (implicit)       | `_scheduleDeferredScroll()` |
+| Chip-strip horizontal     | `MessageMeta._scrollToEnd()`      | Two-rAF inline              |
+| History restore final     | `restoreBatchFinal()` → rAF×2     | Two-rAF wrapper             |
+| Nav indicator update      | `MessageMeta.scheduleNavUpdate()` | Two-rAF inline (Fix 11b)    |
+
+### Fix 11 — Render-pending retry and nav-indicator two-rAF deferral (2025)
+
+**Status**: In testing.
+
+**Problem**: Four residual tearing scenarios persisted after Fix 10:
+
+1. **Thought chip added/collapsed during streaming**: The 2-rAF scroll from the chip's
+   MutationObserver trigger fires in frame N+1. `MessageBubble.appendStreamingText()` also fires
+   its rAF-render in frame N+1 (for tokens that arrived between frames N and N+1). Both land in
+   the same paint frame → dirty-rect collapse → tearing. The timing collision is a consequence of
+   rAF queue ordering: scrollRAF-outer was queued at frame N's MutationObserver microtask;
+   rAF-render was queued in a task between N and N+1, so after scrollRAF-outer. Therefore in
+   frame N+1, scrollRAF-outer fires first (good), but rAF-render fires AFTER — meaning the inner
+   scrollRAF (N+2) and the next frame's rAF-render (also N+2 if tokens arrive between N+1 and
+   N+2) still collide.
+
+2. **Tool chip loading indicator removed during streaming**: `setToolChipState()` →
+   `ToolChip._render()` → synchronous innerHTML change → MutationObserver → 2-rAF scroll. Same
+   N+2 collision with rAF-renders from concurrent streaming.
+
+3. **Nav indicator (‹ ›) appearance when chip strip overflows**: `scheduleNavUpdate()` used a
+   single rAF. The `sharedResizeObserver` fires in frame N's layout phase and queues
+   `scheduleNavUpdate()` for frame N+1. The container scroll (from the same chip-addition
+   trigger) fires in frame N+1 via its own 2-rAF chain. Nav button class toggle + container
+   `scrollTop` write in the same frame → dirty-rect collapse → tearing.
+
+4. **Multiple events on consecutive frames**: Prompt, chip, and thinking arrivals in a tight
+   burst use the coalesced gate, but discrete events interleaved with streaming tokens could
+   land the scroll in a frame that also has an rAF-render from newer tokens.
+
+**Root cause — rAF queue ordering**: `MessageBubble.appendStreamingText()` queues its rAF-render
+during a task (tokens arriving between frames). `_scheduleDeferredScroll()` queues scrollRAF-outer
+during the MutationObserver microtask that follows. The task runs *before* the microtask, so
+rAF-render is queued *before* scrollRAF-outer. In the next frame, rAF callbacks run in queue
+order, so rAF-render fires *before* scrollRAF-outer. This means `renderPending = true` at the
+time the *inner* scrollRAF fires — the render for the *next* batch of tokens (queued in a new
+task between frames) is still in the queue when the scroll fires, putting mutation and scroll
+in the same paint frame.
+
+**Fix**:
+
+- **`ChatContainer.ts` `_flushScrollOrRetry()`** (Fix 11a): When the inner rAF fires, check
+  whether any `message-bubble[streaming]` element has `renderPending === true`. If yes, a
+  rAF-render for tokens that arrived this inter-frame window is queued *after* the inner rAF
+  (per queue order) and will fire in the same paint frame. Defer by one more rAF. Retry up to
+  `MAX_SCROLL_RETRIES = 3` times to guarantee progress during sustained heavy streaming.
+  After `MAX_SCROLL_RETRIES`, scroll is forced regardless (accepting occasional rare tearing
+  during extremely fast streams).
+
+  The `renderPending` check is accurate: it is set `true` when a token arrives (in the task)
+  and cleared `false` at the start of the rAF-render callback. At the time the inner scrollRAF
+  fires, `renderPending = true` means there is a rAF-render queued in the current frame (already
+  in the queue, fires after us). This is precisely the collision we need to avoid.
+
+- **`MessageBubble.ts` `renderPending` getter** (Fix 11a): Exposes `_renderPending` as a read-
+  only public property for `ChatContainer` to inspect.
+
+- **`MessageMeta.ts` `scheduleNavUpdate()`** (Fix 11b): Changed from one rAF to two rAFs.
+  The `sharedResizeObserver` fires in frame N's layout phase; with one rAF the nav update fired
+  in frame N+1 — the same frame as the container scroll. With two rAFs it fires in frame N+2,
+  one frame after the scroll, eliminating the nav-button layout-change + scrollTop collision.
 
 ---
 
@@ -511,7 +574,9 @@ bridge-initiated toggle, go through the two-rAF deferral pattern.
 | `ChatController.ts`        | `addUserMessage()`               | Uses `scheduleForceScroll()` — two-rAF deferred, not synchronous `forceScroll()` (Fix 9)             |
 | `MessageMeta.ts`           | `_scrollToEnd()`                 | Two-rAF deferred, `behavior: 'instant'` — chip-strip horizontal scroll (Fix 9)                       |
 | `chat.css`                 | `chat-container`, `chat-message` | No paint containment, content-visibility virtualization, or hover tooltip overlays in OSR            |
-| `MessageBubble.ts`         | `appendStreamingText()`          | rAF-debounced markdown re-render                                                                     |
+| `MessageBubble.ts`         | `renderPending` getter           | Exposes `_renderPending` for `ChatContainer` to detect pending rAF-render collision (Fix 11a)        |
+| `MessageMeta.ts`           | `scheduleNavUpdate()`            | Two-rAF deferred nav update — separates nav button layout change from container scroll (Fix 11b)     |
+| `ChatContainer.ts`         | `_flushScrollOrRetry()`          | Retries the scroll when `renderPending` is true; caps at `MAX_SCROLL_RETRIES` (Fix 11a)              |
 | `MonitorSwitchRecovery.kt` | `triggerRecovery()`              | Refreshes OSR and asks the chat panel to replay DOM state after monitor changes                      |
 
 ---
@@ -568,3 +633,22 @@ When modifying the streaming pipeline, watch for:
     *next* paint frame. Same-frame batching enables Chromium compositor tile-translation cache
     reuse, which collapses the dirty rect and leaves shifted siblings stale in JBR's
     `BufferedImage` cache. See Fix 8 for the full mechanism.
+
+12. **rAF-render + scrollRAF-inner in the same frame** (Fix 11a) — the 2-rAF scroll pattern
+    guarantees the scroll fires one frame after the triggering mutation. But `MessageBubble`
+    queues its rAF-render *before* the MutationObserver microtask (task vs microtask ordering),
+    so scrollRAF-inner and rAF-render can still land in the same frame for tokens that arrive
+    in the inter-frame window. The `_flushScrollOrRetry()` check ensures the scroll defers if
+    `renderPending` is true at the time the inner rAF fires. **Do NOT remove the `renderPending`
+    check or change the ordering of `_renderPending = false` relative to `innerHTML =` in
+    `MessageBubble._doRender()`** — the correctness of the retry depends on this flag being
+    cleared *before* the innerHTML assignment so that a retry in the same frame has a clean
+    DOM to measure.
+
+13. **Nav update in same frame as scroll** (Fix 11b) — `scheduleNavUpdate()` MUST use 2 rAFs
+    (not 1). A single rAF from a `ResizeObserver` callback lands in the same frame as
+    `_scheduleDeferredScroll()`'s inner rAF. The nav button class change (layout shift inside
+    the scrolled content) and the `scrollTop` write in the same frame cause dirty-rect collapse.
+    **Do not reduce `scheduleNavUpdate()` back to a single rAF** without re-testing chip strip
+    overflow during streaming on both Linux and Windows.
+

--- a/plugin-core/chat-ui/src/components/ChatContainer.ts
+++ b/plugin-core/chat-ui/src/components/ChatContainer.ts
@@ -5,6 +5,8 @@ export default class ChatContainer extends HTMLElement {
     private _messages!: HTMLDivElement;
     private _workingIndicator!: HTMLElement;
     private _scrollRAF: number | null = null;
+    private _scrollRAFRetries = 0;
+    private static readonly MAX_SCROLL_RETRIES = 3;
     private _copyRAF: number | null = null;
     private _observer!: MutationObserver;
     private _copyObs!: MutationObserver;
@@ -387,17 +389,48 @@ export default class ChatContainer extends HTMLElement {
      *   - Frame N+1: scroll happens. Tiny scroll-revealed strip dirty rect, but `myImage` is
      *                already correct from frame N.
      *
-     * Cost: ~16ms additional autoscroll latency during streaming. Imperceptible vs. the
-     * stream cadence; users don't notice the bottom-snap arriving one frame later.
+     * During continuous streaming, MessageBubble queues a rAF-render per burst that fires
+     * in the frame after tokens arrive. If that rAF-render lands in the same frame as the
+     * inner scroll rAF (Fix 8's N+1), the mutation+scroll collision re-appears. Fix 11
+     * adds a render-pending retry: if any streaming bubble's rAF-render is still queued at
+     * the time the inner rAF fires, the scroll is deferred by one more rAF (up to
+     * MAX_SCROLL_RETRIES). Since rAF callbacks run in queue order, MessageBubble's render
+     * fires AFTER the inner scroll rAF (it was queued later), so renderPending is still
+     * true when we check — letting us detect and defer the collision.
+     *
+     * Cost: ~16ms additional autoscroll latency per retry (up to ~64ms total). Imperceptible
+     * vs. the stream cadence; users don't notice the bottom-snap arriving a few frames later.
      */
     private _scheduleDeferredScroll(): void {
         if (this._scrollRAF) return;
+        this._scrollRAFRetries = 0;
         this._scrollRAF = requestAnimationFrame(() => {
             this._scrollRAF = requestAnimationFrame(() => {
                 this._scrollRAF = null;
-                this.scrollIfNeeded();
+                this._flushScrollOrRetry();
             });
         });
+    }
+
+    /**
+     * Called by the inner rAF of _scheduleDeferredScroll. Fires the scroll unless a
+     * streaming MessageBubble has a rAF-render pending in this same frame (Fix 11).
+     * In that case, defers by one more rAF to keep mutation and scroll in separate frames.
+     */
+    private _flushScrollOrRetry(): void {
+        const hasPendingRender = this._scrollRAFRetries < ChatContainer.MAX_SCROLL_RETRIES
+            && Array.from(this._messages.querySelectorAll<HTMLElement>('message-bubble[streaming]'))
+                .some(b => (b as any).renderPending === true);
+        if (hasPendingRender) {
+            this._scrollRAFRetries++;
+            this._scrollRAF = requestAnimationFrame(() => {
+                this._scrollRAF = null;
+                this._flushScrollOrRetry();
+            });
+        } else {
+            this._scrollRAFRetries = 0;
+            this.scrollIfNeeded();
+        }
     }
 
     private _isAtBottom(): boolean {

--- a/plugin-core/chat-ui/src/components/MessageBubble.ts
+++ b/plugin-core/chat-ui/src/components/MessageBubble.ts
@@ -67,6 +67,15 @@ export default class MessageBubble extends HTMLElement {
         this.innerHTML = html;
     }
 
+    /**
+     * True while a rAF re-render is queued but hasn't fired yet.
+     * ChatContainer reads this to avoid writing scrollTop in the same paint frame as
+     * the rAF-render — see Fix 11 in SCREEN-TEARING-BUG.md.
+     */
+    get renderPending(): boolean {
+        return this._renderPending;
+    }
+
     get content(): string {
         return this.innerHTML;
     }

--- a/plugin-core/chat-ui/src/components/MessageMeta.ts
+++ b/plugin-core/chat-ui/src/components/MessageMeta.ts
@@ -96,12 +96,24 @@ export default class MessageMeta extends HTMLElement {
         return super.appendChild(node);
     }
 
-    /** Schedule a nav update coalesced via requestAnimationFrame. */
+    /**
+     * Schedule a nav update deferred by two rAFs.
+     *
+     * Why two rAFs (Fix 11 — see SCREEN-TEARING-BUG.md): nav buttons showing/hiding is a
+     * layout change that happens inside the scrolled content. If it fires in the same paint
+     * frame as a chat-container scrollTop write, Chromium's compositor may apply tile-
+     * translation cache reuse for both, collapsing the dirty rect and leaving the JBR
+     * BufferedImage stale — the same mechanism as Fix 8. The chip-strip container scroll
+     * (_scrollToEnd) and the chat-container deferred scroll both fire one frame earlier, so
+     * placing the nav update one frame later ensures clean separation.
+     */
     scheduleNavUpdate(): void {
         if (this._navRAF) return;
         this._navRAF = requestAnimationFrame(() => {
-            this._navRAF = null;
-            this._updateNav();
+            this._navRAF = requestAnimationFrame(() => {
+                this._navRAF = null;
+                this._updateNav();
+            });
         });
     }
 


### PR DESCRIPTION
## Summary

Fixes the remaining screen tearing scenarios after Fix 8–10 (2-rAF deferral, non-streaming scroll, autoScroll bridge).

## Root Causes Fixed

### Fix 11a — Render-pending retry (`ChatContainer`, `MessageBubble`)
**Problem**: Task vs microtask ordering puts `MessageBubble`'s rAF-render *before* MutationObserver's microtask in the rAF queue. So `scrollRAF-inner` and `rAF-render` land in the same paint frame for tokens arriving between frames — dirty-rect collapse → tearing.

**Fix**: `_flushScrollOrRetry()` checks `renderPending` on all `message-bubble[streaming]` elements when the inner rAF fires. If any bubble has a rAF-render queued in the same frame, it defers by 1 more rAF (up to `MAX_SCROLL_RETRIES = 3`), then forces the scroll regardless. This covers thought chip add/collapse, tool chip loading removal, and rapid multi-event bursts.

### Fix 11b — Nav indicator 2-rAF deferral (`MessageMeta`)
**Problem**: `scheduleNavUpdate()` used a single rAF. ResizeObserver fires in frame N → nav update fires in N+1 = same frame as `scrollRAF-inner`. Nav button class change (layout shift) + `scrollTop` write in the same frame → tearing when chip strip overflows.

**Fix**: Changed to 2 rAFs — nav update fires in N+2, one frame after the scroll.

## Changes
- `ChatContainer.ts`: `_scheduleDeferredScroll()` delegates inner rAF to `_flushScrollOrRetry()`; new fields `_scrollRAFRetries` / `MAX_SCROLL_RETRIES`
- `MessageBubble.ts`: `renderPending` getter exposes `_renderPending` for container inspection  
- `MessageMeta.ts`: `scheduleNavUpdate()` 1→2 rAFs
- `SCREEN-TEARING-BUG.md`: Fix 11 section, regression vectors 12–13, updated tables
