### PR TITLE
fix: secure ClusterFuzzLite fork PR workflow with explicit approval gate

### DIFF
--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -15,6 +15,7 @@ jobs:
   BatchFuzzing:
     name: ClusterFuzzLite Batch
     runs-on: ubuntu-latest
+    environment: fuzzing
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -15,6 +15,7 @@ jobs:
   Pruning:
     name: ClusterFuzzLite Corpus Pruning
     runs-on: ubuntu-latest
+    environment: fuzzing
     permissions:
       contents: read
     steps:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -73,7 +73,11 @@ jobs:
     environment: fuzzing-gate
     steps:
       - name: Approval received
-        run: echo "Maintainer approved fuzzing fork PR ${{ github.event.pull_request.number }} from ${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: echo "Maintainer approved fuzzing fork PR $PR_NUMBER from $HEAD_REPO@$HEAD_SHA"
 
   PR:
     name: ClusterFuzzLite PR

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -49,10 +49,36 @@ jobs:
 
           > This comment is posted automatically whenever ClusterFuzzLite is triggered on a fork PR."
 
+  # For fork PRs, this job acts as the explicit approval gate.
+  # It requires a maintainer to approve the 'ci' environment deployment before proceeding.
+  #
+  # IMPORTANT: The 'ci' environment MUST be configured with required reviewers in the
+  # repository settings (Settings → Environments → ci → Required reviewers). Without
+  # that setting, this job — and therefore the fuzzer — will run automatically for fork
+  # PRs with no approval, defeating the entire security model.
+  fork-approval-gate:
+    name: Maintainer approval gate (fork PR)
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    # The environment gate: requires a maintainer to click "Approve and deploy" before
+    # this job (and the dependent PR fuzzing job) can proceed.
+    # Requires 'ci' environment to have required reviewers configured — see comment above.
+    environment: ci
+    steps:
+      - name: Approval received
+        run: echo "Maintainer approved fuzzing fork PR ${{ github.event.pull_request.number }} from ${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}"
+
   PR:
     name: ClusterFuzzLite PR
+    # For fork PRs: wait for maintainer approval via fork-approval-gate.
+    # For same-repo PRs: fork-approval-gate is skipped (result == 'skipped'), run directly.
+    needs: [fork-approval-gate]
+    if: |
+      always() && (
+        needs.fork-approval-gate.result == 'success' ||
+        needs.fork-approval-gate.result == 'skipped'
+      )
     runs-on: ubuntu-latest
-    environment: ci
     concurrency:
       # Use PR number to isolate each PR's concurrency group. With pull_request_target,
       # github.ref is always the base branch (refs/heads/master), so using github.ref
@@ -74,9 +100,9 @@ jobs:
         with:
           egress-policy: audit
 
-      # Intentionally checks out fork code to fuzz it. The `environment: ci` gate above
-      # requires maintainer approval before this runs. The warn-fork-fuzz job posts a
-      # security review reminder on the PR so approvers know to review the code first.
+      # Intentionally checks out fork code to fuzz it. The fork-approval-gate job above
+      # requires maintainer approval before this runs for fork PRs. The warn-fork-fuzz
+      # job posts a security review reminder on the PR so approvers know to review first.
       #
       # Why this is an accepted risk rather than a fixable issue:
       #   Fuzzing by definition requires executing the code under test. Unlike SonarQube
@@ -85,14 +111,6 @@ jobs:
       #   requirement. The environment gate + explicit reviewer warning is therefore the
       #   strongest practical mitigation available.
       #
-      #   The environment gate is a stronger safeguard than a regular PR approval because:
-      #   (a) it is a distinct, less common action that specifically prompts the reviewer
-      #   to ask "why is this requiring separate approval?", and (b) the warn-fork-fuzz
-      #   job posts an explicit security checklist before the gate can be triggered.
-      #   A maintainer who rubber-stamps the environment gate without reading that warning
-      #   is no less careful than one who merges a PR without review — and such a reviewer
-      #   would represent a process failure, not a workflow design failure.
-      #
       #   CFLITE_STORAGE_REPO_TOKEN scope (fine-grained PAT):
       #     Repository:   catatafishen/agentbridge-cflite-storage (only)
       #     Permissions:  Read access to metadata
