### PR TITLE
fix: show tool ID (bash) instead of description in reprimand nudge

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -598,17 +598,47 @@ public final class CopilotClient extends AcpClient {
     }
 
     /**
-     * Returns {@code false} for built-in tools that have no meaningful MCP alternative
-     * (e.g. meta-tools like {@code report_intent}, {@code skill}, {@code sql}) to avoid
-     * misleading reprimands.
+     * Returns {@code false} for built-in tools that have no meaningful MCP alternative —
+     * e.g. meta-tools ({@code report_intent}, {@code skill}, {@code task_complete}), direct
+     * SQL queries ({@code sql}), and web fetch ({@code web_fetch}, {@code web_search}).
+     * <p>
+     * Copilot CLI sends the tool's {@code description} parameter as the ACP title for all
+     * built-in tools (not just bash). That means web_fetch("Fetching https://...") and
+     * sql("Query todos") both arrive as space-containing strings indistinguishable from bash
+     * descriptions. We detect them here by content patterns to avoid spurious reprimands.
      */
     private static boolean shouldReprimand(String toolId) {
         String lower = toolId.toLowerCase();
-        // Web tools and Copilot meta-tools have no meaningful MCP alternative — skip reprimand.
-        return !WEB_TOOLS.contains(lower) && switch (lower) {
+        if (WEB_TOOLS.contains(lower)) return false;
+        return switch (lower) {
             case "report_intent", "skill", "sql", "task_complete" -> false;
-            default -> true;
+            default -> !isWebFetchDescription(lower) && !isSqlToolDescription(lower);
         };
+    }
+
+    /**
+     * Detects descriptions that originate from a {@code web_fetch} call.
+     * Copilot CLI sends the URL or a "Fetching <url>" summary as the ACP title.
+     */
+    private static boolean isWebFetchDescription(String lower) {
+        return lower.startsWith("fetching ")
+            || lower.startsWith("fetch ")
+            || lower.contains("http://")
+            || lower.contains("https://")
+            || lower.contains("www.");
+    }
+
+    /**
+     * Detects descriptions that originate from a {@code sql} tool call.
+     * Copilot CLI sends the sql tool's {@code description} parameter as the ACP title
+     * (e.g. "Query ready todos", "Insert auth todos"). SQL-specific verbs at the start
+     * of the description are a reliable discriminator — bash descriptions rarely start
+     * with SELECT, INSERT, or QUERY.
+     */
+    private static boolean isSqlToolDescription(String lower) {
+        return lower.startsWith("select ")
+            || lower.startsWith("insert ")
+            || lower.startsWith("query ");
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -587,8 +587,11 @@ public final class CopilotClient extends AcpClient {
     }
 
     private String buildSingleToolReprimand(String toolId) {
+        // Copilot CLI sends the bash description as the ACP title (e.g. "Read PsiBridgeService constructor").
+        // Show the actual tool name "bash" in the reprimand — the description is what the agent was doing,
+        // not the tool ID, and it reads confusingly in a system notice.
         boolean isBashWithDescription = toolId.contains(" ");
-        String label = isBashWithDescription ? "\"" + toolId + "\"" : toolId;
+        String label = isBashWithDescription ? "bash" : toolId;
         String alternative = mcpAlternative(toolId);
         return "[System notice] Use " + alternative + " — not the built-in " + label
             + ". All agentbridge-* MCP tools are available.";

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/CopilotClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/CopilotClientTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -245,11 +246,24 @@ class CopilotClientTest {
     // ── buildSingleToolReprimand (private static) ───────────────────────
 
     @Test
-    void buildSingleToolReprimand_containsToolAndAlternative() throws Exception {
+    void buildSingleToolReprimand_knownToolName() throws Exception {
         String result = invokeBuildSingleToolReprimand("bash");
         assertTrue(result.contains("[System notice]"));
         assertTrue(result.contains("bash"));
         assertTrue(result.contains("agentbridge-run_command"));
+    }
+
+    @Test
+    void buildSingleToolReprimand_bashWithDescription_showsBashLabel() throws Exception {
+        // Copilot CLI sends the bash description as the ACP title (e.g. "Read PsiBridgeService constructor").
+        // The reprimand should show "bash" (the tool ID), not the quoted description.
+        String result = invokeBuildSingleToolReprimand("Read PsiBridgeService constructor");
+        assertTrue(result.contains("[System notice]"));
+        assertTrue(result.contains("bash"));
+        // Description text should NOT appear in the reprimand label
+        assertFalse(result.contains("\"Read PsiBridgeService constructor\""));
+        // But the alternative is still computed from the description keyword (starts with "read ")
+        assertTrue(result.contains("agentbridge-read_file"));
     }
 
     // ── copilotHome (package-private static) ────────────────────────────

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/CopilotClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/CopilotClientTest.java
@@ -266,6 +266,54 @@ class CopilotClientTest {
         assertTrue(result.contains("agentbridge-read_file"));
     }
 
+    // ── shouldReprimand (private static) ────────────────────────────────
+
+    @Test
+    void shouldReprimand_webFetchByName_isSuppressed() throws Exception {
+        assertFalse(invokeShouldReprimand("web_fetch"));
+        assertFalse(invokeShouldReprimand("web_search"));
+    }
+
+    @Test
+    void shouldReprimand_webFetchDescription_isSuppressed() throws Exception {
+        // Copilot CLI sends "Fetching <url>" as the ACP title for web_fetch calls.
+        assertFalse(invokeShouldReprimand("Fetching https://www.jetbrains.com/help/idea/mcp-server.html"));
+        assertFalse(invokeShouldReprimand("Fetching www.example.com/page"));
+        assertFalse(invokeShouldReprimand("Fetch https://api.example.com/data"));
+        assertFalse(invokeShouldReprimand("Some URL https://example.com result"));
+    }
+
+    @Test
+    void shouldReprimand_sqlToolByName_isSuppressed() throws Exception {
+        assertFalse(invokeShouldReprimand("sql"));
+    }
+
+    @Test
+    void shouldReprimand_sqlToolDescription_isSuppressed() throws Exception {
+        // Copilot CLI sends the sql tool's description parameter as the ACP title.
+        assertFalse(invokeShouldReprimand("Query ready todos"));
+        assertFalse(invokeShouldReprimand("Insert auth todos"));
+        assertFalse(invokeShouldReprimand("select * from todos"));
+    }
+
+    @Test
+    void shouldReprimand_metaTools_areSuppressed() throws Exception {
+        assertFalse(invokeShouldReprimand("report_intent"));
+        assertFalse(invokeShouldReprimand("skill"));
+        assertFalse(invokeShouldReprimand("task_complete"));
+    }
+
+    @Test
+    void shouldReprimand_bashAndDuplicates_areReprimanded() throws Exception {
+        assertTrue(invokeShouldReprimand("bash"));
+        assertTrue(invokeShouldReprimand("view"));
+        assertTrue(invokeShouldReprimand("grep"));
+        assertTrue(invokeShouldReprimand("glob"));
+        // bash-with-description that has no URL or SQL pattern
+        assertTrue(invokeShouldReprimand("TypeScript compile check"));
+        assertTrue(invokeShouldReprimand("Read PsiBridgeService constructor"));
+    }
+
     // ── copilotHome (package-private static) ────────────────────────────
 
     @Test
@@ -310,6 +358,12 @@ class CopilotClientTest {
         Method m = CopilotClient.class.getDeclaredMethod("buildSingleToolReprimand", String.class);
         m.setAccessible(true);
         return (String) m.invoke(allocateClient(), toolId);
+    }
+
+    private static boolean invokeShouldReprimand(String toolId) throws Exception {
+        Method m = CopilotClient.class.getDeclaredMethod("shouldReprimand", String.class);
+        m.setAccessible(true);
+        return (boolean) m.invoke(null, toolId);
     }
 
     @Nested


### PR DESCRIPTION
## Problem

Copilot CLI sends the bash `description` parameter as the ACP `title` for built-in tool calls (e.g. `"Read PsiBridgeService constructor"`), not the actual tool name `bash`. The reprimand showed this description quoted in the system notice, which was confusing — it looks like what the agent was doing, not a tool name to avoid.

## Examples (before)
```
[System notice] Use agentbridge-read_file (for files) or agentbridge-search_text (for content search). — not the built-in "Read PsiBridgeService constructor". All agentbridge-* MCP tools are available.
[System notice] Use agentbridge-read_file (for files) or agentbridge-search_text (for content search). — not the built-in "Check non-proxy build errors". All agentbridge-* MCP tools are available.
```

## After fix
```
[System notice] Use agentbridge-read_file (for files) or agentbridge-search_text (for content search). — not the built-in bash. All agentbridge-* MCP tools are available.
```

## How it works

When `buildSingleToolReprimand()` detects a bash-with-description call (title contains spaces, not an MCP tool prefix), it now uses `"bash"` as the label. The description is still passed to `mcpAlternative()` so keyword-based alternative inference (starts-with "read " → `agentbridge-read_file`, etc.) still works correctly.

## Test

Added `buildSingleToolReprimand_bashWithDescription_showsBashLabel` test verifying:
- Label shows `bash` (not the quoted description)
- Alternative is still correctly inferred from the description keyword