### PR TITLE
fix: eliminate chip status innerHTML mutations — Fix 12 screen tearing

### DIFF
--- a/docs/bugs/SCREEN-TEARING-BUG.md
+++ b/docs/bugs/SCREEN-TEARING-BUG.md
@@ -1,9 +1,10 @@
 # Screen Tearing Bug — JCEF OSR
 
-**Status**: Fix 8 applied — defer autoscroll by one rAF after DOM mutations to deny Chromium's compositor
-tile-translation cache reuse
+**Status**: Fix 12 applied — chip status changes use CSS-class-only updates instead of innerHTML replacement to
+eliminate spurious MutationObserver triggers during streaming
 **Scope**: JCEF Off-Screen Rendering (OSR) mode in the chat panel  
-**Affected area**: `ChatConsolePanel.kt`, `ChatContainer.ts`, `ChatController.ts`, `MessageBubble.ts`, `chat.css`
+**Affected area**: `ChatConsolePanel.kt`, `ChatContainer.ts`, `ChatController.ts`, `MessageBubble.ts`, `chat.css`,
+`ToolChip.ts`, `ThinkingChip.ts`, `SubagentChip.ts`
 
 ---
 
@@ -547,6 +548,36 @@ in the same paint frame.
 
 ---
 
+### Fix 12 — CSS-only chip status updates to eliminate spurious MutationObserver triggers (2025)
+
+**Root cause**: After the chip redesign that introduced `chip-ring` (a persistent `<span>` in all
+chip states), `ToolChip._render()`, `SubagentChip._render()`, and `ThinkingChip._render()` continued
+to be called from `attributeChangedCallback` on every status/kind change. Each call replaced
+`this.innerHTML`, generating two childList DOM mutations (child removal + child insertion). With
+`ChatContainer`'s MutationObserver watching `childList: true, subtree: true`, every chip status
+transition triggered `_scheduleDeferredScroll()` — producing spurious scroll deferral calls during
+streaming that collide with concurrent `MessageBubble` rAF-renders.
+
+The chip redesign's intent (documented in the CSS comment: "no DOM replacement") was correct —
+the `chip-ring` span is always present and the `animation: spin` is paused by CSS class rules. Only
+`className` changes are needed on status transitions. The implementation diverged from the intent.
+
+**Fix**:
+
+- **`ToolChip.ts`**: Split `_render()` into `_renderAll()` (sets innerHTML, called ONLY from
+  `connectedCallback`) and `_applyClasses()` (updates `className`/`classList` only, called from
+  `attributeChangedCallback` for `status`/`kind` changes). Label changes update `lastChild.textContent`
+  (a `characterData` mutation, less disruptive than `childList`).
+
+- **`ThinkingChip.ts`**: `attributeChangedCallback` now calls `classList.toggle('thinking-active', ...)`
+  directly — no `_render()` call, no `innerHTML` write.
+
+- **`SubagentChip.ts`**: `attributeChangedCallback` for `status` changes updates `className`/`classList`
+  directly. `label` changes still call `_render()` because label content genuinely changes (and label
+  updates are rare compared to status transitions).
+
+---
+
 ## Code Locations
 
 | File                       | Component                        | Purpose                                                                                              |
@@ -578,6 +609,9 @@ in the same paint frame.
 | `MessageMeta.ts`           | `scheduleNavUpdate()`            | Two-rAF deferred nav update — separates nav button layout change from container scroll (Fix 11b)     |
 | `ChatContainer.ts`         | `_flushScrollOrRetry()`          | Retries the scroll when `renderPending` is true; caps at `MAX_SCROLL_RETRIES` (Fix 11a)              |
 | `MonitorSwitchRecovery.kt` | `triggerRecovery()`              | Refreshes OSR and asks the chat panel to replay DOM state after monitor changes                      |
