### PR TITLE
fix: tool chip shows "Sub-Agent Task" and sticks loading for non-sub-agent calls

### DIFF
--- a/docs/tool-execution-correlation.md
+++ b/docs/tool-execution-correlation.md
@@ -1,5 +1,10 @@
 # Tool Execution Correlation Architecture
 
+> **Note:** The `ToolExecutionCorrelator` design in this document (sections up to "ToolChipRegistry Chip Correlation")
+> was an early architectural proposal. The class was never implemented — the actual result-correlation for Junie's
+> natural-language summaries is handled inline in the ACP client. Jump to
+> [ToolChipRegistry Chip Correlation](#toolchipregistry-chip-correlation) for the current, implemented architecture.
+
 ## Problem Statement
 
 Tool execution in the plugin happens through **two separate channels**:

--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -1030,41 +1030,6 @@ const ChatController = {
         document.getElementById('nudge-' + id)?.remove();
     },
 
-    showSystemNoticeBubble(id: string, text: string): void {
-        const existing = document.getElementById('sysnotice-' + id);
-        if (existing) {
-            const bubble = existing.querySelector('message-bubble');
-            if (bubble) {
-                bubble.textContent = text;
-                this._container()?.scheduleScrollIfNeeded();
-            }
-            return;
-        }
-        const msg = document.createElement('chat-message');
-        msg.id = 'sysnotice-' + id;
-        msg.setAttribute('type', 'user');
-        const meta = document.createElement('message-meta');
-        meta.innerHTML = '<span class="ts system-notice-label">⚙ System notice</span>';
-        msg.appendChild(meta);
-        const bubble = document.createElement('message-bubble');
-        // No type attribute — MessageBubble.connectedCallback will add prompt-bubble class
-        // (because parent chat-message has type="user"). system-notice-bubble overrides the color.
-        bubble.classList.add('system-notice-bubble');
-        bubble.textContent = text;
-        msg.appendChild(bubble);
-        const firstQueued = this._msgs().querySelector('.message-queued');
-        if (firstQueued) {
-            this._msgs().insertBefore(msg, firstQueued);
-        } else {
-            this._msgs().appendChild(msg);
-        }
-        this._container()?.scheduleScrollIfNeeded();
-    },
-
-    removeSystemNoticeBubble(id: string): void {
-        document.getElementById('sysnotice-' + id)?.remove();
-    },
-
     showQueuedMessage(id: string, text: string): void {
         const msg = document.createElement('chat-message');
         msg.id = 'queued-' + id;

--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -976,9 +976,9 @@ const ChatController = {
     showNudgeBubble(id: string, text: string): void {
         const existing = document.getElementById('nudge-' + id);
         if (existing) {
-            const bubble = existing.querySelector('message-bubble');
-            if (bubble) {
-                bubble.textContent = text;
+            const textSpan = existing.querySelector('.nudge-text');
+            if (textSpan) {
+                textSpan.textContent = text;
                 this._container()?.scheduleScrollIfNeeded();
             }
             return;
@@ -992,14 +992,21 @@ const ChatController = {
         msg.appendChild(meta);
         const bubble = document.createElement('message-bubble');
         bubble.setAttribute('type', 'user');
-        bubble.textContent = text;
+        const textSpan = document.createElement('span');
+        textSpan.className = 'nudge-text';
+        textSpan.textContent = text;
+        bubble.appendChild(textSpan);
+        const cancelX = document.createElement('button');
+        cancelX.type = 'button';
+        cancelX.className = 'nudge-cancel-x';
+        cancelX.title = 'Cancel nudge';
+        cancelX.textContent = '✕';
+        cancelX.onclick = (e: MouseEvent) => {
+            e.stopPropagation();
+            (globalThis as any)._bridge?.cancelNudge(id);
+        };
+        bubble.appendChild(cancelX);
         msg.appendChild(bubble);
-        const cancelBtn = document.createElement('button');
-        cancelBtn.type = 'button';
-        cancelBtn.className = 'quick-reply-btn nudge-cancel-btn';
-        cancelBtn.textContent = '✕ Cancel nudge';
-        cancelBtn.onclick = () => (globalThis as any)._bridge?.cancelNudge(id);
-        msg.appendChild(cancelBtn);
         // Insert before the first queued message so nudge appears above queued messages.
         const firstQueued = this._msgs().querySelector('.message-queued');
         if (firstQueued) {
@@ -1016,7 +1023,7 @@ const ChatController = {
         el.classList.remove('nudge-pending');
         el.classList.add('nudge-sent');
         el.querySelector('.nudge-label')?.remove();
-        el.querySelector('.nudge-cancel-btn')?.remove();
+        el.querySelector('.nudge-cancel-x')?.remove();
     },
 
     removeNudgeBubble(id: string): void {

--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -414,6 +414,11 @@ const ChatController = {
         }
     },
 
+    updateChipLabel(id: string, label: string): void {
+        const chip = document.querySelector('[data-chip-for="' + id + '"]') as HTMLElement | null;
+        if (chip) chip.setAttribute('label', label);
+    },
+
     setToolChipState(id: string, state: string): void {
         const chip = document.querySelector('[data-chip-for="' + id + '"]');
         if (!chip) return;

--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -2882,16 +2882,3 @@ pre.word-wrap code {
     background: rgba(128, 128, 128, 0.25);
 }
 
-/* ── System notice bubble ──────────────────────────────── */
-.system-notice-bubble {
-    background: var(--fg-a08) !important;
-}
-
-.system-notice-bubble:hover {
-    background: var(--fg-a16) !important;
-}
-
-.system-notice-label {
-    color: var(--fg-muted);
-    font-size: 0.82em;
-}

--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -2836,7 +2836,9 @@ pre.word-wrap code {
 
 /* ── Nudge bubble ────────────────────────────────────── */
 .nudge-pending message-bubble {
+    position: relative;
     opacity: 0.7;
+    padding-right: 1.8em;
 }
 
 .nudge-pending .nudge-label {
@@ -2853,10 +2855,31 @@ pre.word-wrap code {
     opacity: 0.7;
 }
 
-.nudge-cancel-btn {
-    margin-top: var(--sp-2);
-    font-size: 0.82em;
-    opacity: 0.8;
+.nudge-cancel-x {
+    position: absolute;
+    top: 50%;
+    right: var(--sp-2);
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.3em;
+    height: 1.3em;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: inherit;
+    font-size: 0.8em;
+    line-height: 1;
+    opacity: 0.5;
+    cursor: pointer;
+    transition: opacity 0.15s, background 0.15s;
+}
+
+.nudge-cancel-x:hover {
+    opacity: 1;
+    background: rgba(128, 128, 128, 0.25);
 }
 
 /* ── System notice bubble ──────────────────────────────── */

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParser.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParser.java
@@ -142,8 +142,8 @@ class AcpMessageParser {
             }
         }
 
-        // Sub-agent detection uses the ORIGINAL title (e.g. "Intellij-Explore") because
-        // resolveToolId normalises unknown names to "task" which breaks agent-name matching.
+        // Sub-agent detection uses the ORIGINAL title (e.g. "Intellij-Explore") so that
+        // client-specific name normalization in resolveToolId does not interfere.
         String agentType = delegate.extractSubAgentType(params, title, argumentsObj);
         String subAgentDesc = null;
         String subAgentPrompt = null;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -555,27 +555,20 @@ public final class CopilotClient extends AcpClient {
     protected void onBuiltInToolApproved(String toolId, boolean userApproved) {
         if (!userApproved) {
             misusedBuiltInTools.add(toolId);
-            // Inject reprimand into the next MCP tool result for immediate mid-turn
-            // feedback — the agent corrects behaviour within the same turn instead of
-            // waiting until the user sends another prompt.
+            // Notify the UI so it can show a nudge bubble and arm the pending nudge for
+            // injection into the next MCP tool result.  Chain the cleanup callback first
+            // so it fires before the UI's resolve callback when the nudge is consumed.
             String notice = buildSingleToolReprimand(toolId);
             PsiBridgeService psi = PsiBridgeService.getInstance(project);
-            psi.setPendingNudge(notice);
-            // Fire system notice to the UI so the user can see it in the chat bubble.
-            psi.fireSystemNotice(notice);
-            // Once the nudge is consumed (agent saw it), clear the tracking set so
-            // beforeSendPrompt() doesn't repeat the same reprimand on the next prompt.
-            // Use addOnNudgeConsumed (not set) to chain with any existing callback,
-            // e.g. the UI callback from onNudgeClicked that clears pendingNudgeId.
             psi.addOnNudgeConsumed(misusedBuiltInTools::clear);
+            psi.fireSystemNotice(notice);
         }
     }
 
     @Override
     protected PromptRequest beforeSendPrompt(PromptRequest request) {
-        // System notices are now shown in the chat input area at end-of-turn
-        // (visible to the user) rather than silently prepended to the prompt.
-        // Mid-turn correction still happens via pendingNudge on tool results.
+        // Clear nudge state at turn start so mid-turn reprimands from the previous
+        // turn don't leak into the new prompt if they were never consumed.
         misusedBuiltInTools.clear();
         PsiBridgeService.getInstance(project).setPendingNudge(null);
         return request;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -307,16 +307,16 @@ public final class CopilotClient extends AcpClient {
         if (protocolTitle.startsWith(MCP_TOOL_PREFIX)) {
             return protocolTitle.substring(MCP_TOOL_PREFIX.length());
         }
-        // Copilot CLI sends known tool names (bash, grep, task, etc.) directly, but
-        // for sub-agent "task" invocations it sends human-readable descriptions like
-        // "Post review comment on PR 500". Normalize to the actual tool name to prevent
-        // these descriptions from leaking into system notices and confusing the model.
+        // Copilot CLI sends known tool names (bash, grep, task, etc.) directly.
+        // Normalize to lowercase so the rest of the system uses consistent IDs.
         String lower = protocolTitle.toLowerCase();
         if (KNOWN_BUILTIN_TOOL_NAMES.contains(lower)) {
             return lower;
         }
-        // Unrecognized title — most likely a task sub-agent description
-        return "task";
+        // Unrecognized title (e.g. sub-agent internal calls like "Confirm new file exists"
+        // or human-readable task descriptions). Return as-is — ToolChipRegistry will correct
+        // the chip label to the real MCP tool name once execution is correlated via args hash.
+        return protocolTitle;
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -5,8 +5,8 @@ import com.github.catatafishen.agentbridge.acp.model.PromptRequest;
 import com.github.catatafishen.agentbridge.acp.model.PromptResponse;
 import com.github.catatafishen.agentbridge.agent.AbstractAgentClient;
 import com.github.catatafishen.agentbridge.agent.AgentSessionException;
-import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
 import com.github.catatafishen.agentbridge.services.ActiveAgentManager;
+import com.github.catatafishen.agentbridge.services.AgentNudgeService;
 import com.github.catatafishen.agentbridge.services.ToolDefinition;
 import com.github.catatafishen.agentbridge.services.ToolRegistry;
 import com.google.gson.JsonArray;
@@ -559,9 +559,9 @@ public final class CopilotClient extends AcpClient {
             // injection into the next MCP tool result.  Chain the cleanup callback first
             // so it fires before the UI's resolve callback when the nudge is consumed.
             String notice = buildSingleToolReprimand(toolId);
-            PsiBridgeService psi = PsiBridgeService.getInstance(project);
-            psi.addOnNudgeConsumed(misusedBuiltInTools::clear);
-            psi.fireNudge(notice);
+            AgentNudgeService nudgeService = AgentNudgeService.getInstance(project);
+            nudgeService.addOnNudgeConsumed(misusedBuiltInTools::clear);
+            nudgeService.fireNudge(notice);
         }
     }
 
@@ -570,7 +570,7 @@ public final class CopilotClient extends AcpClient {
         // Clear nudge state at turn start so mid-turn reprimands from the previous
         // turn don't leak into the new prompt if they were never consumed.
         misusedBuiltInTools.clear();
-        PsiBridgeService.getInstance(project).setPendingNudge(null);
+        AgentNudgeService.getInstance(project).setPendingNudge(null);
         return request;
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -561,7 +561,7 @@ public final class CopilotClient extends AcpClient {
             String notice = buildSingleToolReprimand(toolId);
             PsiBridgeService psi = PsiBridgeService.getInstance(project);
             psi.addOnNudgeConsumed(misusedBuiltInTools::clear);
-            psi.fireSystemNotice(notice);
+            psi.fireNudge(notice);
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.psi;
 
 import com.github.catatafishen.agentbridge.services.ActiveAgentManager;
+import com.github.catatafishen.agentbridge.services.AgentNudgeService;
 import com.github.catatafishen.agentbridge.services.ToolChipRegistry;
 import com.github.catatafishen.agentbridge.services.ToolDefinition;
 import com.github.catatafishen.agentbridge.services.ToolPermission;
@@ -171,18 +172,6 @@ public final class PsiBridgeService implements Disposable {
     private final ToolRegistry registry;
     private final java.util.Set<String> sessionAllowedTools =
         java.util.concurrent.ConcurrentHashMap.newKeySet();
-    private final java.util.concurrent.atomic.AtomicReference<String> pendingNudge =
-        new java.util.concurrent.atomic.AtomicReference<>();
-    /**
-     * When true, {@link #consumePendingNudge()} is suppressed and returns {@code null}.
-     * Set while a sub-agent is active so nudges are held until the main agent resumes.
-     */
-    private volatile boolean nudgesHeld = false;
-    private final java.util.Queue<String> messageQueue = new java.util.concurrent.ConcurrentLinkedQueue<>();
-    private final java.util.concurrent.atomic.AtomicReference<Runnable> onNudgeConsumed =
-        new java.util.concurrent.atomic.AtomicReference<>();
-    private final java.util.concurrent.atomic.AtomicReference<java.util.function.Consumer<String>> onNudgeRequested =
-        new java.util.concurrent.atomic.AtomicReference<>();
 
     public PsiBridgeService(@NotNull Project project) {
         this.project = project;
@@ -244,74 +233,6 @@ public final class PsiBridgeService implements Disposable {
      */
     public void clearSessionAllowedTools() {
         sessionAllowedTools.clear();
-    }
-
-    public void setPendingNudge(@Nullable String nudge) {
-        if (nudge == null) {
-            pendingNudge.set(null);
-            return;
-        }
-        pendingNudge.updateAndGet(existing -> mergeNudges(existing, nudge));
-    }
-
-    public void setOnNudgeConsumed(@Nullable Runnable callback) {
-        onNudgeConsumed.set(callback);
-    }
-
-    /**
-     * Holds or releases nudge delivery. While held, {@link #consumePendingNudge()} returns
-     * {@code null} so nudges are not injected into sub-agent tool results — they wait until the
-     * main agent resumes and makes the next tool call.
-     */
-    public void setNudgesHeld(boolean held) {
-        nudgesHeld = held;
-    }
-
-    public void addOnNudgeConsumed(@NotNull Runnable callback) {
-        onNudgeConsumed.accumulateAndGet(callback, (current, newCb) ->
-            current == null ? newCb : () -> {
-                current.run();
-                newCb.run();
-            }
-        );
-    }
-
-    public void setOnNudgeRequested(@Nullable java.util.function.Consumer<String> callback) {
-        this.onNudgeRequested.set(callback);
-    }
-
-    /** Delivers a plugin-initiated nudge (e.g. built-in tool reprimand) to the UI. */
-    public void fireNudge(@NotNull String text) {
-        java.util.function.Consumer<String> cb = onNudgeRequested.get();
-        if (cb != null) cb.accept(text);
-    }
-
-    public void enqueueMessage(@NotNull String message) {
-        if (!message.trim().isEmpty()) {
-            messageQueue.offer(message.trim());
-        }
-    }
-
-    public void removeQueuedMessage(@NotNull String message) {
-        messageQueue.remove(message.trim());
-    }
-
-    @Nullable
-    public String getNextQueuedMessage() {
-        return messageQueue.poll();
-    }
-
-    @Nullable
-    private String consumePendingNudge() {
-        if (nudgesHeld) return null;
-        String nudge = pendingNudge.getAndSet(null);
-        if (nudge != null) {
-            // Clear the callback atomically to prevent stale callbacks from firing
-            // on future nudge sources (e.g., tool reprimands, revert nudges)
-            Runnable cb = onNudgeConsumed.getAndSet(null);
-            if (cb != null) cb.run();
-        }
-        return nudge;
     }
 
     /**
@@ -495,7 +416,7 @@ public final class PsiBridgeService implements Disposable {
 
             result = appendHighlightsIfApplicable(
                 req.toolName(), result, daemonWaiter, filePathForHighlights, vfForHighlights, semaphoreReleasedEarly);
-            result = appendNudgeToResult(result, consumePendingNudge());
+            result = AgentNudgeService.appendNudgeToResult(result, AgentNudgeService.getInstance(project).consumePendingNudge());
             if (result.startsWith("Error")) {
                 success = false;
                 errorMessage = result;
@@ -957,21 +878,6 @@ public final class PsiBridgeService implements Disposable {
         if (arguments.has("path")) return arguments.get("path").getAsString();
         if (arguments.has("file")) return arguments.get("file").getAsString();
         return null;
-    }
-
-    /**
-     * Merges a new nudge with any existing nudge text.
-     * Returns just the new nudge if there's no existing text; concatenates with double-newline otherwise.
-     */
-    static String mergeNudges(@Nullable String existing, @NotNull String newNudge) {
-        return (existing == null || existing.isEmpty()) ? newNudge : existing + "\n\n" + newNudge;
-    }
-
-    /**
-     * Appends a nudge message to a tool result, or returns the result unchanged if nudge is null.
-     */
-    static String appendNudgeToResult(@NotNull String result, @Nullable String nudge) {
-        return nudge != null ? result + "\n\n[User nudge]: " + nudge : result;
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -280,6 +280,9 @@ public final class PsiBridgeService implements Disposable {
         this.onSystemNotice.set(callback);
     }
 
+    /**
+     * Delivers a system notice (e.g. built-in tool reprimand) to the registered UI callback.
+     */
     public void fireSystemNotice(@NotNull String text) {
         java.util.function.Consumer<String> cb = onSystemNotice.get();
         if (cb != null) cb.accept(text);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -181,7 +181,7 @@ public final class PsiBridgeService implements Disposable {
     private final java.util.Queue<String> messageQueue = new java.util.concurrent.ConcurrentLinkedQueue<>();
     private final java.util.concurrent.atomic.AtomicReference<Runnable> onNudgeConsumed =
         new java.util.concurrent.atomic.AtomicReference<>();
-    private final java.util.concurrent.atomic.AtomicReference<java.util.function.Consumer<String>> onSystemNotice =
+    private final java.util.concurrent.atomic.AtomicReference<java.util.function.Consumer<String>> onNudgeRequested =
         new java.util.concurrent.atomic.AtomicReference<>();
 
     public PsiBridgeService(@NotNull Project project) {
@@ -276,15 +276,13 @@ public final class PsiBridgeService implements Disposable {
         );
     }
 
-    public void setOnSystemNotice(@Nullable java.util.function.Consumer<String> callback) {
-        this.onSystemNotice.set(callback);
+    public void setOnNudgeRequested(@Nullable java.util.function.Consumer<String> callback) {
+        this.onNudgeRequested.set(callback);
     }
 
-    /**
-     * Delivers a system notice (e.g. built-in tool reprimand) to the registered UI callback.
-     */
-    public void fireSystemNotice(@NotNull String text) {
-        java.util.function.Consumer<String> cb = onSystemNotice.get();
+    /** Delivers a plugin-initiated nudge (e.g. built-in tool reprimand) to the UI. */
+    public void fireNudge(@NotNull String text) {
+        java.util.function.Consumer<String> cb = onNudgeRequested.get();
         if (cb != null) cb.accept(text);
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.psi.review;
 
 import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
+import com.github.catatafishen.agentbridge.services.AgentNudgeService;
 import com.github.catatafishen.agentbridge.services.ChatWebServer;
 import com.github.catatafishen.agentbridge.settings.McpServerSettings;
 import com.intellij.openapi.Disposable;
@@ -164,7 +165,7 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
     /**
      * Buffer of revert nudges accumulated during the current gate. Flushed on either
      * {@link RevertGateAction#SEND_NOW} (returned as the tool error) or on natural gate
-     * resolution (forwarded into {@link PsiBridgeService#setPendingNudge}).
+     * resolution (forwarded into {@link AgentNudgeService#setPendingNudge}).
      */
     private final List<String> gateRevertBuffer = Collections.synchronizedList(new ArrayList<>());
 
@@ -627,7 +628,7 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
                         gateRevertBuffer.add(nudge);
                     }
                 } else {
-                    PsiBridgeService.getInstance(project).setPendingNudge(nudge);
+                    AgentNudgeService.getInstance(project).setPendingNudge(nudge);
                 }
             }
         }
@@ -998,7 +999,7 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
             merged = String.join("\n\n", gateRevertBuffer);
             gateRevertBuffer.clear();
         }
-        PsiBridgeService.getInstance(project).setPendingNudge(merged);
+        AgentNudgeService.getInstance(project).setPendingNudge(merged);
     }
 
     static @NotNull String formatReviewTimeoutError(@NotNull String operation, int fileCount) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentNudgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentNudgeService.java
@@ -1,0 +1,128 @@
+package com.github.catatafishen.agentbridge.services;
+
+import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Project-level service that owns all nudge and message-queue state.
+ *
+ * <p>A <em>nudge</em> is a short plain-text hint injected into the next MCP tool result so the
+ * agent sees it immediately without a round-trip message. Nudges are produced by user interactions
+ * (e.g. the nudge bubble in the chat panel) or by plugin logic (e.g. built-in tool reprimands
+ * from {@link com.github.catatafishen.agentbridge.acp.client.CopilotClient#onBuiltInToolApproved})
+ * and consumed once by {@link #consumePendingNudge()} inside
+ * {@link com.github.catatafishen.agentbridge.psi.PsiBridgeService}.</p>
+ *
+ * <p>The message queue holds pre-typed user messages that are auto-sent at the end of the current
+ * turn via {@link com.github.catatafishen.agentbridge.ui.PromptOrchestrator}.</p>
+ */
+@Service(Service.Level.PROJECT)
+public final class AgentNudgeService {
+
+    private final java.util.concurrent.atomic.AtomicReference<String> pendingNudge =
+        new java.util.concurrent.atomic.AtomicReference<>();
+    /**
+     * When true, {@link #consumePendingNudge()} is suppressed and returns {@code null}.
+     * Set while a sub-agent is active so nudges are held until the main agent resumes.
+     */
+    private volatile boolean nudgesHeld = false;
+    private final java.util.Queue<String> messageQueue = new java.util.concurrent.ConcurrentLinkedQueue<>();
+    private final java.util.concurrent.atomic.AtomicReference<Runnable> onNudgeConsumed =
+        new java.util.concurrent.atomic.AtomicReference<>();
+    private final java.util.concurrent.atomic.AtomicReference<java.util.function.Consumer<String>> onNudgeRequested =
+        new java.util.concurrent.atomic.AtomicReference<>();
+
+    public static AgentNudgeService getInstance(@NotNull Project project) {
+        return PlatformApiCompat.getService(project, AgentNudgeService.class);
+    }
+
+    public void setPendingNudge(@Nullable String nudge) {
+        if (nudge == null) {
+            pendingNudge.set(null);
+            return;
+        }
+        pendingNudge.updateAndGet(existing -> mergeNudges(existing, nudge));
+    }
+
+    public void setOnNudgeConsumed(@Nullable Runnable callback) {
+        onNudgeConsumed.set(callback);
+    }
+
+    /**
+     * Holds or releases nudge delivery. While held, {@link #consumePendingNudge()} returns
+     * {@code null} so nudges are not injected into sub-agent tool results — they wait until the
+     * main agent resumes and makes the next tool call.
+     */
+    public void setNudgesHeld(boolean held) {
+        nudgesHeld = held;
+    }
+
+    public void addOnNudgeConsumed(@NotNull Runnable callback) {
+        onNudgeConsumed.accumulateAndGet(callback, (current, newCb) ->
+            current == null ? newCb : () -> {
+                current.run();
+                newCb.run();
+            }
+        );
+    }
+
+    public void setOnNudgeRequested(@Nullable java.util.function.Consumer<String> callback) {
+        this.onNudgeRequested.set(callback);
+    }
+
+    /** Delivers a plugin-initiated nudge (e.g. built-in tool reprimand) to the UI. */
+    public void fireNudge(@NotNull String text) {
+        java.util.function.Consumer<String> cb = onNudgeRequested.get();
+        if (cb != null) cb.accept(text);
+    }
+
+    public void enqueueMessage(@NotNull String message) {
+        if (!message.trim().isEmpty()) {
+            messageQueue.offer(message.trim());
+        }
+    }
+
+    public void removeQueuedMessage(@NotNull String message) {
+        messageQueue.remove(message.trim());
+    }
+
+    @Nullable
+    public String getNextQueuedMessage() {
+        return messageQueue.poll();
+    }
+
+    /**
+     * Atomically consumes the pending nudge and fires the registered callback.
+     * Returns {@code null} while nudges are held (sub-agent active) or when no nudge is pending.
+     */
+    @Nullable
+    public String consumePendingNudge() {
+        if (nudgesHeld) return null;
+        String nudge = pendingNudge.getAndSet(null);
+        if (nudge != null) {
+            // Clear the callback atomically to prevent stale callbacks from firing
+            // on future nudge sources (e.g., tool reprimands, revert nudges)
+            Runnable cb = onNudgeConsumed.getAndSet(null);
+            if (cb != null) cb.run();
+        }
+        return nudge;
+    }
+
+    /**
+     * Merges a new nudge with any existing nudge text.
+     * Returns just the new nudge if there's no existing text; concatenates with double-newline otherwise.
+     */
+    public static String mergeNudges(@Nullable String existing, @NotNull String newNudge) {
+        return (existing == null || existing.isEmpty()) ? newNudge : existing + "\n\n" + newNudge;
+    }
+
+    /**
+     * Appends a nudge message to a tool result, or returns the result unchanged if nudge is null.
+     */
+    public static String appendNudgeToResult(@NotNull String result, @Nullable String nudge) {
+        return nudge != null ? result + "\n\n[User nudge]: " + nudge : result;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -1692,14 +1692,6 @@ class ChatConsolePanel(
         executeJs("ChatController.removeQueuedMessageByText('${escJs(text)}');")
     }
 
-    override fun showSystemNoticeBubble(id: String, text: String) {
-        executeJs("ChatController.showSystemNoticeBubble('${escJs(id)}','${escJs(text)}');")
-    }
-
-    override fun removeSystemNoticeBubble(id: String) {
-        executeJs("ChatController.removeSystemNoticeBubble('${escJs(id)}');")
-    }
-
     // ── Open in scratch file ─────────────────────────────────────────
 
     private fun handleOpenScratch(data: String) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -84,6 +84,15 @@ class ChatConsolePanel(
             executeJs("ChatController.markMcpHandled('$did')")
             // Mark the entry as MCP handled for persistence
             toolCallEntries[did]?.pluginTool = mcpToolName ?: toolCallNames[did]
+            // Correct the chip label when ACP used a wrong display name (e.g. Copilot CLI sends
+            // a human-readable description as the ACP title for sub-agent internal tool calls,
+            // causing resolveToolId to fall back to "task" → "Sub-Agent Task" display).
+            // Once MCP resolves the real tool name, we can recompute the accurate label.
+            if (mcpToolName != null && toolCallNames[did] != mcpToolName) {
+                val newLabel = toolChipTitle(mcpToolName, toolCallEntries[did]?.arguments)
+                toolCallNames[did] = mcpToolName
+                executeJs("ChatController.updateChipLabel('$did','${escJs(newLabel)}')")
+            }
         } else {
             // COMPLETE, EXTERNAL, FAILED — just remove the spinner; border already shows origin
             val jsState = if (state == ToolChipRegistry.ChipState.FAILED) "failed" else "complete"

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatPanelApi.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatPanelApi.kt
@@ -182,7 +182,4 @@ interface ChatPanelApi : Disposable {
     fun showQueuedMessage(id: String, text: String)
     fun removeQueuedMessage(id: String)
     fun removeQueuedMessageByText(text: String)
-
-    fun showSystemNoticeBubble(id: String, text: String)
-    fun removeSystemNoticeBubble(id: String)
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -1865,10 +1865,11 @@ class ChatToolWindowContent(
         }
         com.intellij.openapi.util.Disposer.register(project, consolePanel)
 
-        // Route system notices (built-in tool reprimands) through the nudge flow so they
-        // appear as a regular nudge bubble and are injected into the next MCP tool result.
+        // Route plugin-initiated nudges (e.g. built-in tool reprimands) through the
+        // nudge flow so they appear as a regular nudge bubble and are injected into the
+        // next MCP tool result.
         val psiBridge = com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
-        psiBridge.setOnSystemNotice { notice ->
+        psiBridge.setOnNudgeRequested { notice ->
             com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
                 submitNudge(notice)
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -103,12 +103,6 @@ class ChatToolWindowContent(
 
     @Volatile
     private var pendingNudgeText: String? = null
-
-    @Volatile
-    private var pendingSystemNoticeId: String? = null
-
-    @Volatile
-    private var pendingSystemNoticeText: String? = null
     private lateinit var processingTimerPanel: ProcessingTimerPanel
     private lateinit var promptOrchestrator: PromptOrchestrator
     private lateinit var pasteToScratchHandler: PasteToScratchHandler
@@ -1214,7 +1208,6 @@ class ChatToolWindowContent(
         ChatWebServer.getInstance(project)?.setAgentRunning(sending)
         if (!sending) {
             restoreUnhandledNudgeIfNeeded()
-            restoreSystemNoticeIfNeeded()
         }
         ApplicationManager.getApplication().invokeLater {
             updatePromptPlaceholder()
@@ -1257,40 +1250,6 @@ class ChatToolWindowContent(
     private fun sendUnhandledNudge(nudgeText: String) {
         promptTextArea.text = nudgeText
         onSendStopClicked()
-    }
-
-    private fun showSystemNotice(text: String) {
-        val existingId = pendingSystemNoticeId
-        if (existingId != null) {
-            pendingSystemNoticeText = (pendingSystemNoticeText ?: "") + "\n\n" + text
-        } else {
-            pendingSystemNoticeId = "sysnotice-" + System.currentTimeMillis()
-            pendingSystemNoticeText = text
-        }
-        // If the agent uses an MCP tool next, the notice is injected into the tool result
-        // (via consumePendingNudge). Clear pending state so we don't restore it to input at turn end.
-        com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
-            .addOnNudgeConsumed {
-                pendingSystemNoticeId = null
-                pendingSystemNoticeText = null
-            }
-    }
-
-    private fun restoreSystemNoticeIfNeeded() {
-        val noticeText = pendingSystemNoticeText ?: return
-        pendingSystemNoticeId = null
-        pendingSystemNoticeText = null
-        // Prepend notice to input so the user can review/edit before sending.
-        // No grey bubble — that's reserved for notices actually sent to the agent.
-        prependSystemNoticeToInput(noticeText)
-    }
-
-    private fun prependSystemNoticeToInput(noticeText: String) {
-        ApplicationManager.getApplication().invokeLater {
-            val current = promptTextArea.text
-            promptTextArea.text = if (current.isEmpty()) noticeText else "$noticeText\n\n$current"
-            promptTextArea.requestFocusInWindow()
-        }
     }
 
     private fun updateProcessingTimer(sending: Boolean) {
@@ -1906,11 +1865,12 @@ class ChatToolWindowContent(
         }
         com.intellij.openapi.util.Disposer.register(project, consolePanel)
 
-        // Register the system notice callback so built-in tool reprimands are shown in the chat UI.
+        // Route system notices (built-in tool reprimands) through the nudge flow so they
+        // appear as a regular nudge bubble and are injected into the next MCP tool result.
         val psiBridge = com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
         psiBridge.setOnSystemNotice { notice ->
             com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
-                showSystemNotice(notice)
+                submitNudge(notice)
             }
         }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -1090,13 +1090,13 @@ class ChatToolWindowContent(
             pendingNudgeText = text
             consolePanel.showNudgeBubble(id, text)
         }
-        val psiBridge = com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
+        val nudgeService = com.github.catatafishen.agentbridge.services.AgentNudgeService.getInstance(project)
         // Register callback BEFORE arming the nudge to avoid race condition where
         // a tool call consumes the nudge between setPendingNudge and setOnNudgeConsumed
         val resolveId = pendingNudgeId!!
         // Chain with (not replace) any existing callback — e.g., tool reprimand cleanup
         // from CopilotClient.onBuiltInToolApproved() may already be registered
-        psiBridge.addOnNudgeConsumed {
+        nudgeService.addOnNudgeConsumed {
             val capturedText = pendingNudgeText
             pendingNudgeId = null
             pendingNudgeText = null
@@ -1109,7 +1109,7 @@ class ChatToolWindowContent(
                 refreshShortcutHints()
             }
         }
-        psiBridge.setPendingNudge(text)
+        nudgeService.setPendingNudge(text)
         refreshShortcutHints()
     }
 
@@ -1117,9 +1117,9 @@ class ChatToolWindowContent(
     private fun clearAndRemoveNudge(nudgeId: String) {
         pendingNudgeId = null
         pendingNudgeText = null
-        val psiBridge = com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
-        psiBridge.setPendingNudge(null)
-        psiBridge.setOnNudgeConsumed(null)
+        val nudgeService = com.github.catatafishen.agentbridge.services.AgentNudgeService.getInstance(project)
+        nudgeService.setPendingNudge(null)
+        nudgeService.setOnNudgeConsumed(null)
         ApplicationManager.getApplication().invokeLater {
             consolePanel.removeNudgeBubble(nudgeId)
             refreshShortcutHints()
@@ -1223,9 +1223,9 @@ class ChatToolWindowContent(
         val nudgeText = pendingNudgeText
         pendingNudgeId = null
         pendingNudgeText = null
-        val psiBridge = com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
-        psiBridge.setPendingNudge(null)
-        psiBridge.setOnNudgeConsumed(null)
+        val nudgeService = com.github.catatafishen.agentbridge.services.AgentNudgeService.getInstance(project)
+        nudgeService.setPendingNudge(null)
+        nudgeService.setOnNudgeConsumed(null)
         ApplicationManager.getApplication().invokeLater {
             consolePanel.removeNudgeBubble(nudgeId)
             nudgeText?.let { restoreUnhandledNudgeText(it) }
@@ -1838,8 +1838,8 @@ class ChatToolWindowContent(
             if (pendingNudgeId == id) clearAndRemoveNudge(id)
         }
         chatConsolePanel.onCancelQueuedMessage = { id, text ->
-            val psiBridge = com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
-            psiBridge.removeQueuedMessage(text)
+            val nudgeService = com.github.catatafishen.agentbridge.services.AgentNudgeService.getInstance(project)
+            nudgeService.removeQueuedMessage(text)
             // Drop the most-recent matching entry so Up-arrow recall reflects what's still queued.
             val lastIdx = queuedTexts.indexOfLast { it == text }
             if (lastIdx >= 0) queuedTexts.removeAt(lastIdx)
@@ -1868,8 +1868,8 @@ class ChatToolWindowContent(
         // Route plugin-initiated nudges (e.g. built-in tool reprimands) through the
         // nudge flow so they appear as a regular nudge bubble and are injected into the
         // next MCP tool result.
-        val psiBridge = com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
-        psiBridge.setOnNudgeRequested { notice ->
+        val nudgeService = com.github.catatafishen.agentbridge.services.AgentNudgeService.getInstance(project)
+        nudgeService.setOnNudgeRequested { notice ->
             com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
                 submitNudge(notice)
             }
@@ -2056,8 +2056,8 @@ class ChatToolWindowContent(
                 }
                 val lastQueued = queuedTexts.removeLastOrNull() ?: return
                 promptTextArea.text = lastQueued
-                val psiBridge = com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
-                psiBridge.removeQueuedMessage(lastQueued)
+                val nudgeService = com.github.catatafishen.agentbridge.services.AgentNudgeService.getInstance(project)
+                nudgeService.removeQueuedMessage(lastQueued)
                 ApplicationManager.getApplication().invokeLater {
                     consolePanel.removeQueuedMessageByText(lastQueued)
                     refreshShortcutHints()
@@ -2078,7 +2078,7 @@ class ChatToolWindowContent(
         val id = System.currentTimeMillis().toString()
         promptTextArea.text = ""
         consolePanel.showQueuedMessage(id, rawText)
-        com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
+        com.github.catatafishen.agentbridge.services.AgentNudgeService.getInstance(project)
             .enqueueMessage(rawText)
         queuedTexts.addLast(rawText)
         refreshShortcutHints()

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
@@ -74,6 +74,15 @@ class PromptOrchestrator(
     /** Copilot built-in tool whose summary should render as agent text, not a tool chip. */
     private val taskCompleteTool = "task_complete"
 
+    /**
+     * Sentinel stored in [toolCallTitles] for real sub-agent (Task-tool) launches.
+     * Uses a leading '$' so it can never collide with a real tool name or with the
+     * resolved title "task" that [CopilotClient.resolveToolId] returns for unrecognized
+     * protocol titles (e.g. when Copilot CLI uses a human-readable description as the
+     * ACP notification title for a sub-agent's internal tool call).
+     */
+    private val subAgentCallType = "\$subagent"
+
     internal var currentSessionId: String? = null
     internal var conversationSummaryInjected: Boolean = false
     private var currentPromptThread: Thread? = null
@@ -638,7 +647,7 @@ class PromptOrchestrator(
             val agentType = toolCall.agentType() ?: return
             turnToolCallCount++
             callbacks.onTimerIncrementToolCalls()
-            toolCallTitles[toolCallId] = "task"
+            toolCallTitles[toolCallId] = subAgentCallType
             activeSubAgentStack.addLast(toolCallId)
             agentManager.client.setSubAgentActive(true)
             AgentNudgeService.getInstance(project).setNudgesHeld(true)
@@ -703,7 +712,7 @@ class PromptOrchestrator(
             return
         }
 
-        val isSubAgent = callType == "task"
+        val isSubAgent = callType == subAgentCallType
         val isInternal = callType == "subagent_internal"
 
         val uiStatus = when (status) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
@@ -7,6 +7,7 @@ import com.github.catatafishen.agentbridge.agent.AbstractAgentClient
 import com.github.catatafishen.agentbridge.bridge.PermissionResponse
 import com.github.catatafishen.agentbridge.psi.CodeChangeTracker
 import com.github.catatafishen.agentbridge.psi.PsiBridgeService
+import com.github.catatafishen.agentbridge.services.AgentNudgeService
 import com.github.catatafishen.agentbridge.services.ActiveAgentManager
 import com.github.catatafishen.agentbridge.services.AgentScratchTracker
 import com.github.catatafishen.agentbridge.services.AgentTabTracker
@@ -497,7 +498,7 @@ class PromptOrchestrator(
             )
         )
 
-        val nextMsg = PsiBridgeService.getInstance(project).nextQueuedMessage
+        val nextMsg = AgentNudgeService.getInstance(project).nextQueuedMessage
         if (nextMsg != null) {
             callbacks.onQueuedMessageConsumed(nextMsg)
             ApplicationManager.getApplication().invokeLater {
@@ -640,7 +641,7 @@ class PromptOrchestrator(
             toolCallTitles[toolCallId] = "task"
             activeSubAgentStack.addLast(toolCallId)
             agentManager.client.setSubAgentActive(true)
-            PsiBridgeService.getInstance(project).setNudgesHeld(true)
+            AgentNudgeService.getInstance(project).setNudgesHeld(true)
             agentManager.settings.setActiveAgentLabel(agentType)
             consolePanel().setCurrentAgent(
                 agentType,
@@ -743,7 +744,7 @@ class PromptOrchestrator(
             activeSubAgentStack.remove(toolCallId)
             if (activeSubAgentStack.isEmpty()) {
                 agentManager.client.setSubAgentActive(false)
-                PsiBridgeService.getInstance(project).setNudgesHeld(false)
+                AgentNudgeService.getInstance(project).setNudgesHeld(false)
                 agentManager.settings.setActiveAgentLabel(null)
                 consolePanel().setCurrentAgent(
                     agentManager.activeProfile.displayName,

--- a/plugin-core/src/main/resources/META-INF/plugin.xml
+++ b/plugin-core/src/main/resources/META-INF/plugin.xml
@@ -100,6 +100,8 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and Ope
     <projectService
       serviceImplementation="com.github.catatafishen.agentbridge.services.ToolChipRegistry"/>
     <projectService
+      serviceImplementation="com.github.catatafishen.agentbridge.services.AgentNudgeService"/>
+    <projectService
       serviceImplementation="com.github.catatafishen.agentbridge.psi.PsiBridgeService"/>
     <projectService
       serviceImplementation="com.github.catatafishen.agentbridge.settings.McpServerSettings"/>

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/PsiBridgeServiceStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/PsiBridgeServiceStaticMethodsTest.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.psi;
 
+import com.github.catatafishen.agentbridge.services.AgentNudgeService;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Nested;
@@ -16,8 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Unit tests for the static utility methods in {@link PsiBridgeService}.
- * These methods are package-private, so this test lives in the same package.
+ * Unit tests for the static utility methods in {@link PsiBridgeService} and {@link AgentNudgeService}.
+ * Package-private methods from {@link PsiBridgeService} are tested here because the test lives in the same package.
+ * {@link AgentNudgeService} static methods ({@code mergeNudges}, {@code appendNudgeToResult}) are public.
  */
 class PsiBridgeServiceStaticMethodsTest {
 
@@ -527,30 +529,30 @@ class PsiBridgeServiceStaticMethodsTest {
 
         @Test
         void nullExistingReturnNewNudge() {
-            assertEquals("hello", PsiBridgeService.mergeNudges(null, "hello"));
+            assertEquals("hello", AgentNudgeService.mergeNudges(null, "hello"));
         }
 
         @Test
         void emptyExistingReturnNewNudge() {
-            assertEquals("hello", PsiBridgeService.mergeNudges("", "hello"));
+            assertEquals("hello", AgentNudgeService.mergeNudges("", "hello"));
         }
 
         @Test
         void existingAndNewAreConcatenatedWithDoubleNewline() {
-            assertEquals("first\n\nsecond", PsiBridgeService.mergeNudges("first", "second"));
+            assertEquals("first\n\nsecond", AgentNudgeService.mergeNudges("first", "second"));
         }
 
         @Test
         void multipleAccumulatedNudges() {
-            String merged = PsiBridgeService.mergeNudges("a", "b");
-            merged = PsiBridgeService.mergeNudges(merged, "c");
+            String merged = AgentNudgeService.mergeNudges("a", "b");
+            merged = AgentNudgeService.mergeNudges(merged, "c");
             assertEquals("a\n\nb\n\nc", merged);
         }
 
         @Test
         void existingWithWhitespaceOnlyIsNotConsideredEmpty() {
             // " " is not null and not isEmpty(), so it merges
-            assertEquals(" \n\nnew", PsiBridgeService.mergeNudges(" ", "new"));
+            assertEquals(" \n\nnew", AgentNudgeService.mergeNudges(" ", "new"));
         }
     }
 
@@ -562,25 +564,25 @@ class PsiBridgeServiceStaticMethodsTest {
 
         @Test
         void nullNudgeReturnsResultUnchanged() {
-            assertEquals("OK: done", PsiBridgeService.appendNudgeToResult("OK: done", null));
+            assertEquals("OK: done", AgentNudgeService.appendNudgeToResult("OK: done", null));
         }
 
         @Test
         void nonNullNudgeAppendsWithPrefix() {
-            String result = PsiBridgeService.appendNudgeToResult("OK: done", "please use foo");
+            String result = AgentNudgeService.appendNudgeToResult("OK: done", "please use foo");
             assertEquals("OK: done\n\n[User nudge]: please use foo", result);
         }
 
         @Test
         void emptyNudgeStillAppends() {
             // Empty string is non-null, so it appends (the nudge prefix is still visible)
-            String result = PsiBridgeService.appendNudgeToResult("result", "");
+            String result = AgentNudgeService.appendNudgeToResult("result", "");
             assertEquals("result\n\n[User nudge]: ", result);
         }
 
         @Test
         void emptyResultWithNudge() {
-            String result = PsiBridgeService.appendNudgeToResult("", "nudge");
+            String result = AgentNudgeService.appendNudgeToResult("", "nudge");
             assertEquals("\n\n[User nudge]: nudge", result);
         }
     }


### PR DESCRIPTION
## Problem

Two bugs triggered when `CopilotClient.resolveToolId` returns `"task"` for an unrecognized ACP protocol title (Copilot CLI uses `run_command`'s `title` argument as the ACP notification display title):

**Bug 1 — wrong label:** A chip for a regular MCP tool call (e.g. `run_command`) showed "Sub-Agent Task — Confirm new file exists" because `toolChipTitle("task", args)` resolves via `TOOL_DISPLAY_INFO["task"]` = "Sub-Agent Task", with the args' `description` field as the subtitle.

**Bug 2 — chip frozen in loading:** `toolCallTitles` stored `"task"` as *both* the sentinel for real sub-agent launches AND the resolved tool name for unrecognized calls. On the update, `callType == "task"` → `isSubAgent = true` → update routed to `updateSubAgentResult` (expects a sub-agent DOM element, finds nothing) → chip stays spinning forever.

## Fix

**Bug 2:** Replace the `"task"` sentinel in `toolCallTitles` with a private constant `subAgentCallType = "\$subagent"`. The leading `$` ensures it can never collide with any real tool name. `isSubAgent` now checks `callType == subAgentCallType`.

**Bug 1:** In `kindStateListener`, when `ChipState.RUNNING` fires with a real MCP tool name that differs from the client-registered name, recompute the correct label via `toolChipTitle(mcpToolName, ...)` and call a new `ChatController.updateChipLabel()` helper to correct the DOM. The rebuilt `chat-components.js` is included.