@@ -100,7 +118,7 @@ jobs:
       #   Even if a malicious fork PR exfiltrates this token, the blast radius is limited
       #   to the fuzz corpus storage repository — not the main codebase.
       #
-      # NOSONAR: S7631 — mitigated by environment gate + explicit reviewer warning
+      # NOSONAR: S7631 — mitigated by fork-approval-gate job + explicit reviewer warning
       # zizmor: ignore[pull-request-target]
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 NOSONAR
         with:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -50,24 +50,27 @@ jobs:
           > This comment is posted automatically whenever ClusterFuzzLite is triggered on a fork PR."
 
   # For fork PRs, this job acts as the explicit approval gate.
-  # It requires a maintainer to approve the 'fuzzing' environment deployment before proceeding.
+  # It requires a maintainer to approve the 'fuzzing-gate' environment deployment before proceeding.
   #
-  # Because this job only runs for fork PRs (see `if` condition below), the 'fuzzing'
+  # Because this job only runs for fork PRs (see `if` condition below), the 'fuzzing-gate'
   # environment effectively requires approval for forks only — same-repo PRs never reach
   # this job and are never subject to the environment gate.
   #
-  # IMPORTANT: The 'fuzzing' environment MUST be configured with required reviewers in the
-  # repository settings (Settings → Environments → fuzzing → Required reviewers). Without
-  # that setting, this job — and therefore the fuzzer — will run automatically for fork
-  # PRs with no approval, defeating the entire security model.
+  # Environment layout:
+  #   fuzzing-gate — required reviewers, no secrets (approval mechanism only)
+  #   fuzzing      — CFLITE_STORAGE_REPO_TOKEN, no required reviewers (secret store)
+  #
+  # IMPORTANT: The 'fuzzing-gate' environment MUST be configured with required reviewers
+  # (Settings → Environments → fuzzing-gate → Required reviewers). Without that setting,
+  # this job runs automatically for fork PRs with no approval, defeating the security model.
   fork-approval-gate:
     name: Maintainer approval gate (fork PR)
     if: github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     # The environment gate: requires a maintainer to click "Approve and deploy" before
     # this job (and the dependent PR fuzzing job) can proceed.
-    # Requires 'fuzzing' environment to have required reviewers configured — see comment above.
-    environment: fuzzing
+    # Requires 'fuzzing-gate' environment to have required reviewers — see comment above.
+    environment: fuzzing-gate
     steps:
       - name: Approval received
         run: echo "Maintainer approved fuzzing fork PR ${{ github.event.pull_request.number }} from ${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}"
@@ -76,7 +79,7 @@ jobs:
     name: ClusterFuzzLite PR
     # For fork PRs: wait for maintainer approval via fork-approval-gate.
     # For same-repo PRs: fork-approval-gate is skipped (result == 'skipped'), run directly.
