### PR TITLE
feat: replace nudge cancel button with inline X inside bubble

### DIFF
--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -976,9 +976,9 @@ const ChatController = {
     showNudgeBubble(id: string, text: string): void {
         const existing = document.getElementById('nudge-' + id);
         if (existing) {
-            const bubble = existing.querySelector('message-bubble');
-            if (bubble) {
-                bubble.textContent = text;
+            const textSpan = existing.querySelector('.nudge-text');
+            if (textSpan) {
+                textSpan.textContent = text;
                 this._container()?.scheduleScrollIfNeeded();
             }
             return;
@@ -992,14 +992,21 @@ const ChatController = {
         msg.appendChild(meta);
         const bubble = document.createElement('message-bubble');
         bubble.setAttribute('type', 'user');
-        bubble.textContent = text;
+        const textSpan = document.createElement('span');
+        textSpan.className = 'nudge-text';
+        textSpan.textContent = text;
+        bubble.appendChild(textSpan);
+        const cancelX = document.createElement('button');
+        cancelX.type = 'button';
+        cancelX.className = 'nudge-cancel-x';
+        cancelX.title = 'Cancel nudge';
+        cancelX.textContent = '✕';
+        cancelX.onclick = (e: MouseEvent) => {
+            e.stopPropagation();
+            (globalThis as any)._bridge?.cancelNudge(id);
+        };
+        bubble.appendChild(cancelX);
         msg.appendChild(bubble);
-        const cancelBtn = document.createElement('button');
-        cancelBtn.type = 'button';
-        cancelBtn.className = 'quick-reply-btn nudge-cancel-btn';
-        cancelBtn.textContent = '✕ Cancel nudge';
-        cancelBtn.onclick = () => (globalThis as any)._bridge?.cancelNudge(id);
-        msg.appendChild(cancelBtn);
         // Insert before the first queued message so nudge appears above queued messages.
         const firstQueued = this._msgs().querySelector('.message-queued');
         if (firstQueued) {
@@ -1016,7 +1023,7 @@ const ChatController = {
         el.classList.remove('nudge-pending');
         el.classList.add('nudge-sent');
         el.querySelector('.nudge-label')?.remove();
-        el.querySelector('.nudge-cancel-btn')?.remove();
+        el.querySelector('.nudge-cancel-x')?.remove();
     },
 
     removeNudgeBubble(id: string): void {

--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -2836,7 +2836,9 @@ pre.word-wrap code {
 
 /* ── Nudge bubble ────────────────────────────────────── */
 .nudge-pending message-bubble {
+    position: relative;
     opacity: 0.7;
+    padding-right: 1.8em;
 }
 
 .nudge-pending .nudge-label {
@@ -2853,10 +2855,31 @@ pre.word-wrap code {
     opacity: 0.7;
 }
 
-.nudge-cancel-btn {
-    margin-top: var(--sp-2);
-    font-size: 0.82em;
-    opacity: 0.8;
+.nudge-cancel-x {
+    position: absolute;
+    top: 50%;
+    right: var(--sp-2);
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.3em;
+    height: 1.3em;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: inherit;
+    font-size: 0.8em;
+    line-height: 1;
+    opacity: 0.5;
+    cursor: pointer;
+    transition: opacity 0.15s, background 0.15s;
+}
+
+.nudge-cancel-x:hover {
+    opacity: 1;
+    background: rgba(128, 128, 128, 0.25);
 }
 
 /* ── System notice bubble ──────────────────────────────── */


### PR DESCRIPTION
The "Cancel nudge" button was a separate element rendered below the chat bubble. This replaces it with a small ✕ button positioned inside the bubble's top-right corner, with a "Cancel nudge" tooltip.

**Changes:**
- Wrap bubble text in `.nudge-text` span so text updates work cleanly
- Add `.nudge-cancel-x` button inside the bubble (absolutely positioned, top-right)
- Stop click propagation so the bubble's collapse handler doesn't fire
- `.nudge-pending message-bubble`: add `position: relative` + right padding to make room
- Replace `.nudge-cancel-btn` (external button styles) with `.nudge-cancel-x` (inline overlay styles)

The button disappears automatically when `resolveNudgeBubble()` is called (nudge sent), unchanged from current behavior.