### PR TITLE
feat: add acpName for proper tool name vs display title distinction

### DIFF
--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -397,9 +397,8 @@ working-indicator .working-text {
     font-size: 0.92em;
     white-space: nowrap;
     flex-shrink: 0;
-    /* Timestamps always appear on their own line below chips */
+    /* Timestamps always appear on their own line above chips */
     flex-basis: 100%;
-    order: 99;
     margin-top: 1px;
 }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
@@ -165,6 +165,11 @@ public abstract class AcpClient extends AbstractAgentClient {
             }
 
             @Override
+            public @Nullable String resolveAcpName(@NotNull String rawTitle, @Nullable String kind) {
+                return AcpClient.this.resolveAcpName(rawTitle, kind);
+            }
+
+            @Override
             public @Nullable JsonObject parseToolCallArguments(@NotNull JsonObject p) {
                 return AcpClient.this.parseToolCallArguments(p);
             }
@@ -1072,6 +1077,17 @@ public abstract class AcpClient extends AbstractAgentClient {
      */
     protected String resolveToolId(String protocolTitle) {
         return protocolTitle;
+    }
+
+    /**
+     * Resolve a canonical tool name from the raw protocol title and kind.
+     * <p>
+     * For MCP-bridged tools, returns the stripped MCP name (e.g., "read_file").
+     * For native/built-in tools, returns the {@code kind} value (e.g., "read", "execute").
+     * Subclasses may override to recognize additional built-in tool names.
+     */
+    protected @Nullable String resolveAcpName(@NotNull String rawTitle, @Nullable String kind) {
+        return kind;
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParser.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParser.java
@@ -52,6 +52,14 @@ class AcpMessageParser {
         @Nullable JsonObject parseToolCallArguments(@NotNull JsonObject params);
 
         /**
+         * Resolve a canonical tool name from the raw protocol title and kind.
+         * For MCP tools, returns the stripped MCP name (e.g., "read_file").
+         * For known built-in tools, returns the tool name (e.g., "bash").
+         * For unknown native tools, returns the kind (e.g., "read", "execute").
+         */
+        @Nullable String resolveAcpName(@NotNull String rawTitle, @Nullable String kind);
+
+        /**
          * Detect sub-agent invocations and return the agent type, or {@code null} if this is not
          * a sub-agent call.
          */
@@ -128,6 +136,9 @@ class AcpMessageParser {
             kind = SessionUpdate.ToolKind.fromString(params.get("kind").getAsString());
         }
 
+        String kindValue = kind != null ? kind.value() : null;
+        String acpName = delegate.resolveAcpName(title, kindValue);
+
         JsonObject argumentsObj = delegate.parseToolCallArguments(params);
         String arguments = argumentsObj != null ? argumentsObj.toString() : null;
 
@@ -152,7 +163,7 @@ class AcpMessageParser {
             subAgentPrompt = argumentsObj.has("prompt") ? argumentsObj.get("prompt").getAsString() : null;
         }
 
-        return new SessionUpdate.ToolCall(toolCallId, resolvedTitle, kind, arguments, locations, agentType, subAgentDesc, subAgentPrompt, null);
+        return new SessionUpdate.ToolCall(toolCallId, resolvedTitle, acpName, kind, arguments, locations, agentType, subAgentDesc, subAgentPrompt, null);
     }
 
     private SessionUpdate.ToolCallUpdate parseToolCallUpdate(JsonObject params) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -14,6 +14,7 @@ import com.github.catatafishen.agentbridge.ui.NudgeSource;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -316,6 +317,18 @@ public final class CopilotClient extends AcpClient {
     }
 
     @Override
+    protected @Nullable String resolveAcpName(@NotNull String rawTitle, @Nullable String kind) {
+        if (rawTitle.startsWith(MCP_TOOL_PREFIX)) {
+            return rawTitle.substring(MCP_TOOL_PREFIX.length());
+        }
+        String lower = rawTitle.toLowerCase();
+        if (KNOWN_BUILTIN_TOOL_NAMES.contains(lower)) {
+            return lower;
+        }
+        return kind;
+    }
+
+    @Override
     protected boolean isMcpToolTitle(@org.jetbrains.annotations.NotNull String protocolTitle) {
         if (protocolTitle.startsWith(MCP_TOOL_PREFIX)) {
             return true;
@@ -558,7 +571,6 @@ public final class CopilotClient extends AcpClient {
     protected SessionUpdate processUpdate(SessionUpdate update) {
         if (update instanceof SessionUpdate.ToolCall toolCall && !toolCall.isSubAgent()) {
             String title = toolCall.title();
-            // Built-in detection: known names (grep, view, bash…) or bash-with-description (has spaces).
             boolean isBuiltIn = KNOWN_BUILTIN_TOOL_NAMES.contains(title.toLowerCase())
                 || (title.contains(" ") && !title.startsWith(MCP_TOOL_PREFIX));
             if (isBuiltIn && shouldReprimand(title)) {
@@ -566,7 +578,8 @@ public final class CopilotClient extends AcpClient {
                     com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance().getReprimandNudgeMode();
                 if (mode != com.github.catatafishen.agentbridge.settings.ChatInputSettings.ReprimandNudgeMode.DISABLED) {
                     boolean showBubble = mode == com.github.catatafishen.agentbridge.settings.ChatInputSettings.ReprimandNudgeMode.ENABLED;
-                    AgentNudgeService.getInstance(project).addNudge(buildSingleToolReprimand(title), NudgeSource.NATIVE_TOOL_REPRIMAND, showBubble);
+                    String kind = toolCall.kind() != null ? toolCall.kind().value() : "unknown";
+                    AgentNudgeService.getInstance(project).addNudge(buildReprimand(kind), NudgeSource.NATIVE_TOOL_REPRIMAND, showBubble);
                 }
             }
         }
@@ -586,12 +599,8 @@ public final class CopilotClient extends AcpClient {
         return request;
     }
 
-    private String buildSingleToolReprimand(String toolId) {
-        boolean isBashWithDescription = toolId.contains(" ");
-        String label = isBashWithDescription ? "\"" + toolId + "\"" : toolId;
-        String alternative = mcpAlternative(toolId);
-        return "[System notice] Use " + alternative + " — not the built-in " + label
-            + ". All agentbridge-* MCP tools are available.";
+    private static String buildReprimand(String kind) {
+        return "You used native " + kind + " tools. Use Agentbridge MCP tools instead.";
     }
 
     /**
@@ -626,35 +635,5 @@ public final class CopilotClient extends AcpClient {
     @Override
     protected boolean isAutoDenyEnabled() {
         return false;
-    }
-
-    @Override
-    protected String mcpAlternative(String toolId) {
-        // Copilot CLI sends the bash `description` as the protocol title; descriptions contain spaces.
-        if (toolId.contains(" ")) {
-            return bashDescriptionAlternative(toolId.toLowerCase());
-        }
-        return super.mcpAlternative(toolId);
-    }
-
-    /**
-     * Infers the best MCP alternative from the human-readable bash description.
-     * Copilot CLI sends the {@code description} parameter as the ACP title for bash calls,
-     * so we never know the literal tool name — only what the agent said it was doing.
-     */
-    private static String bashDescriptionAlternative(String lowerDesc) {
-        if (lowerDesc.startsWith("write ") || lowerDesc.startsWith("create ") || lowerDesc.startsWith("save ")) {
-            return "agentbridge-write_file (for existing files) or agentbridge-create_file (for new files)"
-                + " — these write through the IDE editor buffer and stay in sync with IntelliJ."
-                + " Never use shell redirection (cat >, tee, heredocs) to write project files.";
-        }
-        if (lowerDesc.startsWith("find ") || lowerDesc.startsWith("search ") || lowerDesc.startsWith("grep ")) {
-            return "agentbridge-search_text or agentbridge-search_symbols — these are IDE-integrated and semantic-aware.";
-        }
-        if (lowerDesc.startsWith("read ") || lowerDesc.startsWith("get ") || lowerDesc.startsWith("check ")) {
-            return "agentbridge-read_file (for files) or agentbridge-search_text (for content search).";
-        }
-        return "agentbridge-run_command for shell commands, agentbridge-write_file for file writes,"
-            + " or agentbridge-search_text for searches.";
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/KiroClient.java
@@ -387,7 +387,7 @@ public final class KiroClient extends AcpClient {
         String purpose = extractPurposeFromArgs(tc.arguments());
         if (purpose != null) {
             return new SessionUpdate.ToolCall(
-                tc.toolCallId(), tc.title(), tc.kind(), tc.arguments(),
+                tc.toolCallId(), tc.title(), tc.acpName(), tc.kind(), tc.arguments(),
                 tc.locations(), tc.agentType(), tc.subAgentDescription(),
                 tc.subAgentPrompt(), purpose
             );

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/model/SessionUpdate.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/model/SessionUpdate.java
@@ -194,7 +194,8 @@ public sealed interface SessionUpdate
      * A new tool call initiated by the agent.
      *
      * @param toolCallId          unique ID correlating with {@link ToolCallUpdate}
-     * @param title               normalised tool name (MCP prefix stripped)
+     * @param title               display title reported by the protocol (for UI display only)
+     * @param acpName             canonical tool name: MCP name for bridged tools, kind for native tools
      * @param kind                functional category for UI chip styling
      * @param arguments           serialised JSON string of the tool arguments, or null if empty
      * @param locations           file locations extracted from the tool event
@@ -206,6 +207,7 @@ public sealed interface SessionUpdate
     record ToolCall(
         @NotNull String toolCallId,
         @NotNull String title,
+        @Nullable String acpName,
         @Nullable ToolKind kind,
         @Nullable String arguments,
         @Nullable List<Location> locations,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/claude/AbstractClaudeAgentClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/claude/AbstractClaudeAgentClient.java
@@ -139,7 +139,7 @@ abstract class AbstractClaudeAgentClient extends AbstractAgentClient {
             }
         }
         onUpdate.accept(new SessionUpdate.ToolCall(
-            toolUseId, normalized, kind, args, null,
+            toolUseId, normalized, normalized, kind, args, null,
             agentType, subAgentDesc, subAgentPrompt, null));
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/codex/CodexAppServerClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/codex/CodexAppServerClient.java
@@ -1252,7 +1252,7 @@ public final class CodexAppServerClient extends AbstractAgentClient {
             ToolDefinition def = registry.findById(toolName);
             if (def != null) kind = SessionUpdate.ToolKind.fromCategory(def.category());
         }
-        cb.accept(new SessionUpdate.ToolCall(id, toolName, kind, args.toString(), null, null, null, null, null));
+        cb.accept(new SessionUpdate.ToolCall(id, toolName, toolName, kind, args.toString(), null, null, null, null, null));
     }
 
     private void emitMcpToolCallEnd(@NotNull JsonObject item, @NotNull Consumer<SessionUpdate> cb) {
@@ -1272,7 +1272,7 @@ public final class CodexAppServerClient extends AbstractAgentClient {
     private void emitNativeCommandItem(@NotNull JsonObject item, @NotNull Consumer<SessionUpdate> cb) {
         String id = item.has(F_ID) ? item.get(F_ID).getAsString() : UUID.randomUUID().toString();
         String cmd = item.has(F_COMMAND) ? item.get(F_COMMAND).getAsString() : "shell";
-        cb.accept(new SessionUpdate.ToolCall(id, "shell_command", SessionUpdate.ToolKind.OTHER,
+        cb.accept(new SessionUpdate.ToolCall(id, "shell_command", "shell_command", SessionUpdate.ToolKind.OTHER,
             buildCommandArgsJson(cmd), null, null, null, null, null));
         cb.accept(new SessionUpdate.ToolCallUpdate(id, SessionUpdate.ToolCallStatus.FAILED,
             null, "Declined: native shell execution is not permitted. Use MCP tools instead.", null));
@@ -1300,7 +1300,7 @@ public final class CodexAppServerClient extends AbstractAgentClient {
         String chipId = UUID.randomUUID().toString();
         Consumer<SessionUpdate> cb = activeTurnCallback.get();
         if (cb != null) {
-            cb.accept(new SessionUpdate.ToolCall(chipId, "ask_user", SessionUpdate.ToolKind.OTHER,
+            cb.accept(new SessionUpdate.ToolCall(chipId, "ask_user", "ask_user", SessionUpdate.ToolKind.OTHER,
                 toolArgs.toString(), null, null, null, null, null));
         }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpProtocolHandler.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpProtocolHandler.java
@@ -590,7 +590,8 @@ public final class McpProtocolHandler {
                 System.currentTimeMillis() - callStartMs, !isError);
 
             enrichConversationDb(new ToolCallEnrichmentData(
-                toolUseId, inputJson, fullResult, durationMs, !isError,
+                toolUseId, toolName, displayName, originalArguments,
+                inputJson, fullResult, durationMs, !isError,
                 isError ? resultText : null, kind, hookStages));
 
             return buildToolResult(msg, fullResult, isError);
@@ -608,7 +609,8 @@ public final class McpProtocolHandler {
                 System.currentTimeMillis() - callStartMs, !isError);
 
             enrichConversationDb(new ToolCallEnrichmentData(
-                toolUseId, inputJson, finalOutput, durationMs, false,
+                toolUseId, toolName, displayName, originalArguments,
+                inputJson, finalOutput, durationMs, false,
                 e.getMessage(), kind, hookStages));
 
             return buildToolResult(msg, finalOutput, isError);
@@ -619,6 +621,9 @@ public final class McpProtocolHandler {
 
     private record ToolCallEnrichmentData(
         @Nullable String toolUseId,
+        @NotNull String toolName,
+        @Nullable String displayName,
+        @NotNull JsonObject arguments,
         @NotNull String inputJson,
         @Nullable String output,
         long durationMs,
@@ -630,15 +635,24 @@ public final class McpProtocolHandler {
     }
 
     private void enrichConversationDb(@NotNull ToolCallEnrichmentData data) {
-        if (data.toolUseId() == null) return;
+        // Resolve the record to get the stable DB event_id (= record.recordId).
+        // Fallback: toolUseId lookup → MCP tool+args match → skip if neither succeeds.
+        ToolCallTracker tracker = ToolCallTracker.getInstance(project);
+        ToolCallRecord record = tracker.findByToolUseId(data.toolUseId());
+        if (record == null) {
+            record = tracker.findByMcpCall(data.toolName(), data.arguments());
+        }
+        String dbEventId = record != null ? record.getRecordId() : data.toolUseId();
+        if (dbEventId == null) return;
+
         ConversationService service = ConversationService.getInstance(project);
         long inputSize = data.inputJson().getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
         long outputSize = data.output() != null
             ? data.output().getBytes(java.nio.charset.StandardCharsets.UTF_8).length : 0;
-        service.enrichToolCallStats(data.toolUseId(), inputSize, outputSize, data.durationMs(),
-            data.success(), data.errorMessage(), data.category());
+        service.enrichToolCallStats(dbEventId, inputSize, outputSize, data.durationMs(),
+            data.success(), data.errorMessage(), data.category(), data.displayName());
         if (!data.hookStages().isEmpty()) {
-            service.recordHookStages(data.toolUseId(), data.hookStages());
+            service.recordHookStages(dbEventId, data.hookStages());
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallRecord.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallRecord.java
@@ -69,6 +69,7 @@ public final class ToolCallRecord {
     // ── ACP-side (set when ACP reports) ──────────────────────────────────────
 
     private @Nullable String acpClientId;
+    private @Nullable String acpName;
     private @Nullable String acpTitle;
     private @Nullable JsonObject acpArgs;
     private @NotNull RoutingType routingType = RoutingType.REGULAR;
@@ -121,12 +122,14 @@ public final class ToolCallRecord {
 
     void setAcpFields(
         @NotNull String acpClientId,
+        @Nullable String acpName,
         @NotNull String acpTitle,
         @Nullable JsonObject acpArgs,
         @NotNull RoutingType routingType,
         int acpSequence
     ) {
         this.acpClientId = acpClientId;
+        this.acpName = acpName;
         this.acpTitle = acpTitle;
         this.acpArgs = acpArgs;
         this.routingType = routingType;
@@ -211,6 +214,10 @@ public final class ToolCallRecord {
     // ACP-side
     public @Nullable String getAcpClientId() {
         return acpClientId;
+    }
+
+    public @Nullable String getAcpName() {
+        return acpName;
     }
 
     public @Nullable String getAcpTitle() {
@@ -312,10 +319,12 @@ public final class ToolCallRecord {
     }
 
     /**
-     * The best available tool name — MCP is authoritative, falls back to ACP title.
+     * The best available tool name — MCP is authoritative, then ACP canonical name,
+     * then falls back to ACP title.
      */
     public @NotNull String getEffectiveToolName() {
         if (mcpToolName != null) return mcpToolName;
+        if (acpName != null) return acpName;
         if (acpTitle != null) return acpTitle;
         return "unknown";
     }
@@ -324,6 +333,7 @@ public final class ToolCallRecord {
     public String toString() {
         return "ToolCallRecord{" + recordId +
             ", acp=" + acpClientId +
+            ", acpName=" + acpName +
             ", mcp=" + mcpToolName +
             ", state=" + state +
             ", routing=" + routingType +

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallTracker.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallTracker.java
@@ -136,7 +136,8 @@ public final class ToolCallTracker {
      * Called when ACP reports a new tool call ({@code tool_call} notification).
      *
      * @param acpClientId the ACP-assigned tool call ID
-     * @param acpTitle    the display title reported by the protocol (may be imprecise)
+     * @param acpName     canonical tool name (MCP name for bridged tools, kind for native tools), or null
+     * @param acpTitle    the display title reported by the protocol (always a display string, never a tool name)
      * @param args        tool arguments (may be null for some agents like Junie)
      * @param kind        tool category (e.g. "file", "git") or null
      * @param routingType the call's role: REGULAR, SUB_AGENT, SUB_AGENT_INTERNAL, TASK_COMPLETE
@@ -145,6 +146,7 @@ public final class ToolCallTracker {
      */
     public synchronized @NotNull ToolCallRecord acpRegister(
         @NotNull String acpClientId,
+        @Nullable String acpName,
         @NotNull String acpTitle,
         @Nullable JsonObject args,
         @Nullable String kind,
@@ -159,7 +161,7 @@ public final class ToolCallTracker {
             if (existingRecordId != null) {
                 ToolCallRecord record = liveRecords.get(existingRecordId);
                 if (record != null && record.getAcpClientId() == null) {
-                    record.setAcpFields(acpClientId, acpTitle, args, routingType, seq);
+                    record.setAcpFields(acpClientId, acpName, acpTitle, args, routingType, seq);
                     acpIdToRecordId.put(acpClientId, existingRecordId);
                     LOG.info("ToolCallTracker [ACP]: correlated via toolUseId=" + toolUseId + " → " + existingRecordId);
                     fireOnCorrelated(record);
@@ -173,7 +175,7 @@ public final class ToolCallTracker {
             String argsHash = ToolCallHasher.computeBaseHash(args);
             ToolCallRecord mcpFirst = findNewestUnmatchedMcpRecord(argsHash);
             if (mcpFirst != null) {
-                mcpFirst.setAcpFields(acpClientId, acpTitle, args, routingType, seq);
+                mcpFirst.setAcpFields(acpClientId, acpName, acpTitle, args, routingType, seq);
                 acpIdToRecordId.put(acpClientId, mcpFirst.getRecordId());
                 if (toolUseId != null) toolUseIdToRecordId.put(toolUseId, mcpFirst.getRecordId());
                 LOG.info("ToolCallTracker [ACP]: correlated via hash=" + argsHash + " → " + mcpFirst.getRecordId());
@@ -187,14 +189,14 @@ public final class ToolCallTracker {
         String argsHash = args != null ? ToolCallHasher.computeBaseHash(args) : null;
         String recordId = allocateRecordId(argsHash);
         ToolCallRecord record = new ToolCallRecord(recordId, argsHash);
-        record.setAcpFields(acpClientId, acpTitle, args, routingType, seq);
+        record.setAcpFields(acpClientId, acpName, acpTitle, args, routingType, seq);
         if (kind != null) record.setKind(kind);
 
         liveRecords.put(recordId, record);
         acpIdToRecordId.put(acpClientId, recordId);
         if (toolUseId != null) toolUseIdToRecordId.put(toolUseId, recordId);
 
-        LOG.info("ToolCallTracker [ACP]: new record " + recordId + " title=" + acpTitle + " routing=" + routingType);
+        LOG.info("ToolCallTracker [ACP]: new record " + recordId + " name=" + acpName + " title=" + acpTitle + " routing=" + routingType);
         fireOnAcpRegistered(record);
         return record;
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/ConversationReader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/ConversationReader.java
@@ -452,23 +452,29 @@ public final class ConversationReader {
     ) throws SQLException {
         try (PreparedStatement ps = conn.prepareStatement("""
             SELECT tool_name, arguments, tool_kind, result, status, file_path,
-                   auto_denied, denial_reason, display_name
+                   auto_denied, denial_reason, is_mcp
             FROM tool_call_events WHERE event_id = ?
             """)) {
             ps.setString(1, eventId);
             try (ResultSet rs = ps.executeQuery()) {
                 if (!rs.next()) return null;
+                String toolName = rs.getString(1);
+                // Derive pluginTool from is_mcp + tool_name.
+                // Old rows: tool_name may still carry the ACP prefix ("agentbridge-read_file") →
+                // stripMcpPrefix normalises them. New rows already store the canonical name.
+                Integer isMcp = (Integer) rs.getObject(9);
+                String pluginTool = (isMcp != null && isMcp == 1) ? stripMcpPrefix(toolName) : null;
                 return new EntryData.ToolCall(
-                    rs.getString(1),  // title = tool_name
-                    rs.getString(2),  // arguments
+                    toolName,          // title = canonical tool name
+                    rs.getString(2),   // arguments
                     nullToEmpty(rs.getString(3)),  // kind
-                    rs.getString(4),  // result
-                    rs.getString(5),  // status
-                    null,             // description
-                    rs.getString(6),  // filePath
+                    rs.getString(4),   // result
+                    rs.getString(5),   // status
+                    null,              // description
+                    rs.getString(6),   // filePath
                     rs.getInt(7) == 1, // autoDenied
-                    rs.getString(8),  // denialReason
-                    rs.getString(9),  // pluginTool = display_name
+                    rs.getString(8),   // denialReason
+                    pluginTool,        // from is_mcp + tool_name
                     timestamp, agent, model, eventId
                 );
             }
@@ -639,6 +645,19 @@ public final class ConversationReader {
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Strips the ACP client prefix from a tool name to get the canonical MCP name.
+     * Handles both dash (Copilot/Junie) and underscore (OpenCode) prefix styles.
+     * Already-canonical names pass through unchanged.
+     */
+    @NotNull
+    private static String stripMcpPrefix(@NotNull String toolName) {
+        int dash = toolName.indexOf('-');
+        if (dash >= 0) return toolName.substring(dash + 1);
+        if (toolName.startsWith("agentbridge_")) return toolName.substring("agentbridge_".length());
+        return toolName;
+    }
 
     @NotNull
     private static String nullToEmpty(@Nullable String value) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/ConversationService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/ConversationService.java
@@ -385,13 +385,26 @@ public final class ConversationService implements Disposable {
      * Enriches an existing tool-call event row with performance stats.
      * Best-effort — silently returns if the writer is unavailable.
      */
+    @SuppressWarnings("java:S107")
+    // All 8 parameters map to distinct DB columns; a wrapper adds indirection without clarity.
     public void enrichToolCallStats(@NotNull String toolEventId, long inputSize, long outputSize,
                                     long durationMs, boolean success, @Nullable String errorMessage,
-                                    @Nullable String category) {
+                                    @Nullable String category, @Nullable String displayName) {
         ConversationWriter writer = getOrCreateWriter();
         if (writer == null) return;
         writer.enrichToolCallStats(toolEventId, inputSize, outputSize, durationMs,
-            success, errorMessage, category);
+            success, errorMessage, category, displayName);
+    }
+
+    /**
+     * Marks a tool-call event as non-MCP (ACP-only) if it was previously unknown (NULL).
+     * Called when ACP completes a tool call that was never correlated with an MCP execution.
+     * Best-effort — silently returns if the writer is unavailable.
+     */
+    public void markToolCallNonMcp(@NotNull String eventId) {
+        ConversationWriter writer = getOrCreateWriter();
+        if (writer == null) return;
+        writer.markToolCallNonMcp(eventId);
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/ConversationWriter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/ConversationWriter.java
@@ -449,32 +449,56 @@ public final class ConversationWriter {
     ) throws SQLException {
         try (PreparedStatement ps = conn.prepareStatement("""
             INSERT OR IGNORE INTO tool_call_events (
-                event_id, tool_name, tool_kind, client_id, display_name,
-                arguments, result, status, file_path, auto_denied, denial_reason, is_mcp
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                event_id, tool_name, tool_kind, client_id, category,
+                arguments, result, status, file_path, auto_denied, denial_reason,
+                input_size_bytes, output_size_bytes, duration_ms, is_mcp
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """)) {
             ps.setString(1, tc.getEntryId());
-            ps.setString(2, tc.getTitle());
+            // Canonical tool name: prefer pluginTool (set by tracker on MCP correlation),
+            // otherwise strip the ACP client prefix (e.g. "agentbridge-read_file" → "read_file").
+            ps.setString(2, canonicalToolName(tc));
             ps.setString(3, tc.getKind());
             ps.setString(4, emptyToNull(clientId));
-            ps.setString(5, tc.getPluginTool());
+            // category mirrors tool_kind initially; enrichToolCallStats overwrites with
+            // the authoritative value from the ToolDefinition on MCP completion.
+            ps.setString(5, tc.getKind());
             ps.setString(6, tc.getArguments());
             ps.setString(7, tc.getResult());
             ps.setString(8, tc.getStatus());
             ps.setString(9, tc.getFilePath());
             ps.setInt(10, tc.getAutoDenied() ? 1 : 0);
             ps.setString(11, tc.getDenialReason());
-            // pluginTool is the confirmed MCP tool name set by ToolCallTracker when ACP↔MCP
-            // correlation succeeds. It is the single source of truth for is_mcp=1.
-            // NULL = unknown at flush time; enrichToolCallStats will confirm 1 for any MCP
-            // tool whose flush races ahead of correlation.
-            if (tc.getPluginTool() != null) {
-                ps.setInt(12, 1);
+            // Stat fields: populated by onMcpCompleted when it fires before the 30s-throttled
+            // INSERT (Path 1). If INSERT races ahead, enrichToolCallStats UPDATE fills them in
+            // afterwards (Path 2). Both paths use record.recordId as the stable DB event_id.
+            ps.setLong(12, tc.getInputSizeBytes());
+            ps.setLong(13, tc.getOutputSizeBytes());
+            ps.setLong(14, tc.getDurationMs()); // column is NOT NULL DEFAULT 0; 0 = not yet measured
+            Boolean isMcp = tc.isMcp();
+            if (isMcp != null) {
+                ps.setInt(15, isMcp ? 1 : 0);
+            } else if (tc.getPluginTool() != null) {
+                // pluginTool set = ACP↔MCP correlation confirmed before flush.
+                ps.setInt(15, 1);
             } else {
-                ps.setNull(12, Types.INTEGER);
+                ps.setNull(15, Types.INTEGER);
             }
             ps.executeUpdate();
         }
+    }
+
+    /**
+     * Returns the canonical tool name for DB storage: uses pluginTool when available (confirms
+     * MCP correlation), otherwise strips the ACP client prefix so "agentbridge-read_file" becomes
+     * "read_file" and bare tool names like "bash" are stored unchanged.
+     */
+    @NotNull
+    private static String canonicalToolName(@NotNull EntryData.ToolCall tc) {
+        if (tc.getPluginTool() != null) return tc.getPluginTool();
+        String title = tc.getTitle();
+        int dash = title.indexOf('-');
+        return dash >= 0 ? title.substring(dash + 1) : title;
     }
 
     private void insertSubAgent(
@@ -540,14 +564,17 @@ public final class ConversationWriter {
 
     // ── MCP stats enrichment + hook executions ─────────────────────────────────
 
+    @SuppressWarnings("java:S107")
+    // All 8 parameters map to distinct SQL columns; a wrapper object would add indirection without clarity.
     public void enrichToolCallStats(
-        @NotNull String toolUseId,
+        @NotNull String dbEventId,
         long inputSizeBytes,
         long outputSizeBytes,
         long durationMs,
         boolean success,
         @Nullable String errorMessage,
-        @Nullable String category
+        @Nullable String category,
+        @Nullable String displayName
     ) {
         synchronized (database) {
             Connection conn = database.getConnection();
@@ -560,6 +587,7 @@ public final class ConversationWriter {
                     success           = ?,
                     error_message     = COALESCE(?, error_message),
                     category          = COALESCE(?, category),
+                    display_name      = COALESCE(?, display_name),
                     is_mcp            = 1
                 WHERE event_id = ?
                 """)) {
@@ -569,10 +597,25 @@ public final class ConversationWriter {
                 ps.setInt(4, success ? 1 : 0);
                 ps.setString(5, errorMessage);
                 ps.setString(6, category);
-                ps.setString(7, toolUseId);
+                ps.setString(7, displayName);
+                ps.setString(8, dbEventId);
                 ps.executeUpdate();
             } catch (SQLException e) {
-                LOG.warn("ConversationWriter: failed to enrich stats for event " + toolUseId, e);
+                LOG.warn("ConversationWriter: failed to enrich stats for event " + dbEventId, e);
+            }
+        }
+    }
+
+    public void markToolCallNonMcp(@NotNull String eventId) {
+        synchronized (database) {
+            Connection conn = database.getConnection();
+            if (conn == null) return;
+            try (PreparedStatement ps = conn.prepareStatement(
+                "UPDATE tool_call_events SET is_mcp = 0 WHERE event_id = ? AND is_mcp IS NULL")) {
+                ps.setString(1, eventId);
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                LOG.warn("ConversationWriter: failed to mark non-MCP for event " + eventId, e);
             }
         }
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/ConversationWriter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/ConversationWriter.java
@@ -451,12 +451,10 @@ public final class ConversationWriter {
             INSERT OR IGNORE INTO tool_call_events (
                 event_id, tool_name, tool_kind, client_id, category,
                 arguments, result, status, file_path, auto_denied, denial_reason,
-                input_size_bytes, output_size_bytes, duration_ms, is_mcp
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                input_size_bytes, output_size_bytes, duration_ms, is_mcp, display_name
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """)) {
             ps.setString(1, tc.getEntryId());
-            // Canonical tool name: prefer pluginTool (set by tracker on MCP correlation),
-            // otherwise strip the ACP client prefix (e.g. "agentbridge-read_file" → "read_file").
             ps.setString(2, canonicalToolName(tc));
             ps.setString(3, tc.getKind());
             ps.setString(4, emptyToNull(clientId));
@@ -484,18 +482,21 @@ public final class ConversationWriter {
             } else {
                 ps.setNull(15, Types.INTEGER);
             }
+            // ACP title is always a display string — store it as display_name on initial insert.
+            ps.setString(16, tc.getTitle());
             ps.executeUpdate();
         }
     }
 
     /**
      * Returns the canonical tool name for DB storage: uses pluginTool when available (confirms
-     * MCP correlation), otherwise strips the ACP client prefix so "agentbridge-read_file" becomes
-     * "read_file" and bare tool names like "bash" are stored unchanged.
+     * MCP correlation), then acpName (canonical ACP name: MCP name for bridged tools, kind for
+     * native tools). Falls back to stripping the ACP client prefix from the title.
      */
     @NotNull
     private static String canonicalToolName(@NotNull EntryData.ToolCall tc) {
         if (tc.getPluginTool() != null) return tc.getPluginTool();
+        if (tc.getAcpName() != null) return tc.getAcpName();
         String title = tc.getTitle();
         int dash = title.indexOf('-');
         return dash >= 0 ? title.substring(dash + 1) : title;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -6,6 +6,7 @@ import com.github.catatafishen.agentbridge.services.ChatWebServer
 import com.github.catatafishen.agentbridge.services.ToolCallRecord
 import com.github.catatafishen.agentbridge.services.ToolCallTracker
 import com.github.catatafishen.agentbridge.services.ToolRegistry
+import com.github.catatafishen.agentbridge.session.db.ConversationService
 import com.github.catatafishen.agentbridge.settings.McpServerSettings
 import com.github.catatafishen.agentbridge.settings.ScratchTypeSettings
 import com.github.catatafishen.agentbridge.ui.ChatConsolePanel.Companion.instances
@@ -92,6 +93,26 @@ class ChatConsolePanel(
                 val jsKind = kind.replace("'", "\\'")
                 executeJs("ChatController.updateToolCallKind('$did','$jsKind')")
                 toolCallEntries[did]?.kind = kind
+            }
+            // Populate stats on the entry so they are written at INSERT time.
+            // Belt-and-suspenders: McpProtocolHandler.enrichConversationDb also updates
+            // the DB row if the INSERT already happened before this listener fires.
+            toolCallEntries[did]?.let { entry ->
+                entry.isMcp = true
+                entry.inputSizeBytes =
+                    record.mcpArgs?.toString()?.toByteArray(Charsets.UTF_8)?.size?.toLong() ?: 0L
+                entry.outputSizeBytes = record.resultBytes.toLong()
+                entry.durationMs = record.mcpDurationMs
+            }
+        }
+
+        override fun onAcpCompleted(record: ToolCallRecord) {
+            // If no MCP correlation happened, confirm this is a non-MCP (ACP-only) tool call.
+            if (record.isAcpOnly) {
+                val did = domId(record.recordId)
+                toolCallEntries[did]?.isMcp = false
+                // If the entry was already flushed to DB, mark it retroactively.
+                ConversationService.getInstance(project).markToolCallNonMcp(record.recordId)
             }
         }
     }
@@ -516,7 +537,8 @@ class ChatConsolePanel(
             EntryData.ToolCall(
                 cleanTitle, arguments, resolvedKind, null, null, null, filePath,
                 autoDenied = false, denialReason = null,
-                timestamp = timestamp(), agent = currentAgent
+                timestamp = timestamp(), agent = currentAgent,
+                entryId = id
             )
         entries.add(entry)
 
@@ -649,7 +671,8 @@ class ChatConsolePanel(
 
         val entry = EntryData.ToolCall(
             cleanTitle, arguments, resolvedKind,
-            timestamp = timestamp(), agent = currentAgent
+            timestamp = timestamp(), agent = currentAgent,
+            entryId = toolId
         )
         if (isMcpHandled) entry.pluginTool = cleanTitle
         toolCallNames[did] = cleanTitle

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -82,6 +82,7 @@ class ChatConsolePanel(
             val did = domId(record.recordId)
             executeJs("ChatController.markMcpHandled('$did')")
             toolCallEntries[did]?.pluginTool = record.mcpToolName ?: toolCallNames[did]
+            record.acpName?.let { toolCallEntries[did]?.acpName = it }
         }
 
         override fun onMcpCompleted(record: ToolCallRecord) {
@@ -546,6 +547,7 @@ class ChatConsolePanel(
         toolCallNames[did] = cleanTitle
         toolCallEntries[did] = entry
         if (isMcpHandled) entry.pluginTool = cleanTitle
+        ToolCallTracker.getInstance(project).findByRecordId(id)?.acpName?.let { entry.acpName = it }
 
         val label = toolChipTitle(cleanTitle, arguments)
         val hasCustomRenderer = ToolRenderers.hasRenderer(cleanTitle, toolRegistry)
@@ -675,6 +677,7 @@ class ChatConsolePanel(
             entryId = toolId
         )
         if (isMcpHandled) entry.pluginTool = cleanTitle
+        record?.acpName?.let { entry.acpName = it }
         toolCallNames[did] = cleanTitle
         toolCallEntries[did] = entry
         entries.add(entry)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatDataModel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatDataModel.kt
@@ -121,7 +121,17 @@ sealed class EntryData {
         val agent: String = "",
         val model: String = "",
         override val entryId: String = java.util.UUID.randomUUID().toString()
-    ) : EntryData()
+    ) : EntryData() {
+        /** Set by MCP protocol on completion; null = not yet executed via MCP. */
+        var isMcp: Boolean? = null
+        var inputSizeBytes: Long = 0
+        var outputSizeBytes: Long = 0
+        var durationMs: Long = 0
+        var mcpErrorMessage: String? = null
+
+        /** Human-readable display name from the MCP tool class (e.g. "Read File"). */
+        var mcpDisplayName: String? = null
+    }
 
     class SubAgent @JvmOverloads constructor(
         val agentType: String,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatDataModel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatDataModel.kt
@@ -131,6 +131,9 @@ sealed class EntryData {
 
         /** Human-readable display name from the MCP tool class (e.g. "Read File"). */
         var mcpDisplayName: String? = null
+
+        /** Canonical tool name from ACP: MCP name for bridged tools, kind for native tools. */
+        var acpName: String? = null
     }
 
     class SubAgent @JvmOverloads constructor(

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
@@ -616,6 +616,7 @@ class PromptOrchestrator(
 
     private fun handleStreamingToolCall(toolCall: SessionUpdate.ToolCall) {
         val title = toolCall.title()
+        val acpName = toolCall.acpName()
         val toolCallId = toolCall.toolCallId()
         val kind = toolCall.kind()?.value() ?: "other"
         val arguments = toolCall.arguments()
@@ -626,7 +627,7 @@ class PromptOrchestrator(
         // emit the summary text and suppress the chip update.
         if (title == taskCompleteTool) {
             log.info("task_complete detected (id=$toolCallId) — suppressing chip creation")
-            acpRegisterToolCall(toolCallId, title, arguments, kind, ToolCallRecord.RoutingType.TASK_COMPLETE)
+            acpRegisterToolCall(toolCallId, acpName, title, arguments, kind, ToolCallRecord.RoutingType.TASK_COMPLETE)
             return
         }
 
@@ -646,7 +647,7 @@ class PromptOrchestrator(
             val description =
                 toolCall.subAgentDescription()?.takeIf { it.isNotBlank() } ?: title.ifBlank { "Sub-agent task" }
             val record =
-                acpRegisterToolCall(toolCallId, title, arguments, kind, ToolCallRecord.RoutingType.SUB_AGENT)
+                acpRegisterToolCall(toolCallId, acpName, title, arguments, kind, ToolCallRecord.RoutingType.SUB_AGENT)
             consolePanel().addSubAgentEntry(record.recordId, agentType, description, toolCall.subAgentPrompt())
         } else if (activeSubAgentId != null) {
             turnToolCallCount++
@@ -654,6 +655,7 @@ class PromptOrchestrator(
             val parentRecord = ToolCallTracker.getInstance(project).findByAcpId(activeSubAgentId!!)
             val record = acpRegisterToolCall(
                 toolCallId,
+                acpName,
                 title,
                 arguments,
                 kind,
@@ -670,7 +672,7 @@ class PromptOrchestrator(
             turnToolCallCount++
             callbacks.onTimerIncrementToolCalls()
             val record =
-                acpRegisterToolCall(toolCallId, title, arguments, kind, ToolCallRecord.RoutingType.REGULAR)
+                acpRegisterToolCall(toolCallId, acpName, title, arguments, kind, ToolCallRecord.RoutingType.REGULAR)
             consolePanel().addToolCallEntry(record.recordId, title, arguments, kind, record.isCorrelated)
         }
 
@@ -684,7 +686,7 @@ class PromptOrchestrator(
     }
 
     private fun acpRegisterToolCall(
-        toolCallId: String, title: String, arguments: String?,
+        toolCallId: String, acpName: String?, title: String, arguments: String?,
         kind: String, routingType: ToolCallRecord.RoutingType
     ): ToolCallRecord {
         val argsObj = arguments?.let {
@@ -697,7 +699,7 @@ class PromptOrchestrator(
         // For Claude CLI, the ACP toolCallId IS the toolUseId that MCP sees in _meta.
         // Passing it enables Priority 0 correlation (exact ID match) in the tracker.
         return ToolCallTracker.getInstance(project).acpRegister(
-            toolCallId, title, argsObj, kind, routingType, toolCallId
+            toolCallId, acpName, title, argsObj, kind, routingType, toolCallId
         )
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParserTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParserTest.java
@@ -40,6 +40,11 @@ class AcpMessageParserTest {
                                                         @Nullable JsonObject argumentsObj) {
                 return null;
             }
+
+            @Override
+            public @Nullable String resolveAcpName(@NotNull String rawTitle, @Nullable String kind) {
+                return kind;
+            }
         },
         () -> "test-agent"
     );
@@ -448,6 +453,11 @@ class AcpMessageParserTest {
                                                             @NotNull String resolvedTitle,
                                                             @Nullable JsonObject argumentsObj) {
                     return "explore"; // Always detect as sub-agent for testing
+                }
+
+                @Override
+                public @Nullable String resolveAcpName(@NotNull String rawTitle, @Nullable String kind) {
+                    return kind;
                 }
             },
             () -> "test-agent"

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/KiroProcessUpdateTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/KiroProcessUpdateTest.java
@@ -43,8 +43,8 @@ class KiroProcessUpdateTest {
         @DisplayName("converts message chunk with mixed Text+Thinking to thought chunk")
         void mixedTextAndThinking() {
             var content = List.<ContentBlock>of(
-                    new ContentBlock.Text("visible text"),
-                    new ContentBlock.Thinking("internal reasoning")
+                new ContentBlock.Text("visible text"),
+                new ContentBlock.Thinking("internal reasoning")
             );
             var input = new SessionUpdate.AgentMessageChunk(content);
 
@@ -113,7 +113,7 @@ class KiroProcessUpdateTest {
         @DisplayName("ToolCall is returned as-is (not a message chunk)")
         void toolCallPassthrough() {
             var input = new SessionUpdate.ToolCall(
-                    "tc-1", "read_file", null, "{}", null, null, null, null, null
+                "tc-1", "read_file", null, null, "{}", null, null, null, null, null
             );
 
             SessionUpdate result = KiroClient.convertThinkingToThought(input);
@@ -125,7 +125,7 @@ class KiroProcessUpdateTest {
         @DisplayName("ToolCallUpdate is returned as-is")
         void toolCallUpdatePassthrough() {
             var input = new SessionUpdate.ToolCallUpdate(
-                    "tc-1", SessionUpdate.ToolCallStatus.COMPLETED, "result", null, null
+                "tc-1", SessionUpdate.ToolCallStatus.COMPLETED, "result", null, null
             );
 
             SessionUpdate result = KiroClient.convertThinkingToThought(input);
@@ -148,7 +148,7 @@ class KiroProcessUpdateTest {
         @DisplayName("Banner is returned as-is")
         void bannerPassthrough() {
             var input = new SessionUpdate.Banner(
-                    "warning msg", SessionUpdate.BannerLevel.WARNING, SessionUpdate.ClearOn.MANUAL
+                "warning msg", SessionUpdate.BannerLevel.WARNING, SessionUpdate.ClearOn.MANUAL
             );
 
             SessionUpdate result = KiroClient.convertThinkingToThought(input);
@@ -170,9 +170,9 @@ class KiroProcessUpdateTest {
         @DisplayName("message chunk with Image and Audio blocks (no Thinking) is unchanged")
         void nonThinkingMediaBlocks() {
             var content = List.<ContentBlock>of(
-                    new ContentBlock.Text("caption"),
-                    new ContentBlock.Image("base64", "image/png"),
-                    new ContentBlock.Audio("base64", "audio/wav")
+                new ContentBlock.Text("caption"),
+                new ContentBlock.Image("base64", "image/png"),
+                new ContentBlock.Audio("base64", "audio/wav")
             );
             var input = new SessionUpdate.AgentMessageChunk(content);
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/model/SessionUpdateEnumTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/model/SessionUpdateEnumTest.java
@@ -483,7 +483,7 @@ class SessionUpdateEnumTest {
 
         private ToolCall toolCall(String agentType, List<Location> locations) {
             return new ToolCall(
-                "tc-1", "title", ToolKind.READ, null,
+                "tc-1", "title", null, ToolKind.READ, null,
                 locations, agentType, null, null, null
             );
         }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallTrackerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallTrackerTest.java
@@ -48,7 +48,7 @@ class ToolCallTrackerTest {
     void acpRegister_createsNewRecord_withPendingState() {
         JsonObject a = argsReadFile("/src/Main.java");
         ToolCallRecord rec = tracker.acpRegister(
-            "acp-1", "read_file", a, "file",
+            "acp-1", null, "read_file", a, "file",
             ToolCallRecord.RoutingType.REGULAR, null);
 
         assertNotNull(rec);
@@ -64,7 +64,7 @@ class ToolCallTrackerTest {
     @Test
     void acpRegister_withoutArgs_createsRecord() {
         ToolCallRecord rec = tracker.acpRegister(
-            "acp-2", "some_tool", null, null,
+            "acp-2", null, "some_tool", null, null,
             ToolCallRecord.RoutingType.REGULAR, null);
 
         assertNotNull(rec);
@@ -76,7 +76,7 @@ class ToolCallTrackerTest {
     @Test
     void acpRegister_setsRoutingType() {
         ToolCallRecord rec = tracker.acpRegister(
-            "acp-sub", "Task", null, null,
+            "acp-sub", null, "Task", null, null,
             ToolCallRecord.RoutingType.SUB_AGENT, null);
 
         assertEquals(ToolCallRecord.RoutingType.SUB_AGENT, rec.getRoutingType());
@@ -105,7 +105,7 @@ class ToolCallTrackerTest {
         // ACP registers first with toolUseId
         JsonObject a = argsReadFile("/file1.txt");
         ToolCallRecord acpRec = tracker.acpRegister(
-            "acp-10", "read_file", a, "file",
+            "acp-10", null, "read_file", a, "file",
             ToolCallRecord.RoutingType.REGULAR, "tool-use-42");
 
         assertEquals(1, tracker.liveCount());
@@ -136,7 +136,7 @@ class ToolCallTrackerTest {
 
         // ACP registers with same toolUseId → should correlate
         tracker.acpRegister(
-            "acp-20", "edit_text", a, "file",
+            "acp-20", null, "edit_text", a, "file",
             ToolCallRecord.RoutingType.REGULAR, "tool-use-99");
 
         // The record should be the same mcpRec updated in-place
@@ -152,7 +152,7 @@ class ToolCallTrackerTest {
         // ACP registers first
         JsonObject a = argsReadFile("/project/build.gradle");
         ToolCallRecord acpRec = tracker.acpRegister(
-            "acp-30", "read_file", a, "file",
+            "acp-30", null, "read_file", a, "file",
             ToolCallRecord.RoutingType.REGULAR, null);
 
         assertEquals(1, tracker.liveCount());
@@ -181,7 +181,7 @@ class ToolCallTrackerTest {
         // ACP registers with same args → correlates
         JsonObject acpArgs = argsReadFile("/src/Test.java");
         ToolCallRecord acpRec = tracker.acpRegister(
-            "acp-40", "read_file", acpArgs, "file",
+            "acp-40", null, "read_file", acpArgs, "file",
             ToolCallRecord.RoutingType.REGULAR, null);
 
         assertSame(mcpRec, acpRec);
@@ -193,7 +193,7 @@ class ToolCallTrackerTest {
     void noCorrelation_whenArgsDiffer() {
         // ACP registers
         JsonObject a1 = argsReadFile("/file-a.txt");
-        tracker.acpRegister("acp-50", "read_file", a1, "file",
+        tracker.acpRegister("acp-50", null, "read_file", a1, "file",
             ToolCallRecord.RoutingType.REGULAR, null);
 
         // MCP registers with different args → no correlation
@@ -246,7 +246,7 @@ class ToolCallTrackerTest {
     void acpComplete_flushesRecord() {
         JsonObject a = argsReadFile("/src/Foo.java");
         ToolCallRecord rec = tracker.acpRegister(
-            "acp-60", "read_file", a, "file",
+            "acp-60", null, "read_file", a, "file",
             ToolCallRecord.RoutingType.REGULAR, null);
 
         assertEquals(1, tracker.liveCount());
@@ -269,7 +269,7 @@ class ToolCallTrackerTest {
     @Test
     void acpComplete_failure_setsFailedState() {
         JsonObject a = argsReadFile("/src/Bar.java");
-        tracker.acpRegister("acp-70", "read_file", a, "file",
+        tracker.acpRegister("acp-70", null, "read_file", a, "file",
             ToolCallRecord.RoutingType.REGULAR, null);
 
         tracker.acpComplete("acp-70", false);
@@ -288,7 +288,7 @@ class ToolCallTrackerTest {
     void acpProvideArgs_updatesHashAndCorrelates() {
         // ACP registers without args
         ToolCallRecord acpRec = tracker.acpRegister(
-            "acp-80", "run_command", null, null,
+            "acp-80", null, "run_command", null, null,
             ToolCallRecord.RoutingType.REGULAR, null);
         assertNull(acpRec.getArgsHash());
 
@@ -316,7 +316,7 @@ class ToolCallTrackerTest {
 
     @Test
     void acpProvideArgs_noMatchingMcp_justUpdatesHash() {
-        tracker.acpRegister("acp-81", "some_tool", null, null,
+        tracker.acpRegister("acp-81", null, "some_tool", null, null,
             ToolCallRecord.RoutingType.REGULAR, null);
 
         JsonObject a = args("key", "value");
@@ -357,7 +357,7 @@ class ToolCallTrackerTest {
         // ACP arrives matching record C → correlates, and flushes A and B (completed, uncorrelated, older)
         JsonObject acpArgs = args("cmd", "echo c");
         ToolCallRecord correlated = tracker.acpRegister(
-            "acp-90", "run_command", acpArgs, "shell",
+            "acp-90", null, "run_command", acpArgs, "shell",
             ToolCallRecord.RoutingType.REGULAR, null);
 
         assertSame(mcpC, correlated);
@@ -391,7 +391,7 @@ class ToolCallTrackerTest {
         assertEquals(3, tracker.liveCount());
 
         // ACP correlates with C
-        tracker.acpRegister("acp-100", "run_command", args("cmd", "target"), "shell",
+        tracker.acpRegister("acp-100", null, "run_command", args("cmd", "target"), "shell",
             ToolCallRecord.RoutingType.REGULAR, null);
 
         // A is still running → NOT flushed; B is completed → flushed
@@ -406,10 +406,10 @@ class ToolCallTrackerTest {
 
     @Test
     void clear_removesAllRecords() {
-        tracker.acpRegister("acp-a", "tool_a", argsReadFile("/a"), null,
+        tracker.acpRegister("acp-a", null, "tool_a", argsReadFile("/a"), null,
             ToolCallRecord.RoutingType.REGULAR, null);
         tracker.mcpRegister("tool_b", argsReadFile("/b"), null, null);
-        tracker.acpRegister("acp-c", "tool_c", argsReadFile("/c"), null,
+        tracker.acpRegister("acp-c", null, "tool_c", argsReadFile("/c"), null,
             ToolCallRecord.RoutingType.SUB_AGENT, null);
 
         assertEquals(3, tracker.liveCount());
@@ -426,7 +426,7 @@ class ToolCallTrackerTest {
     @Test
     void findByAcpId_returnsCorrectRecord() {
         JsonObject a = argsReadFile("/hello.txt");
-        ToolCallRecord rec = tracker.acpRegister("acp-q1", "read_file", a, null,
+        ToolCallRecord rec = tracker.acpRegister("acp-q1", null, "read_file", a, null,
             ToolCallRecord.RoutingType.REGULAR, null);
 
         assertSame(rec, tracker.findByAcpId("acp-q1"));
@@ -501,7 +501,7 @@ class ToolCallTrackerTest {
     @Test
     void acpRegister_setsDisplayNameToAcpTitle() {
         ToolCallRecord rec = tracker.acpRegister(
-            "acp-dn", "my_tool_title", argsReadFile("/t.txt"), null,
+            "acp-dn", null, "my_tool_title", argsReadFile("/t.txt"), null,
             ToolCallRecord.RoutingType.REGULAR, null);
 
         assertEquals("my_tool_title", rec.getDisplayName());
@@ -512,7 +512,7 @@ class ToolCallTrackerTest {
         // ACP first sets displayName from title
         JsonObject a = argsReadFile("/dn.txt");
         ToolCallRecord rec = tracker.acpRegister(
-            "acp-dn2", "acp_title", a, null,
+            "acp-dn2", null, "acp_title", a, null,
             ToolCallRecord.RoutingType.REGULAR, null);
         assertEquals("acp_title", rec.getDisplayName());
 
@@ -525,7 +525,7 @@ class ToolCallTrackerTest {
     void effectiveToolName_prefersMcp() {
         JsonObject a = argsReadFile("/eff.txt");
         ToolCallRecord rec = tracker.acpRegister(
-            "acp-eff", "acp_name", a, null,
+            "acp-eff", null, "acp_name", a, null,
             ToolCallRecord.RoutingType.REGULAR, null);
         assertEquals("acp_name", rec.getEffectiveToolName());
 
@@ -535,11 +535,11 @@ class ToolCallTrackerTest {
 
     @Test
     void acpSequence_incrementsWithEachAcpRegistration() {
-        ToolCallRecord r1 = tracker.acpRegister("a1", "t1", argsReadFile("/1"), null,
+        ToolCallRecord r1 = tracker.acpRegister("a1", null, "t1", argsReadFile("/1"), null,
             ToolCallRecord.RoutingType.REGULAR, null);
-        ToolCallRecord r2 = tracker.acpRegister("a2", "t2", argsReadFile("/2"), null,
+        ToolCallRecord r2 = tracker.acpRegister("a2", null, "t2", argsReadFile("/2"), null,
             ToolCallRecord.RoutingType.REGULAR, null);
-        ToolCallRecord r3 = tracker.acpRegister("a3", "t3", argsReadFile("/3"), null,
+        ToolCallRecord r3 = tracker.acpRegister("a3", null, "t3", argsReadFile("/3"), null,
             ToolCallRecord.RoutingType.REGULAR, null);
 
         assertEquals(1, r1.getAcpSequence());
@@ -551,7 +551,7 @@ class ToolCallTrackerTest {
     void liveCount_reflectsCurrentState() {
         assertEquals(0, tracker.liveCount());
 
-        tracker.acpRegister("a", "t", argsReadFile("/a"), null,
+        tracker.acpRegister("a", null, "t", argsReadFile("/a"), null,
             ToolCallRecord.RoutingType.REGULAR, null);
         assertEquals(1, tracker.liveCount());
 
@@ -577,7 +577,7 @@ class ToolCallTrackerTest {
     void acpProvideArgs_carriesOverMcpResult_whenMcpAlreadyCompleted() {
         // ACP without args
         ToolCallRecord acpRec = tracker.acpRegister(
-            "acp-late", "tool", null, null,
+            "acp-late", null, "tool", null, null,
             ToolCallRecord.RoutingType.REGULAR, null);
 
         // MCP registers and completes
@@ -600,7 +600,7 @@ class ToolCallTrackerTest {
     void correlation_viaToolUseId_matchesAcpClientIdAsFallback() {
         // ACP registers with acpClientId = "tool-use-fallback", no toolUseId
         JsonObject a = argsReadFile("/fallback.txt");
-        tracker.acpRegister("tool-use-fallback", "read_file", a, null,
+        tracker.acpRegister("tool-use-fallback", null, "read_file", a, null,
             ToolCallRecord.RoutingType.REGULAR, null);
 
         // MCP registers with toolUseId matching the acpClientId
@@ -615,7 +615,7 @@ class ToolCallTrackerTest {
     @Test
     void kind_setFromAcpRegister() {
         JsonObject a = argsReadFile("/k.txt");
-        ToolCallRecord rec = tracker.acpRegister("acp-k", "t", a, "git",
+        ToolCallRecord rec = tracker.acpRegister("acp-k", null, "t", a, "git",
             ToolCallRecord.RoutingType.REGULAR, null);
         assertEquals("git", rec.getKind());
     }
@@ -623,7 +623,7 @@ class ToolCallTrackerTest {
     @Test
     void kind_nullFromAcpRegister_doesNotOverwrite() {
         JsonObject a = argsReadFile("/k2.txt");
-        ToolCallRecord rec = tracker.acpRegister("acp-k2", "t", a, null,
+        ToolCallRecord rec = tracker.acpRegister("acp-k2", null, "t", a, null,
             ToolCallRecord.RoutingType.REGULAR, null);
         assertNull(rec.getKind());
     }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/db/ConversationReaderTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/db/ConversationReaderTest.java
@@ -177,7 +177,7 @@ class ConversationReaderTest {
         EntryData.ToolCall tc = new EntryData.ToolCall(
             "agentbridge-read_file", "{\"path\":\"/src/Main.java\"}", "file",
             "file contents here", "success", null, "/src/Main.java",
-            false, null, "Read File",
+            false, null, "read_file",
             "2026-01-01T10:00:01Z", "assistant", "gpt-4", "e1"
         );
         writer.recordEntries("sess-1", "Copilot", "copilot", List.of(
@@ -189,7 +189,9 @@ class ConversationReaderTest {
         assertEquals(2, entries.size());
         assertTrue(entries.get(1) instanceof EntryData.ToolCall);
         EntryData.ToolCall loaded = (EntryData.ToolCall) entries.get(1);
-        assertEquals("agentbridge-read_file", loaded.getTitle());
+        // pluginTool is set and NOT NULL → canonicalToolName uses it as tool_name.
+        // Title after roundtrip = canonical name (prefix stripped).
+        assertEquals("read_file", loaded.getTitle());
         assertEquals("{\"path\":\"/src/Main.java\"}", loaded.getArguments());
         assertEquals("file", loaded.getKind());
         assertEquals("file contents here", loaded.getResult());

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/db/ConversationReaderTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/db/ConversationReaderTest.java
@@ -258,7 +258,10 @@ class ConversationReaderTest {
         assertTrue(entries.size() >= 2);
         EntryData.TurnStats loaded = null;
         for (EntryData e : entries) {
-            if (e instanceof EntryData.TurnStats ts) { loaded = ts; break; }
+            if (e instanceof EntryData.TurnStats ts) {
+                loaded = ts;
+                break;
+            }
         }
         assertNotNull(loaded);
         assertEquals("t1", loaded.getTurnId());

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/db/ConversationWriterTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/db/ConversationWriterTest.java
@@ -350,11 +350,12 @@ class ConversationWriterTest {
                 false, null, null, "2026-01-01T10:00:01Z", "", "", "ev-enrich")
         ));
 
-        writer.enrichToolCallStats("ev-enrich", 256, 1024, 150, true, null, "file");
+        writer.enrichToolCallStats("ev-enrich", 256, 1024, 150, true, null, "file", "Read File");
 
         try (Statement s = conn.createStatement();
              ResultSet rs = s.executeQuery(
-                 "SELECT input_size_bytes, output_size_bytes, duration_ms, success, category "
+                 "SELECT input_size_bytes, output_size_bytes, duration_ms, success, category, "
+                     + "tool_name, display_name "
                      + "FROM tool_call_events WHERE event_id = 'ev-enrich'")) {
             assertTrue(rs.next());
             assertEquals(256, rs.getLong(1));
@@ -362,6 +363,9 @@ class ConversationWriterTest {
             assertEquals(150, rs.getLong(3));
             assertEquals(1, rs.getInt(4));
             assertEquals("file", rs.getString(5));
+            // tool_name must be stripped of the ACP prefix; display_name set by enrichment
+            assertEquals("read_file", rs.getString(6));
+            assertEquals("Read File", rs.getString(7));
         }
     }
 
@@ -373,7 +377,7 @@ class ConversationWriterTest {
                 false, null, null, "2026-01-01T10:00:01Z", "", "", "ev-fail")
         ));
 
-        writer.enrichToolCallStats("ev-fail", 100, 500, 3000, false, "timeout expired", "shell");
+        writer.enrichToolCallStats("ev-fail", 100, 500, 3000, false, "timeout expired", "shell", null);
 
         try (Statement s = conn.createStatement();
              ResultSet rs = s.executeQuery(

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/db/JsonlToSqliteMigratorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/db/JsonlToSqliteMigratorTest.java
@@ -133,7 +133,7 @@ class JsonlToSqliteMigratorTest {
             .filter(e -> e instanceof EntryData.ToolCall)
             .map(e -> (EntryData.ToolCall) e)
             .findFirst().orElseThrow();
-        assertEquals("agentbridge-read_file", tc.getTitle());
+        assertEquals("read_file", tc.getTitle());
     }
 
     @Test
@@ -164,9 +164,9 @@ class JsonlToSqliteMigratorTest {
         // the part kind — this is the exact pattern that caused isEntryFormat() to return true
         // incorrectly (false positive from nested "type":) yet produce null from deserialize().
         String jsonl = """
-                {"type":"prompt","text":"New format","timestamp":"2026-01-01T10:00:00Z","entryId":"t1"}
-                {"id":"msg-1","role":"assistant","parts":[{"type":"text","text":"legacy response"}],"createdAt":1735689601000,"agent":"Copilot"}
-                """;
+            {"type":"prompt","text":"New format","timestamp":"2026-01-01T10:00:00Z","entryId":"t1"}
+            {"id":"msg-1","role":"assistant","parts":[{"type":"text","text":"legacy response"}],"createdAt":1735689601000,"agent":"Copilot"}
+            """;
         Files.writeString(sessionsDir.resolve("sess-1.jsonl"), jsonl);
 
         int count = JsonlToSqliteMigrator.migrate(sessionsDir, writer);
@@ -514,9 +514,9 @@ class JsonlToSqliteMigratorTest {
     void migratesFileWithOnlyLegacyEntries() throws Exception {
         // No sessions-index.json — session discovered via file scan
         String jsonl = """
-                {"id":"user-1","role":"user","parts":[{"type":"text","text":"Fix the bug"}],"createdAt":1735689601000}
-                {"id":"asst-1","role":"assistant","parts":[{"type":"reasoning","text":"Let me look..."},{"type":"text","text":"Here is the fix"}],"createdAt":1735689602000,"agent":"Copilot"}
-                """;
+            {"id":"user-1","role":"user","parts":[{"type":"text","text":"Fix the bug"}],"createdAt":1735689601000}
+            {"id":"asst-1","role":"assistant","parts":[{"type":"reasoning","text":"Let me look..."},{"type":"text","text":"Here is the fix"}],"createdAt":1735689602000,"agent":"Copilot"}
+            """;
         Files.writeString(sessionsDir.resolve("abc-session.jsonl"), jsonl);
 
         int count = JsonlToSqliteMigrator.migrate(sessionsDir, writer);


### PR DESCRIPTION
## Problem

The ACP protocol's `title` field is always a display string — never a tool name. This caused display strings to be stored as `tool_name` in the DB, and reprimand nudges were unreliable due to heuristic bash detection.

## Solution

Add `acpName` field through the entire pipeline:

- **MCP tools**: `resolveAcpName()` strips the prefix → canonical name (e.g., `read_file`)
- **Known builtins** (Copilot): normalized name (e.g., `bash`, `grep`)
- **Unknown native tools**: falls back to `kind` (e.g., `read`, `execute`)

### Changes

1. **ToolCallRecord**: Added `acpName` field, updated `getEffectiveToolName()` priority
2. **AcpMessageParser**: Added `resolveAcpName()` delegate method
3. **CopilotClient**: Override using `KNOWN_BUILTIN_TOOL_NAMES`
4. **SessionUpdate.ToolCall**: Added `acpName` record component
5. **ConversationWriter**: Uses `acpName` in `canonicalToolName()`, stores title as `display_name` on initial insert
6. **Reprimand nudges**: Rewritten to natural language using kind, removed verbose format and heuristic bash detection

Supersedes #550