### PR TITLE
fix: retry verifyPlugin up to 3 times on ClosedFileSystemException flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,21 @@ jobs:
         run: df -h /
 
       - name: Verify plugins (marketplace compatibility)
-        run: gradle :plugin-core:verifyPlugin --no-daemon --quiet
+        # The JetBrains plugin verifier runs 5 IDE targets concurrently via ExecutorWithProgress.
+        # A race condition in PluginJar.resolveDescriptors() can cause ClosedFileSystemException
+        # when concurrent workers share a ZipFileSystem handle for the plugin JAR — a known bug
+        # in the verifier library. The race is non-deterministic, so we retry up to 3 times.
+        run: |
+          for attempt in 1 2 3; do
+            gradle :plugin-core:verifyPlugin --no-daemon --quiet && break
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt $attempt failed, retrying in 15 seconds..."
+              sleep 15
+            else
+              echo "All 3 attempts failed"
+              exit 1
+            fi
+          done
 
       - name: Show disk space after plugin verification
         if: always()


### PR DESCRIPTION
## Problem

The `verifyPlugin` CI step fails non-deterministically with:

```
java.lang.RuntimeException: Worker '...' finished with error
Caused by: java.nio.file.ClosedFileSystemException
    at PluginJar.resolveDescriptors(PluginJar.kt:53)
    at ExecutorWithProgress.waitAllFutures(ConcurrencyUtils.kt:96)
```

The JetBrains plugin verifier runs 5 IDE targets concurrently via `ExecutorWithProgress`. A thread-safety bug in `PluginJar.resolveDescriptors()` causes a `ClosedFileSystemException` when concurrent workers share a `ZipFileSystem` handle — **not caused by our plugin code**.

## Fix

Add a retry loop (up to 3 attempts, 15 s back-off) around the `verifyPlugin` step. The race condition is non-deterministic and does not reproduce consistently, so 3 retries are sufficient. A comment in the workflow documents the root cause for future reference.

## No functional change

This is CI-only. No plugin source code changed.