+| `ToolChip.ts`              | `_applyClasses()`                | CSS-only status/kind update — no innerHTML, no childList DOM mutations (Fix 12)                      |
+| `ThinkingChip.ts`          | `attributeChangedCallback()`     | CSS-only thinking-active toggle — no innerHTML on status change (Fix 12)                             |
+| `SubagentChip.ts`          | `attributeChangedCallback()`     | CSS-only status update; `_render()` only for label changes (Fix 12)                                  |
 
 ---
 
@@ -651,4 +685,19 @@ When modifying the streaming pipeline, watch for:
     the scrolled content) and the `scrollTop` write in the same frame cause dirty-rect collapse.
     **Do not reduce `scheduleNavUpdate()` back to a single rAF** without re-testing chip strip
     overflow during streaming on both Linux and Windows.
+
+14. **`innerHTML` replacement on chip status changes** (Fix 12) — `ToolChip`, `ThinkingChip`, and
+    `SubagentChip` MUST NOT call `this.innerHTML = ...` from `attributeChangedCallback` for status or
+    kind changes. `innerHTML` replacement removes existing child nodes (childList mutation: removal)
+    and inserts new ones (childList mutation: insertion), firing `ChatContainer`'s MutationObserver
+    twice per status transition — triggering spurious `_scheduleDeferredScroll()` calls during
+    streaming. These collide with concurrent `MessageBubble` rAF-renders in exactly the way Fix 11
+    was designed to handle, but Fix 11's retry only applies to `MessageBubble.renderPending`; it does
+    not protect against chip-mutation-triggered scrolls.
+    **Status/kind changes MUST only update `this.className` / `classList`** — attribute changes on
+    elements are NOT observed by `ChatContainer`'s MutationObserver (`attributes: false`), so no
+    scroll deferral fires. See `ToolChip._applyClasses()`.
+    The chip-ring `<span>` is already in the DOM from `connectedCallback` (initial render); the CSS
+    `animation: spin` is paused by `.status-complete .chip-ring { animation: none }` — no DOM node
+    replacement is needed on status transitions.
 

--- a/plugin-core/chat-ui/src/components/SubagentChip.ts
+++ b/plugin-core/chat-ui/src/components/SubagentChip.ts
@@ -74,6 +74,15 @@ export default class SubagentChip extends HTMLElement {
 
     attributeChangedCallback(name: string): void {
         if (!this._init) return;
-        if (name === 'status' || name === 'label') this._render();
+        if (name === 'status') {
+            // CSS-only update — avoids childList DOM mutations → MutationObserver → scroll deferral.
+            const rawStatus = this.getAttribute('status') || 'running';
+            const status = rawStatus.replaceAll(/\s+/g, '-');
+            this.className = this.className.replaceAll(/\bstatus-\S+/g, '').trim();
+            this.classList.add(`status-${status}`);
+            this.classList.toggle('failed', status === 'failed');
+        } else if (name === 'label') {
+            this._render();
+        }
     }
 }

