### PR TITLE
fix: nudge ? button escapes to chat top-right corner + paste IndexOutOfBoundsException

### DIFF
--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -1042,6 +1042,10 @@ const ChatController = {
         el.classList.add('nudge-sent');
         el.querySelector('.nudge-label')?.remove();
         el.querySelector('.nudge-cancel-x')?.remove();
+        // Remove the info button: once resolved, nudge-pending is gone so message-bubble
+        // loses position:relative and the absolutely-positioned ? button escapes to the
+        // chat container's top-right corner.
+        el.querySelector('.nudge-info-btn')?.remove();
     },
 
     removeNudgeBubble(id: string): void {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -2293,7 +2293,13 @@ class ChatToolWindowContent(
 
                 ApplicationManager.getApplication().invokeLater {
                     com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction(project) {
-                        editor.document.deleteString(offset, offset + trigger.length)
+                        val doc = editor.document
+                        val end = offset + trigger.length
+                        // Guard against stale offset: the document may have changed between
+                        // documentChanged() and this invokeLater callback (e.g. pasting a large block).
+                        if (end <= doc.textLength && doc.getText(com.intellij.openapi.util.TextRange(offset, end)) == trigger) {
+                            doc.deleteString(offset, end)
+                        }
                     }
                     contextManager.openFileSearchPopup()
                 }


### PR DESCRIPTION
## Two bugs fixed

### 1. Nudge ? button stays in chat top-right corner after nudge resolves

**Root cause:** `.nudge-info-btn` uses `position: absolute` and is contained by `.nudge-pending message-bubble`, which has `position: relative`. When `resolveNudgeBubble()` fires, the `nudge-pending` class is removed — taking `position: relative` off the bubble with it. The absolutely-positioned `?` button then anchors to the nearest positioned ancestor (the chat container), appearing in the top-right corner and persisting there.

**Fix:** Remove `.nudge-info-btn` in `resolveNudgeBubble()` alongside the existing `.nudge-cancel-x` and `.nudge-label` removals. The info button is only needed while the nudge is pending.

### 2. `IndexOutOfBoundsException: Wrong endOffset` when pasting into prompt

```
java.lang.IndexOutOfBoundsException: Wrong endOffset: 450; documentLength: 449
    at ChatToolWindowContent$registerTriggerCharDetection$1.documentChanged$lambda$0$0(ChatToolWindowContent.kt:2296)
```

**Root cause:** The trigger-char detection listener captures `offset` in `documentChanged()` then uses it in an async `invokeLater()` callback. When the user pastes a block of text, the document changes again before the callback runs, making `offset + trigger.length > textLength`.

**Fix:** Re-validate bounds and confirm the text at `[offset, end)` is still the trigger character before deleting. Silently skip if stale.