### PR TITLE
feat: Add grouped model picker and favorites for opencode

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClient.java
@@ -66,6 +66,11 @@ public final class OpenCodeClient extends AcpClient {
     }
 
     @Override
+    public boolean supportsModelGrouping() {
+        return true;
+    }
+
+    @Override
     public List<AbstractAgentClient.AgentMode> getAvailableAgents() {
         List<AbstractAgentClient.AgentMode> agents = new ArrayList<>(builtInAgents());
         String basePath = project.getBasePath();

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/AbstractAgentClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/AbstractAgentClient.java
@@ -282,6 +282,15 @@ public abstract class AbstractAgentClient {
         return false;
     }
 
+    /**
+     * Whether this agent's model data can be grouped by provider in the model picker.
+     * When {@code true}, the UI renders models in collapsible provider sections
+     * with a favorites feature.
+     */
+    public boolean supportsModelGrouping() {
+        return false;
+    }
+
     // ─── Session Options ─────────────────────────────
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -1751,6 +1751,65 @@ class ChatToolWindowContent(
             return group
         }
 
+        override fun createActionPopup(context: DataContext, component: JComponent, disposeCallback: Runnable?): com.intellij.openapi.ui.popup.JBPopup {
+            if (agentManager.client.supportsModelGrouping()) {
+                return createGroupedPopup(disposeCallback)
+            }
+            return super.createActionPopup(context, component, disposeCallback)
+        }
+
+        private fun createGroupedPopup(disposeCallback: Runnable?): com.intellij.openapi.ui.popup.JBPopup {
+            val models = loadedModels.toList()
+            if (models.isEmpty()) {
+                return com.intellij.openapi.ui.popup.JBPopupFactory.getInstance().createComponentPopupBuilder(
+                    JBLabel("No models available"), null
+                ).createPopup()
+            }
+
+            val favorites = com.github.catatafishen.agentbridge.ui.util.ModelFavorites.getInstance(project)
+            val grouper = com.github.catatafishen.agentbridge.ui.util.ModelGrouper(favorites.toSet())
+            val groups = grouper.group(models)
+
+            val picker = ModelPickerPopup(groups)
+            picker.onModelSelected = { index ->
+                if (index != selectedModelIndex && index in loadedModels.indices) {
+                    val model = loadedModels[index]
+                    selectedModelIndex = index
+                    agentManager.settings.setSelectedModel(model.id())
+                    LOG.debug("Model selected: ${model.id()} (index=$index)")
+                    ApplicationManager.getApplication().invokeLater {
+                        consolePanel.setCurrentModel(model.id())
+                    }
+                    ApplicationManager.getApplication().executeOnPooledThread {
+                        try {
+                            val client = agentManager.client
+                            val sessionId = promptOrchestrator.currentSessionId
+                            if (sessionId != null) {
+                                client.setModel(sessionId, model.id())
+                                LOG.debug("Model switched to ${model.id()} on session $sessionId")
+                            } else {
+                                LOG.debug("No active session; model ${model.id()} will be used on next session")
+                            }
+                        } catch (ex: Exception) {
+                            LOG.warn("Failed to set model ${model.id()} via session/set_model", ex)
+                        }
+                    }
+                }
+            }
+            picker.onFavoriteToggled = { modelId ->
+                favorites.toggle(modelId)
+            }
+            val popup = picker.createPopup()
+            if (disposeCallback != null) {
+                popup.addListener(object : com.intellij.openapi.ui.popup.JBPopupListener {
+                    override fun onClosed(event: com.intellij.openapi.ui.popup.LightweightWindowEvent) {
+                        disposeCallback.run()
+                    }
+                })
+            }
+            return popup
+        }
+
         override fun update(e: AnActionEvent) {
             e.presentation.text = currentModelSelectorText()
             e.presentation.isEnabled = modelsStatusText == null && loadedModels.isNotEmpty()

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ModelPickerPopup.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ModelPickerPopup.kt
@@ -11,7 +11,7 @@ import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import java.awt.*
-import java.awt.event.KeyAdapter
+import java.awt.event.ActionEvent
 import java.awt.event.KeyEvent
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
@@ -22,8 +22,13 @@ import javax.swing.*
  * Group expand/collapse state is persisted via PropertiesComponent.
  */
 class ModelPickerPopup(
-    private val groups: List<ModelGrouper.Group>
+    groups: List<ModelGrouper.Group>
 ) {
+
+    companion object {
+        private const val MENU_ITEM_BG = "MenuItem.background"
+        private const val MENU_ITEM_SELECTION_BG = "MenuItem.selectionBackground"
+    }
 
     var onModelSelected: ((Int) -> Unit)? = null
     var onFavoriteToggled: ((String) -> Unit)? = null
@@ -37,7 +42,11 @@ class ModelPickerPopup(
         .map { it.modelId }
         .toMutableSet()
 
-    // Persistent expand/collapse state: key = provider name, value = expanded
+    // Flat list of all models (exactly once each, no Favorites duplication) for rebuilding
+    // groups after favorite toggles. Groups partition models — no overlap between sections.
+    private val allGroupedModels: List<ModelGrouper.GroupedModel> = groups.flatMap { it.models }
+    private var currentGroups: List<ModelGrouper.Group> = groups
+
     private val expandState: MutableMap<String, Boolean> = mutableMapOf()
     private val props = PropertiesComponent.getInstance()
 
@@ -45,9 +54,10 @@ class ModelPickerPopup(
         if (provider !in expandState) {
             val key = "agentbridge.picker.expanded.$provider"
             val stored = props.getValue(key)
-            expandState[provider] = if (stored != null) stored.toBoolean() else (provider == "Favorites")
+            // Default to expanded so all providers are visible on first open
+            expandState[provider] = stored?.toBoolean() ?: true
         }
-        return expandState[provider]!!
+        return expandState[provider] ?: true
     }
 
     private fun setExpanded(provider: String, expanded: Boolean) {
@@ -72,6 +82,10 @@ class ModelPickerPopup(
             horizontalScrollBarPolicy = JBScrollPane.HORIZONTAL_SCROLLBAR_NEVER
         }
 
+        // Bind keyboard navigation to the focused component (scrollPane) via InputMap/ActionMap
+        // so key events are reliably received regardless of which child has Swing focus.
+        registerKeyBindings(scrollPane)
+
         val p = JBPopupFactory.getInstance()
             .createComponentPopupBuilder(scrollPane, scrollPane)
             .setRequestFocus(true)
@@ -84,19 +98,67 @@ class ModelPickerPopup(
         return p
     }
 
+    private fun registerKeyBindings(component: JComponent) {
+        val im = component.getInputMap(JComponent.WHEN_FOCUSED)
+        val am = component.actionMap
+
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0), "moveUp")
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0), "moveDown")
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "activateRow")
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "closePopup")
+
+        am.put("moveUp", object : AbstractAction() {
+            override fun actionPerformed(e: ActionEvent) = moveUp()
+        })
+        am.put("moveDown", object : AbstractAction() {
+            override fun actionPerformed(e: ActionEvent) = moveDown()
+        })
+        am.put("activateRow", object : AbstractAction() {
+            override fun actionPerformed(e: ActionEvent) = activateCurrentRow()
+        })
+        am.put("closePopup", object : AbstractAction() {
+            override fun actionPerformed(e: ActionEvent) {
+                popup?.cancel()
+            }
+        })
+    }
+
+    private fun moveUp() {
+        val visible = getVisibleRows()
+        if (visible.isEmpty()) return
+        focusedRowIndex = (focusedRowIndex - 1).coerceAtLeast(0)
+        highlightRow(focusedRowIndex)
+    }
+
+    private fun moveDown() {
+        val visible = getVisibleRows()
+        if (visible.isEmpty()) return
+        focusedRowIndex = (focusedRowIndex + 1).coerceAtMost(visible.size - 1)
+        highlightRow(focusedRowIndex)
+    }
+
+    private fun activateCurrentRow() {
+        val visible = getVisibleRows()
+        if (focusedRowIndex !in visible.indices) return
+        val row = visible[focusedRowIndex]
+        if (row.modelRowIndex >= 0) {
+            val model = findModel(row.groupIndex, row.modelRowIndex)
+            if (model != null) selectModel(model.index)
+        } else {
+            row.toggleExpand()
+            val newVisible = getVisibleRows()
+            focusedRowIndex = focusedRowIndex.coerceAtMost(newVisible.size - 1)
+            highlightRow(focusedRowIndex)
+        }
+    }
+
     private var outerPanel: JComponent? = null
 
     private fun buildContent(): JComponent {
         focusableRows.clear()
 
         val outer = JBPanel<JBPanel<*>>(GridBagLayout()).apply {
-            border = JBUI.Borders.empty(4, 0, 4, 0)
-            isFocusable = true
-            addKeyListener(object : KeyAdapter() {
-                override fun keyPressed(e: KeyEvent) {
-                    handleKeyPressed(e)
-                }
-            })
+            border = JBUI.Borders.empty(4, 0)
         }
         outerPanel = outer
 
@@ -107,17 +169,16 @@ class ModelPickerPopup(
         gbc.weighty = 0.0
         gbc.anchor = GridBagConstraints.PAGE_START
 
-        for ((gi, group) in groups.withIndex()) {
+        for ((gi, group) in currentGroups.withIndex()) {
             val section = buildSection(gi, group)
             gbc.gridy = gi
             outer.add(section, gbc)
         }
 
-        // Apply initial collapse state — model rows start visible but must
-        // be hidden for collapsed groups before the popup renders.
+        // Apply initial collapse state before the popup renders
         updateChildrenVisibility()
 
-        gbc.gridy = groups.size
+        gbc.gridy = currentGroups.size
         gbc.weighty = 1.0
         outer.add(JPanel().apply { isOpaque = false; preferredSize = Dimension(0, 0) }, gbc)
 
@@ -143,7 +204,7 @@ class ModelPickerPopup(
                 "Label.infoForeground",
                 JBUI.CurrentTheme.Label.disabledForeground()
             )
-            border = JBUI.Borders.empty(2, 8, 2, 8)
+            border = JBUI.Borders.empty(2, 8)
             cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
             addMouseListener(object : MouseAdapter() {
                 override fun mouseClicked(e: MouseEvent) {
@@ -156,8 +217,6 @@ class ModelPickerPopup(
                 }
             })
         }
-        // Wrap in horizontal box: label left + glue right = guaranteed left-align
-        // regardless of other children's alignmentX in the parent BoxLayout.
         val headerWrapper = Box.createHorizontalBox().apply {
             add(headerLabel)
             add(Box.createHorizontalGlue())
@@ -170,23 +229,8 @@ class ModelPickerPopup(
             isOpaque = false
         }
 
-        for (model in group.models) {
-            val row = buildModelRow(model)
-            modelsPanel.add(row)
-            focusableRows.add(
-                FocusableRow(
-                    component = row,
-                    groupIndex = groupIndex,
-                    modelRowIndex = group.models.indexOf(model),
-                    isExpanded = { isExpanded(provider) },
-                    toggleExpand = {}
-                )
-            )
-        }
-
-        sectionPanel.add(headerWrapper)
-        sectionPanel.add(modelsPanel)
-
+        // Add header focus row FIRST so keyboard navigation order matches visual layout
+        // (header appears above its model rows, so it should be traversed first).
         focusableRows.add(
             FocusableRow(
                 component = headerWrapper,
@@ -204,23 +248,41 @@ class ModelPickerPopup(
             )
         )
 
+        // Use forEachIndexed for O(1) index and correct behaviour with duplicate GroupedModel values
+        group.models.forEachIndexed { modelIdx, model ->
+            val row = buildModelRow(model)
+            modelsPanel.add(row)
+            focusableRows.add(
+                FocusableRow(
+                    component = row,
+                    groupIndex = groupIndex,
+                    modelRowIndex = modelIdx,
+                    isExpanded = { isExpanded(provider) },
+                    toggleExpand = {}
+                )
+            )
+        }
+
+        sectionPanel.add(headerWrapper)
+        sectionPanel.add(modelsPanel)
+
         return sectionPanel
     }
 
     private fun buildModelRow(model: ModelGrouper.GroupedModel): JComponent {
         val row = JBPanel<JBPanel<*>>(BorderLayout()).apply {
             isOpaque = true
-            background = UIManager.getColor("MenuItem.background")
+            background = UIManager.getColor(MENU_ITEM_BG)
             border = JBUI.Borders.empty(2, 20, 2, 8)
             cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
 
             addMouseListener(object : MouseAdapter() {
                 override fun mouseEntered(e: MouseEvent) {
-                    background = UIManager.getColor("MenuItem.selectionBackground")
+                    background = UIManager.getColor(MENU_ITEM_SELECTION_BG)
                 }
 
                 override fun mouseExited(e: MouseEvent) {
-                    background = UIManager.getColor("MenuItem.background")
+                    background = UIManager.getColor(MENU_ITEM_BG)
                 }
 
                 override fun mouseClicked(e: MouseEvent) {
@@ -246,7 +308,7 @@ class ModelPickerPopup(
 
             addMouseListener(object : MouseAdapter() {
                 override fun mouseClicked(e: MouseEvent) {
-                    toggleFavorite(model.modelId, this@apply)
+                    toggleFavorite(model.modelId)
                     e.consume()
                 }
             })
@@ -258,20 +320,43 @@ class ModelPickerPopup(
         return row
     }
 
-    private fun toggleFavorite(modelId: String, starLabel: JLabel) {
-        val wasFavorite = favoritedIds.contains(modelId)
-        if (wasFavorite) {
-            favoritedIds.remove(modelId)
-            starLabel.text = "\u2606"
-            starLabel.foreground = UIManager.getColor("MenuItem.disabledForeground")
-            starLabel.toolTipText = "Add to favorites"
-        } else {
-            favoritedIds.add(modelId)
-            starLabel.text = "\u2605"
-            starLabel.foreground = JBColor(Color(0xFF, 0xB9, 0x00), Color(0xFF, 0xD7, 0x00))
-            starLabel.toolTipText = "Remove from favorites"
-        }
+    private fun toggleFavorite(modelId: String) {
+        if (favoritedIds.contains(modelId)) favoritedIds.remove(modelId) else favoritedIds.add(modelId)
         onFavoriteToggled?.invoke(modelId)
+        // Rebuild so the Favorites section reflects the change immediately
+        rebuildContent()
+    }
+
+    private fun recomputeGroups(): List<ModelGrouper.Group> {
+        val (favs, rest) = allGroupedModels.partition { favoritedIds.contains(it.modelId) }
+        val providerGroups = rest.groupBy { it.providerName ?: "Other" }
+        val sortedProviders = providerGroups.keys.sortedWith(
+            compareBy<String> { it == "Other" }.thenBy { it.lowercase() }
+        )
+        return buildList {
+            if (favs.isNotEmpty()) {
+                add(ModelGrouper.Group("Favorites", favs.map { it.copy(isFavorite = true) }))
+            }
+            for (provider in sortedProviders) {
+                add(
+                    ModelGrouper.Group(
+                        provider, (providerGroups[provider] ?: emptyList())
+                            .map { it.copy(isFavorite = false) })
+                )
+            }
+        }
+    }
+
+    private fun rebuildContent() {
+        currentGroups = recomputeGroups()
+        focusedRowIndex = 0
+        // Save old outer before buildContent() overwrites outerPanel
+        val oldOuter = outerPanel
+        val newContent = buildContent()
+        val scrollPane = oldOuter?.parent?.parent as? JBScrollPane ?: return
+        scrollPane.viewport.view = newContent
+        scrollPane.revalidate()
+        scrollPane.repaint()
     }
 
     private fun selectModel(index: Int) {
@@ -290,56 +375,12 @@ class ModelPickerPopup(
     }
 
     private fun getVisibleRows(): List<FocusableRow> {
-        return focusableRows.filter { row ->
-            row.modelRowIndex < 0 || row.isExpanded()
-        }
-    }
-
-    private fun handleKeyPressed(e: KeyEvent) {
-        val visible = getVisibleRows()
-        if (visible.isEmpty()) return
-
-        when (e.keyCode) {
-            KeyEvent.VK_UP -> {
-                e.consume()
-                focusedRowIndex = (focusedRowIndex - 1).coerceAtLeast(0)
-                highlightRow(focusedRowIndex)
-            }
-
-            KeyEvent.VK_DOWN -> {
-                e.consume()
-                focusedRowIndex = (focusedRowIndex + 1).coerceAtMost(visible.size - 1)
-                highlightRow(focusedRowIndex)
-            }
-
-            KeyEvent.VK_ENTER -> {
-                e.consume()
-                if (focusedRowIndex in visible.indices) {
-                    val row = visible[focusedRowIndex]
-                    if (row.modelRowIndex >= 0) {
-                        val model = findModel(row.groupIndex, row.modelRowIndex)
-                        if (model != null) {
-                            selectModel(model.index)
-                        }
-                    } else {
-                        row.toggleExpand()
-                        val newVisible = getVisibleRows()
-                        focusedRowIndex = focusedRowIndex.coerceAtMost(newVisible.size - 1)
-                        highlightRow(focusedRowIndex)
-                    }
-                }
-            }
-
-            KeyEvent.VK_ESCAPE -> {
-                e.consume()
-                popup?.cancel()
-            }
-        }
+        return focusableRows.filter { row -> row.modelRowIndex < 0 || row.isExpanded() }
     }
 
     private fun findModel(groupIndex: Int, modelRowIndex: Int): ModelGrouper.GroupedModel? {
-        if (groupIndex >= groups.size) return null
-        val group = groups[groupIndex]
+        if (groupIndex >= currentGroups.size) return null
+        val group = currentGroups[groupIndex]
         if (modelRowIndex >= group.models.size) return null
         return group.models[modelRowIndex]
     }
@@ -348,9 +389,9 @@ class ModelPickerPopup(
         val visible = getVisibleRows()
         for ((i, row) in visible.withIndex()) {
             row.component.background = if (i == index)
-                UIManager.getColor("MenuItem.selectionBackground")
+                UIManager.getColor(MENU_ITEM_SELECTION_BG)
             else
-                UIManager.getColor("MenuItem.background")
+                UIManager.getColor(MENU_ITEM_BG)
         }
         if (index in visible.indices) {
             visible[index].component.scrollRectToVisible(visible[index].component.bounds)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ModelPickerPopup.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ModelPickerPopup.kt
@@ -1,0 +1,359 @@
+package com.github.catatafishen.agentbridge.ui
+
+import com.github.catatafishen.agentbridge.ui.util.ModelGrouper
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.ui.popup.JBPopup
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBPanel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import java.awt.*
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.*
+
+/**
+ * Custom model picker popup with collapsible provider sections and favorite toggles.
+ * Group expand/collapse state is persisted via PropertiesComponent.
+ */
+class ModelPickerPopup(
+    private val groups: List<ModelGrouper.Group>
+) {
+
+    var onModelSelected: ((Int) -> Unit)? = null
+    var onFavoriteToggled: ((String) -> Unit)? = null
+
+    private var popup: JBPopup? = null
+    private var focusedRowIndex: Int = 0
+
+    private val favoritedIds: MutableSet<String> = groups
+        .flatMap { it.models }
+        .filter { it.isFavorite }
+        .map { it.modelId }
+        .toMutableSet()
+
+    // Persistent expand/collapse state: key = provider name, value = expanded
+    private val expandState: MutableMap<String, Boolean> = mutableMapOf()
+    private val props = PropertiesComponent.getInstance()
+
+    private fun isExpanded(provider: String): Boolean {
+        if (provider !in expandState) {
+            val key = "agentbridge.picker.expanded.$provider"
+            val stored = props.getValue(key)
+            expandState[provider] = if (stored != null) stored.toBoolean() else (provider == "Favorites")
+        }
+        return expandState[provider]!!
+    }
+
+    private fun setExpanded(provider: String, expanded: Boolean) {
+        expandState[provider] = expanded
+        props.setValue("agentbridge.picker.expanded.$provider", expanded.toString())
+    }
+
+    private data class FocusableRow(
+        val component: JComponent,
+        val groupIndex: Int,
+        val modelRowIndex: Int,
+        val isExpanded: () -> Boolean,
+        val toggleExpand: () -> Unit
+    )
+
+    private val focusableRows = mutableListOf<FocusableRow>()
+
+    fun createPopup(): JBPopup {
+        val content = buildContent()
+        val scrollPane = JBScrollPane(content).apply {
+            border = null
+            horizontalScrollBarPolicy = JBScrollPane.HORIZONTAL_SCROLLBAR_NEVER
+        }
+
+        val p = JBPopupFactory.getInstance()
+            .createComponentPopupBuilder(scrollPane, scrollPane)
+            .setRequestFocus(true)
+            .setFocusable(true)
+            .setResizable(false)
+            .setCancelOnClickOutside(true)
+            .setCancelOnWindowDeactivation(true)
+            .createPopup()
+        this.popup = p
+        return p
+    }
+
+    private var outerPanel: JComponent? = null
+
+    private fun buildContent(): JComponent {
+        focusableRows.clear()
+
+        val outer = JBPanel<JBPanel<*>>(GridBagLayout()).apply {
+            border = JBUI.Borders.empty(4, 0, 4, 0)
+            isFocusable = true
+            addKeyListener(object : KeyAdapter() {
+                override fun keyPressed(e: KeyEvent) {
+                    handleKeyPressed(e)
+                }
+            })
+        }
+        outerPanel = outer
+
+        val gbc = GridBagConstraints()
+        gbc.gridx = 0
+        gbc.fill = GridBagConstraints.HORIZONTAL
+        gbc.weightx = 1.0
+        gbc.weighty = 0.0
+        gbc.anchor = GridBagConstraints.PAGE_START
+
+        for ((gi, group) in groups.withIndex()) {
+            val section = buildSection(gi, group)
+            gbc.gridy = gi
+            outer.add(section, gbc)
+        }
+
+        // Apply initial collapse state — model rows start visible but must
+        // be hidden for collapsed groups before the popup renders.
+        updateChildrenVisibility()
+
+        gbc.gridy = groups.size
+        gbc.weighty = 1.0
+        outer.add(JPanel().apply { isOpaque = false; preferredSize = Dimension(0, 0) }, gbc)
+
+        if (focusableRows.isNotEmpty()) {
+            highlightRow(0)
+        }
+
+        return outer
+    }
+
+    private fun buildSection(groupIndex: Int, group: ModelGrouper.Group): JComponent {
+        val provider = group.provider
+
+        val sectionPanel = JBPanel<JBPanel<*>>().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            isOpaque = false
+        }
+
+        val headerIcon = { if (isExpanded(provider)) "\u25BC" else "\u25B6" }
+        val headerLabel = JBLabel("${headerIcon()}  $provider", SwingConstants.LEFT).apply {
+            font = font.deriveFont(Font.BOLD)
+            foreground = JBColor.namedColor(
+                "Label.infoForeground",
+                JBUI.CurrentTheme.Label.disabledForeground()
+            )
+            border = JBUI.Borders.empty(2, 8, 2, 8)
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            addMouseListener(object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
+                    val now = !isExpanded(provider)
+                    setExpanded(provider, now)
+                    text = "${headerIcon()}  $provider"
+                    updateChildrenVisibility()
+                    outerPanel?.revalidate()
+                    outerPanel?.repaint()
+                }
+            })
+        }
+        // Wrap in horizontal box: label left + glue right = guaranteed left-align
+        // regardless of other children's alignmentX in the parent BoxLayout.
+        val headerWrapper = Box.createHorizontalBox().apply {
+            add(headerLabel)
+            add(Box.createHorizontalGlue())
+            alignmentX = Component.LEFT_ALIGNMENT
+            isOpaque = false
+        }
+
+        val modelsPanel = JBPanel<JBPanel<*>>().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            isOpaque = false
+        }
+
+        for (model in group.models) {
+            val row = buildModelRow(model)
+            modelsPanel.add(row)
+            focusableRows.add(
+                FocusableRow(
+                    component = row,
+                    groupIndex = groupIndex,
+                    modelRowIndex = group.models.indexOf(model),
+                    isExpanded = { isExpanded(provider) },
+                    toggleExpand = {}
+                )
+            )
+        }
+
+        sectionPanel.add(headerWrapper)
+        sectionPanel.add(modelsPanel)
+
+        focusableRows.add(
+            FocusableRow(
+                component = headerWrapper,
+                groupIndex = groupIndex,
+                modelRowIndex = -1,
+                isExpanded = { isExpanded(provider) },
+                toggleExpand = {
+                    val now = !isExpanded(provider)
+                    setExpanded(provider, now)
+                    headerLabel.text = "${headerIcon()}  $provider"
+                    updateChildrenVisibility()
+                    outerPanel?.revalidate()
+                    outerPanel?.repaint()
+                }
+            )
+        )
+
+        return sectionPanel
+    }
+
+    private fun buildModelRow(model: ModelGrouper.GroupedModel): JComponent {
+        val row = JBPanel<JBPanel<*>>(BorderLayout()).apply {
+            isOpaque = true
+            background = UIManager.getColor("MenuItem.background")
+            border = JBUI.Borders.empty(2, 20, 2, 8)
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+
+            addMouseListener(object : MouseAdapter() {
+                override fun mouseEntered(e: MouseEvent) {
+                    background = UIManager.getColor("MenuItem.selectionBackground")
+                }
+
+                override fun mouseExited(e: MouseEvent) {
+                    background = UIManager.getColor("MenuItem.background")
+                }
+
+                override fun mouseClicked(e: MouseEvent) {
+                    selectModel(model.index)
+                }
+            })
+        }
+
+        val nameLabel = JBLabel(model.displayName).apply {
+            font = UIUtil.getLabelFont()
+            foreground = UIManager.getColor("MenuItem.foreground")
+        }
+
+        val isFav = favoritedIds.contains(model.modelId)
+        val starLabel = JBLabel(if (isFav) "\u2605" else "\u2606").apply {
+            font = font.deriveFont(14f)
+            foreground = if (isFav)
+                JBColor(Color(0xFF, 0xB9, 0x00), Color(0xFF, 0xD7, 0x00))
+            else
+                UIManager.getColor("MenuItem.disabledForeground")
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            toolTipText = if (isFav) "Remove from favorites" else "Add to favorites"
+
+            addMouseListener(object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
+                    toggleFavorite(model.modelId, this@apply)
+                    e.consume()
+                }
+            })
+        }
+
+        row.add(nameLabel, BorderLayout.CENTER)
+        row.add(starLabel, BorderLayout.EAST)
+
+        return row
+    }
+
+    private fun toggleFavorite(modelId: String, starLabel: JLabel) {
+        val wasFavorite = favoritedIds.contains(modelId)
+        if (wasFavorite) {
+            favoritedIds.remove(modelId)
+            starLabel.text = "\u2606"
+            starLabel.foreground = UIManager.getColor("MenuItem.disabledForeground")
+            starLabel.toolTipText = "Add to favorites"
+        } else {
+            favoritedIds.add(modelId)
+            starLabel.text = "\u2605"
+            starLabel.foreground = JBColor(Color(0xFF, 0xB9, 0x00), Color(0xFF, 0xD7, 0x00))
+            starLabel.toolTipText = "Remove from favorites"
+        }
+        onFavoriteToggled?.invoke(modelId)
+    }
+
+    private fun selectModel(index: Int) {
+        onModelSelected?.invoke(index)
+        popup?.cancel()
+    }
+
+    private fun updateChildrenVisibility() {
+        for (row in focusableRows) {
+            if (row.modelRowIndex >= 0) {
+                row.component.isVisible = row.isExpanded()
+            }
+        }
+        outerPanel?.revalidate()
+        outerPanel?.repaint()
+    }
+
+    private fun getVisibleRows(): List<FocusableRow> {
+        return focusableRows.filter { row ->
+            row.modelRowIndex < 0 || row.isExpanded()
+        }
+    }
+
+    private fun handleKeyPressed(e: KeyEvent) {
+        val visible = getVisibleRows()
+        if (visible.isEmpty()) return
+
+        when (e.keyCode) {
+            KeyEvent.VK_UP -> {
+                e.consume()
+                focusedRowIndex = (focusedRowIndex - 1).coerceAtLeast(0)
+                highlightRow(focusedRowIndex)
+            }
+
+            KeyEvent.VK_DOWN -> {
+                e.consume()
+                focusedRowIndex = (focusedRowIndex + 1).coerceAtMost(visible.size - 1)
+                highlightRow(focusedRowIndex)
+            }
+
+            KeyEvent.VK_ENTER -> {
+                e.consume()
+                if (focusedRowIndex in visible.indices) {
+                    val row = visible[focusedRowIndex]
+                    if (row.modelRowIndex >= 0) {
+                        val model = findModel(row.groupIndex, row.modelRowIndex)
+                        if (model != null) {
+                            selectModel(model.index)
+                        }
+                    } else {
+                        row.toggleExpand()
+                        val newVisible = getVisibleRows()
+                        focusedRowIndex = focusedRowIndex.coerceAtMost(newVisible.size - 1)
+                        highlightRow(focusedRowIndex)
+                    }
+                }
+            }
+
+            KeyEvent.VK_ESCAPE -> {
+                e.consume()
+                popup?.cancel()
+            }
+        }
+    }
+
+    private fun findModel(groupIndex: Int, modelRowIndex: Int): ModelGrouper.GroupedModel? {
+        if (groupIndex >= groups.size) return null
+        val group = groups[groupIndex]
+        if (modelRowIndex >= group.models.size) return null
+        return group.models[modelRowIndex]
+    }
+
+    private fun highlightRow(index: Int) {
+        val visible = getVisibleRows()
+        for ((i, row) in visible.withIndex()) {
+            row.component.background = if (i == index)
+                UIManager.getColor("MenuItem.selectionBackground")
+            else
+                UIManager.getColor("MenuItem.background")
+        }
+        if (index in visible.indices) {
+            visible[index].component.scrollRectToVisible(visible[index].component.bounds)
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/ModelFavorites.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/ModelFavorites.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.project.Project
  * Backed by [PropertiesComponent], survives IDE restarts.
  * Storage format: JSON array `["providerId/modelId", ...]`.
  */
-class ModelFavorites(private val project: Project) {
+class ModelFavorites(project: Project) {
 
     companion object {
         private const val KEY = "agentbridge.favoriteModels"
@@ -34,7 +34,7 @@ class ModelFavorites(private val project: Project) {
     fun toSet(): Set<String> {
         val raw = props.getValue(KEY) ?: return emptySet()
         return try {
-            gson.fromJson<MutableSet<String>>(raw, setType)
+            gson.fromJson<MutableSet<String>>(raw, setType) ?: emptySet()
         } catch (_: Exception) {
             emptySet()
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/ModelFavorites.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/ModelFavorites.kt
@@ -1,0 +1,42 @@
+package com.github.catatafishen.agentbridge.ui.util
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.project.Project
+
+/**
+ * Persistent store for favorite model IDs, project-scoped.
+ *
+ * Backed by [PropertiesComponent], survives IDE restarts.
+ * Storage format: JSON array `["providerId/modelId", ...]`.
+ */
+class ModelFavorites(private val project: Project) {
+
+    companion object {
+        private const val KEY = "agentbridge.favoriteModels"
+        private val gson = Gson()
+        private val setType = object : TypeToken<MutableSet<String>>() {}.type
+
+        fun getInstance(project: Project): ModelFavorites = ModelFavorites(project)
+    }
+
+    private val props: PropertiesComponent = PropertiesComponent.getInstance(project)
+
+    fun isFavorite(modelId: String): Boolean = toSet().contains(modelId)
+
+    fun toggle(modelId: String) {
+        val set = toSet().toMutableSet()
+        if (set.contains(modelId)) set.remove(modelId) else set.add(modelId)
+        props.setValue(KEY, gson.toJson(set.toList()))
+    }
+
+    fun toSet(): Set<String> {
+        val raw = props.getValue(KEY) ?: return emptySet()
+        return try {
+            gson.fromJson<MutableSet<String>>(raw, setType)
+        } catch (_: Exception) {
+            emptySet()
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/ModelGrouper.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/ModelGrouper.kt
@@ -56,17 +56,13 @@ class ModelGrouper(private val favorites: Set<String>) {
 
         val result = mutableListOf<Group>()
 
-        // Always include Favorites group (even if empty)
-        result.add(Group("Favorites", favs))
+        if (favs.isNotEmpty()) {
+            result.add(Group("Favorites", favs))
+        }
 
         for (provider in sortedProviders) {
             val groupModels = providerGroups[provider] ?: continue
-            // Suppress provider header when single-provider + no favorites
-            if (favs.isEmpty() && sortedProviders.size == 1 && provider != OTHER) {
-                result.add(Group(provider, groupModels))
-            } else {
-                result.add(Group(provider, groupModels))
-            }
+            result.add(Group(provider, groupModels))
         }
 
         return result

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/ModelGrouper.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/ModelGrouper.kt
@@ -1,0 +1,74 @@
+package com.github.catatafishen.agentbridge.ui.util
+
+import com.github.catatafishen.agentbridge.acp.model.Model
+
+/**
+ * Groups a flat model list by provider for the model picker popup.
+ *
+ * Pure logic — zero Swing/UI dependencies, fully unit-testable.
+ */
+class ModelGrouper(private val favorites: Set<String>) {
+
+    data class Group(val provider: String, val models: List<GroupedModel>)
+    data class GroupedModel(
+        val index: Int,
+        val modelId: String,
+        val name: String,
+        val isFavorite: Boolean,
+        val providerName: String?
+    ) {
+        val displayName: String
+            get() = if (isFavorite && providerName != null) "$name ($providerName)" else name
+    }
+
+    companion object {
+        private const val OTHER = "Other"
+    }
+
+    /**
+     * Returns ordered groups: Favorites (if non-empty), then providers
+     * alphabetically with "Other" last. Each entry preserves the original
+     * flat index so model selection still works via the existing `loadedModels` list.
+     */
+    fun group(models: List<Model>): List<Group> {
+        if (models.isEmpty()) return emptyList()
+
+        val indexed = models.mapIndexed { index, model ->
+            val name = ModelProvider.getModelName(model)
+            val provider = ModelProvider.getProvider(model)
+            GroupedModel(index, model.id(), name, favorites.contains(model.id()), provider)
+        }
+
+        // Partition favorites
+        val (favs, rest) = indexed.partition { it.isFavorite }
+
+        // Group rest by provider
+        val providerGroups: LinkedHashMap<String, MutableList<GroupedModel>> = linkedMapOf()
+        for (item in rest) {
+            val provider = ModelProvider.getProvider(models[item.index]) ?: OTHER
+            providerGroups.getOrPut(provider) { mutableListOf() }.add(item)
+        }
+
+        // Sort providers alphabetically, Other last
+        val sortedProviders = providerGroups.keys.sortedWith(
+            compareBy<String> { it == OTHER }.thenBy { it.lowercase() }
+        )
+
+        val result = mutableListOf<Group>()
+
+        // Always include Favorites group (even if empty)
+        result.add(Group("Favorites", favs))
+
+        for (provider in sortedProviders) {
+            val groupModels = providerGroups[provider] ?: continue
+            // Suppress provider header when single-provider + no favorites
+            if (favs.isEmpty() && sortedProviders.size == 1 && provider != OTHER) {
+                result.add(Group(provider, groupModels))
+            } else {
+                result.add(Group(provider, groupModels))
+            }
+        }
+
+        return result
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/ModelProvider.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/ModelProvider.kt
@@ -1,0 +1,48 @@
+package com.github.catatafishen.agentbridge.ui.util
+
+import com.github.catatafishen.agentbridge.acp.model.Model
+
+/**
+ * Extracts provider information from ACP [Model] names.
+ *
+ * OpenCode's model format is `"ProviderName/ModelName"` — the provider prefix
+ * is used for grouping in the model picker dropdown. Other ACP agents use flat
+ * model names without slashes and are not grouped.
+ *
+ * Pure logic — zero UI dependencies, unit-testable in isolation.
+ */
+object ModelProvider {
+
+    /**
+     * Returns the provider display name, or `null` if the model name does not
+     * contain a slash-separated provider prefix.
+     *
+     * Examples:
+     * - `"Nvidia/Llama 3.1 Nemotron"` → `"Nvidia"`
+     * - `"OpenCode/Claude Max"`       → `"OpenCode"`
+     * - `"GPT-4o"`                    → `null`
+     * - `"/LeadingSlash"`             → `null`
+     * - `null` name                   → `null`
+     */
+    fun getProvider(model: Model): String? {
+        val name = model.name() ?: return null
+        val slash = name.indexOf('/')
+        if (slash <= 0) return null
+        return name.substring(0, slash)
+    }
+
+    /**
+     * Returns the model name without the provider prefix.
+     * For flat names, returns the name as-is.
+     *
+     * Examples:
+     * - `"Nvidia/Llama 3.1 Nemotron"` → `"Llama 3.1 Nemotron"`
+     * - `"GPT-4o"`                    → `"GPT-4o"`
+     * - `null` name                   → `model.id()`
+     */
+    fun getModelName(model: Model): String {
+        val name = model.name() ?: return model.id()
+        val slash = name.indexOf('/')
+        return if (slash >= 0) name.substring(slash + 1).trim() else name
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/util/ModelFavoritesTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/util/ModelFavoritesTest.java
@@ -1,0 +1,297 @@
+package com.github.catatafishen.agentbridge.ui.util;
+
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ModelFavorites}.
+ * <p>
+ * Uses a HashMap-based fake for {@link PropertiesComponent} and Mockito for {@link Project}.
+ */
+class ModelFavoritesTest {
+
+    private static final String KEY = "agentbridge.favoriteModels";
+
+    /**
+     * Minimal in-memory stand-in for the abstract PropertiesComponent.
+     */
+    private static class FakePropertiesComponent extends PropertiesComponent {
+        private final HashMap<String, String> data = new HashMap<>();
+
+        @Override
+        public @Nullable String getValue(@NotNull String name) {
+            return data.get(name);
+        }
+
+        @Override
+        public void setValue(@NotNull String name, @Nullable String value) {
+            if (value == null) data.remove(name);
+            else data.put(name, value);
+        }
+
+        @Override
+        public void setValue(@NotNull String name, @Nullable String value, @Nullable String defaultValue) {
+            setValue(name, value);
+        }
+
+        @Override
+        public void unsetValue(@NotNull String name) {
+            data.remove(name);
+        }
+
+        @Override
+        public boolean isValueSet(@NotNull String name) {
+            return data.containsKey(name);
+        }
+
+        @Override
+        public void setValue(@NotNull String name, float value, float defaultValue) {
+            data.put(name, String.valueOf(value));
+        }
+
+        @Override
+        public void setValue(@NotNull String name, int value, int defaultValue) {
+            data.put(name, String.valueOf(value));
+        }
+
+        @Override
+        public void setValue(@NotNull String name, boolean value, boolean defaultValue) {
+            data.put(name, String.valueOf(value));
+        }
+
+        @Override
+        public boolean updateValue(@NotNull String name, boolean value) {
+            String prev = data.put(name, String.valueOf(value));
+            return !String.valueOf(value).equals(prev);
+        }
+
+        @Override
+        public @Nullable String @Nullable [] getValues(@NotNull String name) {
+            return null;
+        }
+
+        @Override
+        public void setValues(@NotNull String name, @Nullable String @Nullable [] values) {
+            // not used by ModelFavorites
+        }
+
+        @Override
+        public @Nullable java.util.List<String> getList(@NotNull String name) {
+            return null;
+        }
+
+        @Override
+        public void setList(@NotNull String name, @Nullable java.util.Collection<String> values) {
+            // not used by ModelFavorites
+        }
+    }
+
+    private FakePropertiesComponent fakeProps;
+    private ModelFavorites favorites;
+
+    @BeforeEach
+    void setUp() {
+        fakeProps = new FakePropertiesComponent();
+        Project mockProject = Mockito.mock(Project.class);
+
+        // Mock the static PropertiesComponent.getInstance(project) to return our fake
+        try (var mockedStatic = Mockito.mockStatic(PropertiesComponent.class)) {
+            mockedStatic.when(() -> PropertiesComponent.getInstance(mockProject))
+                .thenReturn(fakeProps);
+
+            favorites = new ModelFavorites(mockProject);
+        }
+
+        // Verify injection worked
+        assertNotNull(favorites);
+    }
+
+    // ── Empty state ────────────────────────────────────────────────────────────
+
+    @Test
+    void toSet_returnsEmptySet_whenNoFavoritesSet() {
+        assertTrue(favorites.toSet().isEmpty());
+    }
+
+    @Test
+    void isFavorite_returnsFalse_forAnyId_whenNoFavoritesSet() {
+        assertFalse(favorites.isFavorite("gpt-4o"));
+        assertFalse(favorites.isFavorite("claude-3-5-sonnet"));
+        assertFalse(favorites.isFavorite("any-model-id"));
+    }
+
+    // ── Toggle adds ───────────────────────────────────────────────────────────
+
+    @Test
+    void toggle_addsModelId_whenNotAlreadyFavorite() {
+        favorites.toggle("gpt-4o");
+
+        assertTrue(favorites.isFavorite("gpt-4o"));
+    }
+
+    @Test
+    void toSet_containsModel_afterToggleAdds() {
+        favorites.toggle("gpt-4o");
+
+        assertTrue(favorites.toSet().contains("gpt-4o"));
+    }
+
+    // ── Toggle removes ───────────────────────────────────────────────────────
+
+    @Test
+    void toggle_removesModelId_whenAlreadyFavorite() {
+        favorites.toggle("gpt-4o");
+        favorites.toggle("gpt-4o");
+
+        assertFalse(favorites.isFavorite("gpt-4o"));
+    }
+
+    @Test
+    void toSet_doesNotContainModel_afterSecondToggle() {
+        favorites.toggle("gpt-4o");
+        favorites.toggle("gpt-4o");
+
+        assertFalse(favorites.toSet().contains("gpt-4o"));
+    }
+
+    @Test
+    void isFavorite_returnsFalse_afterSecondToggle() {
+        favorites.toggle("gpt-4o");
+        assertTrue(favorites.isFavorite("gpt-4o"));
+
+        favorites.toggle("gpt-4o");
+        assertFalse(favorites.isFavorite("gpt-4o"));
+    }
+
+    // ── Multiple favorites ─────────────────────────────────────────────────────
+
+    @Test
+    void toSet_containsMultipleFavorites() {
+        favorites.toggle("gpt-4o");
+        favorites.toggle("claude-3-5-sonnet");
+        favorites.toggle("gemini-2-0-flash");
+
+        Set<String> set = favorites.toSet();
+        assertEquals(3, set.size());
+        assertTrue(set.contains("gpt-4o"));
+        assertTrue(set.contains("claude-3-5-sonnet"));
+        assertTrue(set.contains("gemini-2-0-flash"));
+    }
+
+    @Test
+    void isFavorite_returnsCorrectState_forMultipleFavorites() {
+        favorites.toggle("gpt-4o");
+        favorites.toggle("claude-3-5-sonnet");
+
+        assertTrue(favorites.isFavorite("gpt-4o"));
+        assertTrue(favorites.isFavorite("claude-3-5-sonnet"));
+        assertFalse(favorites.isFavorite("gemini-2-0-flash"));
+    }
+
+    @Test
+    void toggle_removesOneFavorite_leavingOthersIntact() {
+        favorites.toggle("gpt-4o");
+        favorites.toggle("claude-3-5-sonnet");
+        favorites.toggle("gemini-2-0-flash");
+
+        favorites.toggle("claude-3-5-sonnet");
+
+        Set<String> set = favorites.toSet();
+        assertEquals(2, set.size());
+        assertTrue(set.contains("gpt-4o"));
+        assertFalse(set.contains("claude-3-5-sonnet"));
+        assertTrue(set.contains("gemini-2-0-flash"));
+    }
+
+    // ── getInstance factory method ────────────────────────────────────────────
+
+    @Test
+    void getInstance_returnsNewInstance_eachCall() {
+        // The getInstance factory method creates a new instance each time.
+        // This is by design - the class does not cache instances.
+        Project project = Mockito.mock(Project.class);
+
+        try (var mockedStatic = Mockito.mockStatic(PropertiesComponent.class)) {
+            mockedStatic.when(() -> PropertiesComponent.getInstance(project))
+                .thenReturn(fakeProps);
+
+            // Kotlin companion object methods are accessed via .Companion in Java
+            ModelFavorites instance1 = ModelFavorites.Companion.getInstance(project);
+            ModelFavorites instance2 = ModelFavorites.Companion.getInstance(project);
+
+            // Each call creates a new instance (no caching)
+            assertNotSame(instance1, instance2);
+        }
+    }
+
+    @Test
+    void getInstance_returnsDifferentInstance_forDifferentProject() {
+        Project project1 = Mockito.mock(Project.class);
+        Project project2 = Mockito.mock(Project.class);
+
+        // Mock static to return different fakes for different projects
+        FakePropertiesComponent fakeProps2 = new FakePropertiesComponent();
+        try (var mockedStatic = Mockito.mockStatic(PropertiesComponent.class)) {
+            mockedStatic.when(() -> PropertiesComponent.getInstance(project1))
+                .thenReturn(fakeProps);
+            mockedStatic.when(() -> PropertiesComponent.getInstance(project2))
+                .thenReturn(fakeProps2);
+
+            ModelFavorites instance1 = ModelFavorites.Companion.getInstance(project1);
+            ModelFavorites instance2 = ModelFavorites.Companion.getInstance(project2);
+
+            assertNotSame(instance1, instance2);
+        }
+    }
+
+    // ── Persistence ───────────────────────────────────────────────────────────
+
+    @Test
+    void toggle_persistsToPropertiesComponent() {
+        favorites.toggle("gpt-4o");
+
+        String stored = fakeProps.getValue(KEY);
+        assertNotNull(stored);
+        assertTrue(stored.contains("gpt-4o"));
+    }
+
+    @Test
+    void toSet_readsFromPropertiesComponent() {
+        fakeProps.setValue(KEY, "[\"gpt-4o\",\"claude-3-5-sonnet\"]");
+
+        Set<String> set = favorites.toSet();
+
+        assertEquals(2, set.size());
+        assertTrue(set.contains("gpt-4o"));
+        assertTrue(set.contains("claude-3-5-sonnet"));
+    }
+
+    @Test
+    void toSet_returnsEmptySet_forCorruptedJson() {
+        fakeProps.setValue(KEY, "not valid json");
+
+        assertTrue(favorites.toSet().isEmpty());
+    }
+
+    @Test
+    void toSet_returnsEmptySet_forInvalidJsonType() {
+        // JSON is valid but not an array
+        fakeProps.setValue(KEY, "{\"key\": \"value\"}");
+
+        assertTrue(favorites.toSet().isEmpty());
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/util/ModelFavoritesTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/util/ModelFavoritesTest.java
@@ -6,6 +6,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import java.util.HashMap;
@@ -280,17 +282,12 @@ class ModelFavoritesTest {
         assertTrue(set.contains("claude-3-5-sonnet"));
     }
 
-    @Test
-    void toSet_returnsEmptySet_forCorruptedJson() {
-        fakeProps.setValue(KEY, "not valid json");
-
-        assertTrue(favorites.toSet().isEmpty());
-    }
-
-    @Test
-    void toSet_returnsEmptySet_forInvalidJsonType() {
-        // JSON is valid but not an array
-        fakeProps.setValue(KEY, "{\"key\": \"value\"}");
+    @ParameterizedTest
+    @ValueSource(strings = {"not valid json", "null", "{\"key\": \"value\"}"})
+    void toSet_returnsEmptySet_forUnparsableInput(String json) {
+        // "null" is valid JSON returning null (no exception) — ?: emptySet() guards against that.
+        // Corrupted JSON and wrong types are caught and return emptySet().
+        fakeProps.setValue(KEY, json);
 
         assertTrue(favorites.toSet().isEmpty());
     }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/util/ModelGrouperTest.kt
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/util/ModelGrouperTest.kt
@@ -76,13 +76,13 @@ class ModelGrouperTest {
             "m4" to "Beta/Model-D"
         )
 
-        // Favorites + Alpha + Beta + Zeta + Other
-        assertEquals(5, result.size)
-        assertEquals("Favorites", result[0].provider)
-        assertEquals("Alpha", result[1].provider)
-        assertEquals("Beta", result[2].provider)
-        assertEquals("Zeta", result[3].provider)
-        assertEquals("Other", result[4].provider)
+        // No favorites → Alpha + Beta + Zeta + Other (no Favorites group)
+        assertEquals(4, result.size)
+        assertEquals("Alpha", result[0].provider)
+        assertEquals("Beta", result[1].provider)
+        assertEquals("Zeta", result[2].provider)
+        assertEquals("Other", result[3].provider)
+        assertFalse(result.any { it.provider == "Favorites" })
     }
 
     // ── Test 5: displayName formatting ──────────────────────────────────
@@ -118,19 +118,19 @@ class ModelGrouperTest {
         assertEquals("Llama 3.1", groupedModel.displayName)
     }
 
-    // ── Test 6: Favorites group always present ──────────────────────────
+    // ── Test 6: Favorites group only when non-empty ──────────────────────
 
     @Test
-    fun `Favorites group is always present`() {
+    fun `Favorites group is absent when there are no favorites`() {
         val grouper = grouper()
         val result = grouper.groupModels(
             "m1" to "Nvidia/Llama 3.1"
         )
 
-        // Favorites (empty) + Nvidia
-        assertEquals(2, result.size)
-        assertEquals("Favorites", result[0].provider)
-        assertTrue(result[0].models.isEmpty())
+        // No favorites → only Nvidia group, no Favorites group
+        assertEquals(1, result.size)
+        assertEquals("Nvidia", result[0].provider)
+        assertFalse(result.any { it.provider == "Favorites" })
     }
 
     // ── Test 7: Single provider ─────────────────────────────────────────

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/util/ModelGrouperTest.kt
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/util/ModelGrouperTest.kt
@@ -1,0 +1,223 @@
+package com.github.catatafishen.agentbridge.ui.util
+
+import com.github.catatafishen.agentbridge.acp.model.Model
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class ModelGrouperTest {
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private fun model(id: String, name: String): Model =
+        Model(id, name, null, null)
+
+    private fun grouper(vararg favoriteIds: String): ModelGrouper =
+        ModelGrouper(favoriteIds.toSet())
+
+    private fun ModelGrouper.groupModels(vararg modelSpecs: Pair<String, String>): List<ModelGrouper.Group> {
+        val models = modelSpecs.map { (id, name) -> model(id, name) }
+        return this.group(models)
+    }
+
+    // ── Test 1: Empty list → empty result ───────────────────────────────
+
+    @Test
+    fun `empty list returns empty groups`() {
+        val grouper = grouper()
+        val result = grouper.group(emptyList())
+        assertTrue(result.isEmpty())
+    }
+
+    // ── Test 2: Favorited models go in Favorites group at top ───────────
+
+    @Test
+    fun `favorited models appear in Favorites group at top`() {
+        val grouper = grouper("model1", "model3")
+        val result = grouper.groupModels(
+            "model1" to "Nvidia/Llama 3.1",
+            "model2" to "OpenCode/Claude",
+            "model3" to "Anthropic/Claude"
+        )
+
+        // Favorites (2: model1 + model3) + OpenCode (model2) = 2 groups
+        assertEquals(2, result.size)
+        assertEquals("Favorites", result[0].provider)
+        assertEquals(2, result[0].models.size)
+        assertTrue(result[0].models.all { it.isFavorite })
+        assertEquals("OpenCode", result[1].provider)
+    }
+
+    // ── Test 3: Provider grouping ───────────────────────────────────────
+
+    @Test
+    fun `models with same provider are grouped together`() {
+        val grouper = grouper()
+        val result = grouper.groupModels(
+            "m1" to "Nvidia/Llama 3.1",
+            "m2" to "Nvidia/Llama 3.2",
+            "m3" to "OpenCode/Claude"
+        )
+
+        val nvidiaGroup = result.find { it.provider == "Nvidia" }
+        assertNotNull(nvidiaGroup)
+        assertEquals(2, nvidiaGroup!!.models.size)
+        assertTrue(nvidiaGroup.models.all { it.providerName == "Nvidia" })
+    }
+
+    // ── Test 4: Provider ordering — alphabetical, Other last ────────────
+
+    @Test
+    fun `providers are sorted alphabetically with Other last`() {
+        val grouper = grouper()
+        val result = grouper.groupModels(
+            "m1" to "Zeta/Model-A",
+            "m2" to "Alpha/Model-B",
+            "m3" to "NoSlashModel1",  // "Other"
+            "m4" to "Beta/Model-D"
+        )
+
+        // Favorites + Alpha + Beta + Zeta + Other
+        assertEquals(5, result.size)
+        assertEquals("Favorites", result[0].provider)
+        assertEquals("Alpha", result[1].provider)
+        assertEquals("Beta", result[2].provider)
+        assertEquals("Zeta", result[3].provider)
+        assertEquals("Other", result[4].provider)
+    }
+
+    // ── Test 5: displayName formatting ──────────────────────────────────
+
+    @Test
+    fun `displayName for favorite with providerName shows name with providerName in parentheses`() {
+        val grouper = grouper("m1")
+        val result = grouper.groupModels(
+            "m1" to "Nvidia/Llama 3.1"
+        )
+
+        val favGroup = result.find { it.provider == "Favorites" }
+        assertNotNull(favGroup)
+        assertEquals(1, favGroup!!.models.size)
+        val groupedModel = favGroup.models[0]
+        assertTrue(groupedModel.isFavorite)
+        assertEquals("Nvidia", groupedModel.providerName)
+        assertEquals("Llama 3.1 (Nvidia)", groupedModel.displayName)
+    }
+
+    @Test
+    fun `displayName for non-favorite shows just the name`() {
+        val grouper = grouper()
+        val result = grouper.groupModels(
+            "m1" to "Nvidia/Llama 3.1"
+        )
+
+        val nvidiaGroup = result.find { it.provider == "Nvidia" }
+        assertNotNull(nvidiaGroup)
+        val groupedModel = nvidiaGroup!!.models[0]
+        assertFalse(groupedModel.isFavorite)
+        assertEquals("Nvidia", groupedModel.providerName)
+        assertEquals("Llama 3.1", groupedModel.displayName)
+    }
+
+    // ── Test 6: Favorites group always present ──────────────────────────
+
+    @Test
+    fun `Favorites group is always present`() {
+        val grouper = grouper()
+        val result = grouper.groupModels(
+            "m1" to "Nvidia/Llama 3.1"
+        )
+
+        // Favorites (empty) + Nvidia
+        assertEquals(2, result.size)
+        assertEquals("Favorites", result[0].provider)
+        assertTrue(result[0].models.isEmpty())
+    }
+
+    // ── Test 7: Single provider ─────────────────────────────────────────
+
+    @Test
+    fun `single provider does not add Other group`() {
+        val grouper = grouper()
+        val result = grouper.groupModels(
+            "m1" to "Nvidia/Llama 3.1",
+            "m2" to "Nvidia/Llama 3.2"
+        )
+
+        val providers = result.map { it.provider }
+        assertFalse(providers.contains("Other"), "Should not have Other group with single provider")
+        assertTrue(providers.contains("Nvidia"))
+    }
+
+    // ── Test 8: Multiple providers mixed with favorites ─────────────────
+
+    @Test
+    fun `multiple providers with favorites maintains correct ordering`() {
+        val grouper = grouper("m2")
+        val result = grouper.groupModels(
+            "m1" to "Zeta/Model-A",
+            "m2" to "Nvidia/Llama 3.1",  // favorite
+            "m3" to "Alpha/Model-B"
+        )
+
+        // Favorites first, then providers alphabetically
+        assertEquals("Favorites", result[0].provider)
+        assertEquals(1, result[0].models.size)
+        assertEquals("m2", result[0].models[0].modelId)
+
+        // Provider groups: Alpha, Zeta (Nvidia model is in Favorites)
+        val providers = result.drop(1).map { it.provider }
+        assertEquals(listOf("Alpha", "Zeta"), providers)
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────────
+
+    @Test
+    fun `model without slash uses Other provider`() {
+        val grouper = grouper()
+        val result = grouper.groupModels(
+            "m1" to "GPT-4o"
+        )
+
+        val otherGroup = result.find { it.provider == "Other" }
+        assertNotNull(otherGroup)
+        assertEquals(1, otherGroup!!.models.size)
+    }
+
+    @Test
+    fun `model with leading slash uses Other provider`() {
+        val grouper = grouper()
+        val result = grouper.groupModels(
+            "m1" to "/LeadingSlash"
+        )
+
+        val otherGroup = result.find { it.provider == "Other" }
+        assertNotNull(otherGroup)
+    }
+
+    @Test
+    fun `null model name uses id as fallback`() {
+        val grouper = grouper()
+        val modelWithNullName = Model("model-id", null, null, null)
+        val result = grouper.group(listOf(modelWithNullName))
+
+        val otherGroup = result.find { it.provider == "Other" }
+        assertNotNull(otherGroup)
+        assertEquals(1, otherGroup!!.models.size)
+        assertEquals("model-id", otherGroup.models[0].name)
+    }
+
+    @Test
+    fun `indexes are preserved from original list`() {
+        val grouper = grouper()
+        val result = grouper.groupModels(
+            "m0" to "First",
+            "m1" to "Second",
+            "m2" to "Third"
+        )
+
+        val otherGroup = result.find { it.provider == "Other" }
+        assertNotNull(otherGroup)
+        val indexes = otherGroup!!.models.map { it.index }
+        assertEquals(listOf(0, 1, 2), indexes)
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/util/ModelProviderTest.kt
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/util/ModelProviderTest.kt
@@ -1,0 +1,102 @@
+package com.github.catatafishen.agentbridge.ui.util
+
+import com.github.catatafishen.agentbridge.acp.model.Model
+import com.google.gson.JsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class ModelProviderTest {
+
+    // ── getProvider ────────────────────────────────────────────────────
+
+    @Test
+    fun getProvider_slashSeparatedName_returnsProviderPrefix() {
+        val model = Model("nvidia/llama-3.1-nemotron", "Nvidia/Llama 3.1 Nemotron", null, null)
+        assertEquals("Nvidia", ModelProvider.getProvider(model))
+    }
+
+    @Test
+    fun getProvider_multiSlash_returnsFirstSegment() {
+        val model = Model("opencode/gpt-plus/variant", "OpenCode/GPT Plus/Variant", null, null)
+        assertEquals("OpenCode", ModelProvider.getProvider(model))
+    }
+
+    @Test
+    fun getProvider_noSlash_returnsNull() {
+        val model = Model("gpt-4o", "GPT-4o", null, null)
+        assertNull(ModelProvider.getProvider(model))
+    }
+
+    @Test
+    fun getProvider_nullName_returnsNull() {
+        val model = Model("some-id", null, null, null)
+        assertNull(ModelProvider.getProvider(model))
+    }
+
+    @Test
+    fun getProvider_leadingSlash_returnsNull() {
+        // slash at position 0 means no provider prefix
+        val model = Model("/LeadingSlash", "/LeadingSlash", null, null)
+        assertNull(ModelProvider.getProvider(model))
+    }
+
+    @Test
+    fun getProvider_emptyName_returnsNull() {
+        val model = Model("some-id", "", null, null)
+        assertNull(ModelProvider.getProvider(model))
+    }
+
+    @Test
+    fun getProvider_metaProviderNotUsed() {
+        // _meta.provider is ignored by the implementation; it uses only model.name()
+        val meta = JsonObject().apply { addProperty("provider", "ShouldNotBeUsed") }
+        val model = Model("some-id", "Actual/Provider", null, meta)
+        assertEquals("Actual", ModelProvider.getProvider(model))
+    }
+
+    // ── getModelName ──────────────────────────────────────────────────
+
+    @Test
+    fun getModelName_slashSeparated_returnsSuffixAfterSlash() {
+        val model = Model("nvidia/llama-3.1-nemotron", "Nvidia/Llama 3.1 Nemotron", null, null)
+        assertEquals("Llama 3.1 Nemotron", ModelProvider.getModelName(model))
+    }
+
+    @Test
+    fun getModelName_multiSlash_returnsAfterFirstSlash() {
+        val model = Model("opencode/gpt-plus/variant", "OpenCode/GPT Plus/Variant", null, null)
+        assertEquals("GPT Plus/Variant", ModelProvider.getModelName(model))
+    }
+
+    @Test
+    fun getModelName_noSlash_returnsFullName() {
+        val model = Model("gpt-4o", "GPT-4o", null, null)
+        assertEquals("GPT-4o", ModelProvider.getModelName(model))
+    }
+
+    @Test
+    fun getModelName_nullName_returnsId() {
+        val model = Model("fallback-id-123", null, null, null)
+        assertEquals("fallback-id-123", ModelProvider.getModelName(model))
+    }
+
+    @Test
+    fun getModelName_emptyName_returnsEmptyString() {
+        val model = Model("fallback-id-456", "", null, null)
+        assertEquals("", ModelProvider.getModelName(model))
+    }
+
+    @Test
+    fun getModelName_slashWithNoSuffix_returnsEmptyString() {
+        // slash at end of name — substring after it is empty
+        val model = Model("provider/", "Provider/", null, null)
+        assertEquals("", ModelProvider.getModelName(model))
+    }
+
+    @Test
+    fun getModelName_trimsWhitespaceAfterSlash() {
+        val model = Model("openai/ GPT-4o", "OpenAI/ GPT-4o", null, null)
+        assertEquals("GPT-4o", ModelProvider.getModelName(model))
+    }
+}


### PR DESCRIPTION
Problem:
When using opencode with multiple providers models can get lost and be difficult to find. 

<img width="496" height="685" alt="plain models" src="https://github.com/user-attachments/assets/dbae0f82-3ae2-45c7-aa55-b3667598c0b1" />

Solution:

Models are now grouped by provider and can be favorited:

<img width="342" height="440" alt="models-grouped-favs" src="https://github.com/user-attachments/assets/d39ee8b4-9f52-4e7b-9a75-fa13168a4f66" />

This was only changed for opencode as we tend to have multiple providers as opposed to using copilot, however same treatment could also be applied to Kiro and Hermes but I don't use those tools and don't feel confident applying the same feature to them.

--------------------------
Introduce a provider-grouped model picker with favorites support and persistence. Adds ModelPickerPopup UI plus pure-logic helpers: ModelGrouper, ModelProvider and ModelFavorites (stored via PropertiesComponent). ChatToolWindowContent now uses the grouped popup when the agent supports model grouping and wires selection/favorite toggles to settings/session handling. AbstractAgentClient gains supportsModelGrouping() (default false) and OpenCodeClient opts in (returns true). Includes keyboard navigation, collapsible provider sections and persisted expand/collapse state.