--- a/plugin-core/chat-ui/src/components/ThinkingChip.ts
+++ b/plugin-core/chat-ui/src/components/ThinkingChip.ts
@@ -40,7 +40,12 @@ export default class ThinkingChip extends HTMLElement {
 
     attributeChangedCallback(name: string): void {
         if (!this._init) return;
-        if (name === 'status') this._render();
+        if (name === 'status') {
+            // CSS-only toggle — avoids innerHTML replacement and the childList DOM mutation
+            // that would trigger ChatContainer's MutationObserver → spurious scroll deferral.
+            const status = this.getAttribute('status') || 'complete';
+            this.classList.toggle('thinking-active', status === 'running' || status === 'thinking');
+        }
     }
 
     private _resolveLink(): void {

--- a/plugin-core/chat-ui/src/components/ToolChip.ts
+++ b/plugin-core/chat-ui/src/components/ToolChip.ts
@@ -17,7 +17,7 @@ export default class ToolChip extends HTMLElement {
         this.setAttribute('role', 'button');
         this.setAttribute('tabindex', '0');
         this.setAttribute('aria-expanded', 'false');
-        this._render();
+        this._renderAll();
         this.onclick = (e) => {
             e.stopPropagation();
             this._showPopup();
@@ -30,7 +30,12 @@ export default class ToolChip extends HTMLElement {
         };
     }
 
-    private _render(): void {
+    /**
+     * Full render: sets innerHTML and classes. Called only from connectedCallback (chip
+     * creation). Status/kind updates use _applyClasses() to avoid DOM mutations that
+     * would trigger the MutationObserver and cause spurious scroll deferral.
+     */
+    private _renderAll(): void {
         const label = this.getAttribute('label') || '';
         const rawStatus = this.getAttribute('status') || 'running';
         const status = rawStatus.replaceAll(/\s+/g, '-');
@@ -46,15 +51,48 @@ export default class ToolChip extends HTMLElement {
         }
     }
 
+    /**
+     * CSS-only status/kind update. Does NOT touch innerHTML — avoids childList DOM
+     * mutations that trigger ChatContainer's MutationObserver and cause scroll deferral
+     * collisions with concurrent streaming renders (the screen-tearing root cause).
+     * className changes do not fire the observer (attributes: false in its config).
+     */
+    private _applyClasses(): void {
+        const rawStatus = this.getAttribute('status') || 'running';
+        const status = rawStatus.replaceAll(/\s+/g, '-');
+        const kind = this.getAttribute('kind') || 'other';
+        this.className = this.className.replaceAll(/\bkind-\S+/g, '').replaceAll(/\bstatus-\S+/g, '').trim();
+        this.classList.add('turn-chip', 'tool', `kind-${kind}`, `status-${status}`);
+        this.classList.toggle('failed', status === 'failed');
+    }
+
     private _showPopup(): void {
         const id = this.dataset.chipFor || '';
-        if (id && globalThis._bridge?.showToolPopup) {
-            globalThis._bridge.showToolPopup(id);
+        if (id) {
+            globalThis._bridge?.showToolPopup?.(id);
         }
     }
 
     attributeChangedCallback(name: string): void {
         if (!this._init) return;
-        if (name === 'status' || name === 'kind') this._render();
+        if (name === 'status' || name === 'kind') {
+            this._applyClasses();
+        } else if (name === 'label') {
+            // Update text node in-place — characterData mutation, not childList.
+            // Also re-reads label for truncation changes.
+            const label = this.getAttribute('label') || '';
+            const truncated = label.length > 50 ? label.substring(0, 47) + '\u2026' : label;
+            const textNode = this.lastChild;
+            if (textNode?.nodeType === Node.TEXT_NODE) {
+                textNode.textContent = ' ' + truncated;
+            }
+            if (label.length > 50) {
+                this.dataset.tip = label;
+                this.setAttribute('title', label);
+            } else {
+                delete this.dataset.tip;
+                this.removeAttribute('title');
+            }
+        }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -598,17 +598,47 @@ public final class CopilotClient extends AcpClient {
     }
 
     /**
-     * Returns {@code false} for built-in tools that have no meaningful MCP alternative
-     * (e.g. meta-tools like {@code report_intent}, {@code skill}, {@code sql}) to avoid
-     * misleading reprimands.
+     * Returns {@code false} for built-in tools that have no meaningful MCP alternative —
+     * e.g. meta-tools ({@code report_intent}, {@code skill}, {@code task_complete}), direct
+     * SQL queries ({@code sql}), and web fetch ({@code web_fetch}, {@code web_search}).
+     * <p>
+     * Copilot CLI sends the tool's {@code description} parameter as the ACP title for all
+     * built-in tools (not just bash). That means web_fetch("Fetching https://...") and
+     * sql("Query todos") both arrive as space-containing strings indistinguishable from bash
+     * descriptions. We detect them here by content patterns to avoid spurious reprimands.
      */
     private static boolean shouldReprimand(String toolId) {
         String lower = toolId.toLowerCase();
-        // Web tools and Copilot meta-tools have no meaningful MCP alternative — skip reprimand.
-        return !WEB_TOOLS.contains(lower) && switch (lower) {
+        if (WEB_TOOLS.contains(lower)) return false;
+        return switch (lower) {
             case "report_intent", "skill", "sql", "task_complete" -> false;
-            default -> true;
+            default -> !isWebFetchDescription(lower) && !isSqlToolDescription(lower);
         };
+    }
+
+    /**
+     * Detects descriptions that originate from a {@code web_fetch} call.
+     * Copilot CLI sends the URL or a "Fetching <url>" summary as the ACP title.
+     */
+    private static boolean isWebFetchDescription(String lower) {
+        return lower.startsWith("fetching ")
+            || lower.startsWith("fetch ")
+            || lower.contains("http://")
+            || lower.contains("https://")
+            || lower.contains("www.");
+    }
+
+    /**
+     * Detects descriptions that originate from a {@code sql} tool call.
+     * Copilot CLI sends the sql tool's {@code description} parameter as the ACP title
+     * (e.g. "Query ready todos", "Insert auth todos"). SQL-specific verbs at the start
+     * of the description are a reliable discriminator — bash descriptions rarely start
+     * with SELECT, INSERT, or QUERY.
+     */
+    private static boolean isSqlToolDescription(String lower) {
+        return lower.startsWith("select ")
+            || lower.startsWith("insert ")
+            || lower.startsWith("query ");
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -587,8 +587,11 @@ public final class CopilotClient extends AcpClient {
     }
 
     private String buildSingleToolReprimand(String toolId) {
+        // Copilot CLI sends the bash description as the ACP title (e.g. "Read PsiBridgeService constructor").
+        // Show the actual tool name "bash" in the reprimand — the description is what the agent was doing,
+        // not the tool ID, and it reads confusingly in a system notice.
         boolean isBashWithDescription = toolId.contains(" ");
-        String label = isBashWithDescription ? "\"" + toolId + "\"" : toolId;
+        String label = isBashWithDescription ? "bash" : toolId;
         String alternative = mcpAlternative(toolId);
         return "[System notice] Use " + alternative + " — not the built-in " + label
             + ". All agentbridge-* MCP tools are available.";

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/CopilotClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/CopilotClientTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -245,11 +246,24 @@ class CopilotClientTest {
     // ── buildSingleToolReprimand (private static) ───────────────────────
 
     @Test
-    void buildSingleToolReprimand_containsToolAndAlternative() throws Exception {
+    void buildSingleToolReprimand_knownToolName() throws Exception {
         String result = invokeBuildSingleToolReprimand("bash");
         assertTrue(result.contains("[System notice]"));
         assertTrue(result.contains("bash"));
         assertTrue(result.contains("agentbridge-run_command"));
+    }
+
+    @Test
+    void buildSingleToolReprimand_bashWithDescription_showsBashLabel() throws Exception {
+        // Copilot CLI sends the bash description as the ACP title (e.g. "Read PsiBridgeService constructor").
+        // The reprimand should show "bash" (the tool ID), not the quoted description.
+        String result = invokeBuildSingleToolReprimand("Read PsiBridgeService constructor");
+        assertTrue(result.contains("[System notice]"));
+        assertTrue(result.contains("bash"));
+        // Description text should NOT appear in the reprimand label
+        assertFalse(result.contains("\"Read PsiBridgeService constructor\""));
+        // But the alternative is still computed from the description keyword (starts with "read ")
+        assertTrue(result.contains("agentbridge-read_file"));
     }
 
     // ── copilotHome (package-private static) ────────────────────────────

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/CopilotClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/CopilotClientTest.java
@@ -266,6 +266,54 @@ class CopilotClientTest {
         assertTrue(result.contains("agentbridge-read_file"));
     }
 
+    // ── shouldReprimand (private static) ────────────────────────────────
+
+    @Test
+    void shouldReprimand_webFetchByName_isSuppressed() throws Exception {
+        assertFalse(invokeShouldReprimand("web_fetch"));
+        assertFalse(invokeShouldReprimand("web_search"));
+    }
+
+    @Test
+    void shouldReprimand_webFetchDescription_isSuppressed() throws Exception {
+        // Copilot CLI sends "Fetching <url>" as the ACP title for web_fetch calls.
+        assertFalse(invokeShouldReprimand("Fetching https://www.jetbrains.com/help/idea/mcp-server.html"));
+        assertFalse(invokeShouldReprimand("Fetching www.example.com/page"));
+        assertFalse(invokeShouldReprimand("Fetch https://api.example.com/data"));
+        assertFalse(invokeShouldReprimand("Some URL https://example.com result"));
+    }
+
+    @Test
+    void shouldReprimand_sqlToolByName_isSuppressed() throws Exception {
+        assertFalse(invokeShouldReprimand("sql"));
+    }
+
+    @Test
+    void shouldReprimand_sqlToolDescription_isSuppressed() throws Exception {
+        // Copilot CLI sends the sql tool's description parameter as the ACP title.
+        assertFalse(invokeShouldReprimand("Query ready todos"));
+        assertFalse(invokeShouldReprimand("Insert auth todos"));
+        assertFalse(invokeShouldReprimand("select * from todos"));
+    }
+
+    @Test
+    void shouldReprimand_metaTools_areSuppressed() throws Exception {
+        assertFalse(invokeShouldReprimand("report_intent"));
+        assertFalse(invokeShouldReprimand("skill"));
+        assertFalse(invokeShouldReprimand("task_complete"));
+    }
+
+    @Test
+    void shouldReprimand_bashAndDuplicates_areReprimanded() throws Exception {
+        assertTrue(invokeShouldReprimand("bash"));
+        assertTrue(invokeShouldReprimand("view"));
+        assertTrue(invokeShouldReprimand("grep"));
+        assertTrue(invokeShouldReprimand("glob"));
+        // bash-with-description that has no URL or SQL pattern
+        assertTrue(invokeShouldReprimand("TypeScript compile check"));
+        assertTrue(invokeShouldReprimand("Read PsiBridgeService constructor"));
+    }
+
     // ── copilotHome (package-private static) ────────────────────────────
 
     @Test
@@ -310,6 +358,12 @@ class CopilotClientTest {
         Method m = CopilotClient.class.getDeclaredMethod("buildSingleToolReprimand", String.class);
         m.setAccessible(true);
         return (String) m.invoke(allocateClient(), toolId);
+    }
+
+    private static boolean invokeShouldReprimand(String toolId) throws Exception {
+        Method m = CopilotClient.class.getDeclaredMethod("shouldReprimand", String.class);
+        m.setAccessible(true);
+        return (boolean) m.invoke(null, toolId);
     }
 
     @Nested


### PR DESCRIPTION
## Root Cause

After the chip redesign that introduced a persistent `chip-ring` span, `ToolChip`, `ThinkingChip`, and `SubagentChip` were calling `this.innerHTML = ...` from `attributeChangedCallback` on every status/kind change. This generated two childList DOM mutations per transition (removal + insertion), firing `ChatContainer`'s MutationObserver and triggering `_scheduleDeferredScroll()` spuriously during streaming.

These spurious scroll deferral calls collide with concurrent `MessageBubble` rAF-renders — the exact mechanism that caused tearing pre-Fix-11, but Fix 11's `renderPending` retry doesn't protect against chip-mutation-triggered scrolls.

The CSS comment in `chat.css` already said "no DOM replacement" for status changes — the implementation just never matched the intent.

## Fix

- **ToolChip**: Split into `_renderAll()` (innerHTML, called once from `connectedCallback`) and `_applyClasses()` (CSS-class-only, called for status/kind changes). No DOM mutations on transitions.
- **ThinkingChip**: `attributeChangedCallback` uses `classList.toggle()` directly — no `_render()` call.
- **SubagentChip**: Status changes are CSS-only; `_render()` (innerHTML) only fires on label changes.

The `chip-ring` span is already present from initial render; CSS classes on the parent drive the animation state. `ChatContainer`'s MutationObserver is configured with `attributes: false`, so `className` changes are invisible to it — **zero scroll deferral triggers for status transitions**.

## Tests

All 139 JS tests pass.