-    needs: [fork-approval-gate]
+    needs: [ fork-approval-gate ]
     if: |
       always() && (
         needs.fork-approval-gate.result == 'success' ||
@@ -91,6 +94,9 @@ jobs:
       # cancelling stale runs within the same PR when new commits are pushed.
       group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
+    # Provides access to CFLITE_STORAGE_REPO_TOKEN (stored in the 'fuzzing' environment).
+    # No required reviewers on this environment — fork PRs are gated by fork-approval-gate above.
+    environment: fuzzing
     permissions:
       contents: read
       security-events: write
@@ -137,7 +143,8 @@ jobs:
           language: jvm
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sanitizer: ${{ matrix.sanitizer }}
-          # CFLITE_STORAGE_REPO_TOKEN: fine-grained PAT scoped to catatafishen/agentbridge-cflite-storage only.
+          # CFLITE_STORAGE_REPO_TOKEN: stored in the 'fuzzing' environment (not a repo secret).
+          # Fine-grained PAT scoped to catatafishen/agentbridge-cflite-storage only.
           # Permissions: Read access to metadata; Read and Write access to code.
           # Blast radius if exfiltrated: write access to the fuzz corpus repo only — not the main codebase.
           storage-repo: https://${{ secrets.CFLITE_STORAGE_REPO_TOKEN }}@github.com/catatafishen/agentbridge-cflite-storage.git

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -71,6 +71,7 @@ jobs:
     # this job (and the dependent PR fuzzing job) can proceed.
     # Requires 'fuzzing-gate' environment to have required reviewers — see comment above.
     environment: fuzzing-gate
+    permissions: {}
     steps:
       - name: Approval received
         env:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -50,10 +50,14 @@ jobs:
           > This comment is posted automatically whenever ClusterFuzzLite is triggered on a fork PR."
 
   # For fork PRs, this job acts as the explicit approval gate.
-  # It requires a maintainer to approve the 'ci' environment deployment before proceeding.
+  # It requires a maintainer to approve the 'fuzzing' environment deployment before proceeding.
   #
-  # IMPORTANT: The 'ci' environment MUST be configured with required reviewers in the
-  # repository settings (Settings → Environments → ci → Required reviewers). Without
+  # Because this job only runs for fork PRs (see `if` condition below), the 'fuzzing'
+  # environment effectively requires approval for forks only — same-repo PRs never reach
+  # this job and are never subject to the environment gate.
+  #
+  # IMPORTANT: The 'fuzzing' environment MUST be configured with required reviewers in the
+  # repository settings (Settings → Environments → fuzzing → Required reviewers). Without
   # that setting, this job — and therefore the fuzzer — will run automatically for fork
   # PRs with no approval, defeating the entire security model.
   fork-approval-gate:
@@ -62,8 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     # The environment gate: requires a maintainer to click "Approve and deploy" before
     # this job (and the dependent PR fuzzing job) can proceed.
-    # Requires 'ci' environment to have required reviewers configured — see comment above.
-    environment: ci
+    # Requires 'fuzzing' environment to have required reviewers configured — see comment above.
+    environment: fuzzing
     steps:
       - name: Approval received
         run: echo "Maintainer approved fuzzing fork PR ${{ github.event.pull_request.number }} from ${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -71,7 +71,7 @@ jobs:
     # this job (and the dependent PR fuzzing job) can proceed.
     # Requires 'fuzzing-gate' environment to have required reviewers — see comment above.
     environment: fuzzing-gate
-    permissions: {}
+    permissions: { }
     steps:
       - name: Approval received
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
     # plugin-core-only PR).
     if: github.event_name == 'push' || needs.changes.outputs.mcp_server == 'true'
     runs-on: ubuntu-latest
-    environment: ci
     permissions:
       contents: read
     steps:
@@ -128,7 +127,6 @@ jobs:
     # nor chat-ui sources changed (e.g. docs-only or workflow-only PR).
     if: github.event_name == 'push' || needs.changes.outputs.java == 'true' || needs.changes.outputs.chat_ui == 'true'
     runs-on: ubuntu-latest
-    environment: ci
     permissions:
       contents: read
     steps:
@@ -244,7 +242,6 @@ jobs:
     needs: [ changes ]
     if: github.event_name == 'push' || needs.changes.outputs.java == 'true'
     runs-on: ubuntu-latest
-    environment: ci
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Problem

The `ci` environment had no protection rules, making `environment: ci` on the fuzzer job a no-op. Fork PRs triggered the fuzzer immediately with full access to `CFLITE_STORAGE_REPO_TOKEN` — no approval needed.

## Fix

Three-layer defense:

1. **New `fork-approval-gate` job** — only runs for fork PRs (`github.event.pull_request.head.repo.fork == true`). Uses `environment: fuzzing-gate` (required reviewer: catatafishen). A maintainer must click **Approve and deploy** before fuzzing proceeds.

2. **Secrets moved to dedicated environment** — `CFLITE_STORAGE_REPO_TOKEN` is now in the `fuzzing` environment (not a repo secret), so it is only accessible to jobs that explicitly declare `environment: fuzzing`. Batch and cron fuzzing jobs updated accordingly.

3. **`environment: ci` removed from `ci.yml`** — prevents normal CI from being accidentally gated if required reviewers are ever added to `ci`.

## Security fix

Fixes code injection via template expansion in the approval echo step (reported by zizmor): moved `${{ github.event.pull_request.head.repo.full_name }}` out of the `run:` shell command into `env:` vars.

## Environments configured

- `fuzzing-gate`: required reviewer = catatafishen, `can_admins_bypass: false`
- `fuzzing`: holds `CFLITE_STORAGE_REPO_TOKEN`, no required reviewers