### PR TITLE
fix: JCEF freeze recovery after prolonged EDT blocks

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -270,6 +270,53 @@ Every file write through `write_file` triggers:
 
 This runs inside a single undoable command group on the EDT.
 
+### JCEF OSR Freeze After Prolonged EDT Block
+
+**Summary:** A prolonged EDT (Event Dispatch Thread) freeze (30+ seconds) can permanently stall
+the JCEF off-screen renderer. The JS engine remains alive (`executeJs` succeeds, DOM updates),
+but the visual viewport is stuck on the pre-freeze frame.
+
+**Chain of events (first observed 2026-05-09):**
+
+1. **Trigger:** Burst of 10+ simultaneous `read_file` MCP tool calls.
+2. **Amplification:** Each `read_file` call invokes `followFileIfEnabled()`, which opens the file
+   in the editor via `OpenFileDescriptor.navigate()`.
+3. **VCS cascade:** Opening each file triggers IntelliJ's VCS integration — `git log` (to fetch
+   revision info) and `git blame` (for gutter annotations) per file. On large repositories these
+   can take 10–80 seconds *each*.
+4. **EDT blocked:** The git operations cascaded, blocking EDT for 72 seconds total
+   (`git log` 54s + `git log` 12s + `git blame` 80s).
+5. **JCEF desynchronized:** In OSR mode, CEF delivers rendered frames to Swing via `onPaint()`
+   callbacks. During the freeze, Swing couldn't process `repaint()`. After EDT unblocked, CEF
+   stopped delivering new frames — it believed the last frame was acknowledged, but Swing never
+   actually painted it. Without a `wasResized()` or `invalidate()` signal, no fresh frame was
+   ever sent.
+6. **Permanent freeze:** The panel appeared permanently frozen — the scrollbar indicated more
+   content below (DOM was updated by JS), but the visual viewport was stuck and unresponsive
+   to mouse events.
+
+**Defenses implemented:**
+
+| Defense | Class | Purpose |
+|---------|-------|---------|
+| `EdtFreezeRecovery` | `ui/EdtFreezeRecovery.kt` | EDT heartbeat monitor. Detects freezes >30s and triggers JCEF OSR recovery (`setWindowVisibility` toggle + `wasResized` + `invalidate`) on all registered browsers. Logs at ERROR level. |
+| `followFileIfEnabled` cooldown | `psi/tools/file/FileTool.java` | 2-second cooldown between file-open navigations. When 10+ tool calls arrive in a burst, only the first opens a file; subsequent calls are throttled. Prevents cascading VCS operations. |
+| `MonitorSwitchRecovery` | `ui/MonitorSwitchRecovery.kt` | Pre-existing. Recovers JCEF after monitor/display changes. Same recovery sequence, different trigger. |
+
+**Debugging similar issues:**
+
+1. Check `~/.cache/JetBrains/IntelliJIdea*/log/idea.log` (and rotated `idea.1.log`, `idea.2.log`)
+   for `UI was frozen for Nms` from `PerformanceWatcherImpl`.
+2. Look for `git log took Nms` or `git blame took Nms` from `git4idea.commands.GitHandler`.
+3. Check `ActionUpdater` logs — `N ms to grab EDT` values above 100ms indicate EDT contention.
+   Values above 1000ms indicate a serious freeze.
+4. Thread dumps are saved to `~/.cache/JetBrains/IntelliJIdea*/log/threadDumps-freeze-*`.
+   These show what was on EDT during the freeze.
+5. Our `EdtFreezeRecovery` logs at ERROR level: search for `EDT was unresponsive for` to find
+   automatic recovery events.
+6. The `read_ide_log` MCP tool only reads the current in-memory log — for historical analysis,
+   grep the rotated log files directly.
+
 ### JCEF Cursor Bridge
 
 JCEF does **not** propagate CSS `cursor` values to the Swing host component. Setting

--- a/docs/tool-execution-correlation.md
+++ b/docs/tool-execution-correlation.md
@@ -26,25 +26,34 @@ Each tool call is represented by a `ToolCallRecord` with a stable UUID-based `re
 ├──────────────────┬──────────────────────────────────┤
 │ ACP side         │ MCP side                         │
 │  acpClientId     │  mcpToolName (confirmed name)    │
-│  acpTitle        │  mcpArgs                         │
-│  acpArgs         │  mcpResult                       │
-│  routingType     │  mcpSuccess                      │
-│  acpSequence     │  mcpStartedAt / mcpCompletedAt   │
+│  acpName         │  mcpArgs                         │
+│  acpTitle        │  mcpResult                       │
+│  acpArgs         │  mcpSuccess                      │
+│  routingType     │  mcpStartedAt / mcpCompletedAt   │
 ├──────────────────┴──────────────────────────────────┤
 │ Shared: argsHash, state, kind, displayName,         │
 │         correlated (bool), resultBytes              │
 └─────────────────────────────────────────────────────┘
 ```
 
+**`acpName`** is the canonical tool name resolved from ACP protocol data:
+
+- For MCP-bridged tools: the stripped tool ID (e.g. `"read_file"` from `"agentbridge-read_file"`)
+- For known built-in tools: the lowercase name (e.g. `"bash"`, `"grep"`)
+- For unrecognized tools: the ACP `kind` value (e.g. `"read"`, `"execute"`)
+
+**`getEffectiveToolName()`** returns the best available name in priority order:
+`mcpToolName` → `acpName` → `acpTitle` → `"unknown"`
+
 ### States
 
-| State       | Meaning                                                           |
-|-------------|-------------------------------------------------------------------|
-| `PENDING`   | ACP reported the call, MCP has not started                        |
-| `RUNNING`   | MCP execution in progress                                         |
-| `COMPLETED` | MCP execution finished successfully                               |
-| `FAILED`    | MCP execution finished with error                                 |
-| `EXTERNAL`  | MCP-only call that was never correlated with ACP               |
+| State       | Meaning                                          |
+|-------------|--------------------------------------------------|
+| `PENDING`   | ACP reported the call, MCP has not started       |
+| `RUNNING`   | MCP execution in progress                        |
+| `COMPLETED` | MCP execution finished successfully              |
+| `FAILED`    | MCP execution finished with error                |
+| `EXTERNAL`  | MCP-only call that was never correlated with ACP |
 
 ### Routing Types
 
@@ -80,7 +89,7 @@ updates the record's hash and retries correlation against orphan MCP records.
 When a record becomes correlated:
 
 - `isCorrelated()` returns `true`
-- `getEffectiveToolName()` returns the confirmed MCP tool name (preferred over ACP title)
+- `getEffectiveToolName()` returns the best name: mcpToolName → acpName → acpTitle
 - `onCorrelated` event fires to listeners (e.g. UI updates chip border style)
 
 ## Registration Flow
@@ -89,7 +98,7 @@ When a record becomes correlated:
 
 ```
 1. PromptOrchestrator receives tool_call from ACP stream
-2. Calls tracker.acpRegister(acpClientId, title, args, hash, routingType, toolUseId)
+2. Calls tracker.acpRegister(acpClientId, acpName, title, args, kind, routingType, toolUseId)
 3. Tracker creates record with PENDING state, fires onAcpRegistered
 4. If args hash matches an existing MCP-only record → merge + fire onCorrelated
 5. PromptOrchestrator passes recordId to ChatConsolePanel for DOM chip creation
@@ -135,10 +144,10 @@ Records are removed from the live set when they are no longer needed:
    is called. ACP is the ground truth for when an agent is done with a call.
 
 2. **MCP-only calls** (no ACP counterpart): flushed when a newer ACP-correlated call
-   arrives, but only if the MCP-only record was inserted before the correlated record
-   in the live set *and* has already completed execution (`mcpResult != null`). Records
-   still executing are kept — they might still receive an ACP match from a later stream
-   event. This is handled by `flushOlderUncorrelatedMcpRecords(currentSequence, correlatedRecordId)`.
+   arrives, but only if the MCP-only record has already completed execution
+   (`mcpResult != null`). Records still executing are kept — they might still receive
+   an ACP match from a later stream event. This is handled by
+   `flushOlderUncorrelatedMcpRecords(correlatedRecordId)`.
 
 3. **`clear()`**: called at session end to flush all remaining records.
 
@@ -151,23 +160,38 @@ Records are removed from the live set when they are no longer needed:
 | `findByMcpCall(toolName, args)` | MCP tab: find ACP metadata for an MCP execution     |
 | `getStoredResult(recordId)`     | Retrieve cached MCP result by record ID             |
 
-## Client-Specific Tool ID Resolution
+## Client-Specific Tool Name Resolution
 
-ACP clients resolve tool names differently. The `resolveToolId` method in each client
-maps the protocol title to an internal tool ID:
+ACP clients resolve tool names through two methods:
 
-- **MCP tools**: Strip the MCP prefix (e.g. `agentbridge-read_file` → `read_file`)
-- **Known built-in tools**: Normalize to lowercase (e.g. `Bash` → `bash`)
-- **Unrecognized titles**: Pass through as-is — `ToolCallTracker` will correct the
-  display name to the confirmed MCP tool name once execution is correlated
+### `resolveToolId(title)` — for MCP-bridged tools
+
+Maps the protocol title to a bare tool ID by stripping the MCP prefix:
+
+- **Copilot CLI**: `agentbridge-read_file` → `read_file`
+- **OpenCode**: `agentbridge_read_file` → `read_file`
+- **Hermes**: `mcp_agentbridge_read_file` → `read_file`
+- **Kiro**: `@agentbridge/read_file` → `read_file`
+
+### `resolveAcpName(title, kind)` — canonical name for all tools
+
+Called during ACP registration to produce the `acpName` field:
+
+- If title starts with MCP prefix → `resolveToolId(title)` (e.g. `"read_file"`)
+- If title is a known built-in name → lowercase title (e.g. `"bash"`)
+- Otherwise → the `kind` value (e.g. `"read"`, `"execute"`, `"fetch"`)
+
+The ACP `title` is always a display string and is **never** used as a tool name.
+It is stored in `acpTitle` and `displayName` for UI rendering only.
 
 ## File Reference
 
-| File                            | Responsibility                                       |
-|---------------------------------|------------------------------------------------------|
-| `services/ToolCallTracker.java` | Single source of truth, correlation, events          |
-| `services/ToolCallRecord.java`  | Mutable record aggregating ACP + MCP data            |
-| `ui/PromptOrchestrator.kt`      | ACP-side registration (`acpRegister`, `acpComplete`) |
-| `psi/PsiBridgeService.java`     | MCP-side registration (`mcpRegister`, `mcpComplete`) |
-| `ui/ChatConsolePanel.kt`        | UI listener for chip state updates                   |
-| `services/ToolCallHasher.java`  | Deterministic JSON hashing utility                   |
+| File                                      | Responsibility                                       |
+|-------------------------------------------|------------------------------------------------------|
+| `services/ToolCallTracker.java`           | Single source of truth, correlation, events          |
+| `services/ToolCallRecord.java`            | Mutable record aggregating ACP + MCP data            |
+| `ui/PromptOrchestrator.kt`                | ACP-side registration (`acpRegister`, `acpComplete`) |
+| `psi/PsiBridgeService.java`               | MCP-side registration (`mcpRegister`, `mcpComplete`) |
+| `ui/ChatConsolePanel.kt`                  | UI listener for chip state updates                   |
+| `services/ToolCallHasher.java`            | Deterministic JSON hashing utility                   |
+| `session/db/ToolCallStatsEnrichment.java` | Record for MCP stats DB enrichment                   |

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -570,6 +570,10 @@ public final class CopilotClient extends AcpClient {
     @Override
     protected SessionUpdate processUpdate(SessionUpdate update) {
         if (update instanceof SessionUpdate.ToolCall toolCall && !toolCall.isSubAgent()) {
+            // Skip kind=OTHER — these are meta-tools (report_intent, sql, skill) or
+            // third-party MCP tools the user explicitly configured. No reprimand needed.
+            if (toolCall.kind() == SessionUpdate.ToolKind.OTHER) return update;
+
             String title = toolCall.title();
             boolean isBuiltIn = !isMcpToolTitle(title)
                 && (KNOWN_BUILTIN_TOOL_NAMES.contains(title.toLowerCase())

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/HermesClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/HermesClient.java
@@ -54,7 +54,7 @@ public final class HermesClient extends AcpClient {
     protected List<String> buildCommand(String cwd, int mcpPort) {
         // --accept-hooks auto-approves shell hooks that would otherwise prompt
         // on a TTY we don't have when launched from the IDE plugin.
-        return List.of("hermes", "acp", "--accept-hooks");
+        return List.of(AGENT_ID, "acp", "--accept-hooks");
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/TurnMiner.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/TurnMiner.java
@@ -177,12 +177,9 @@ public final class TurnMiner {
                 .evidence(evidenceJson)
                 .build();
 
-            String result = context.store().addDrawer(drawer, vector);
-            if (result != null) {
-                extractTriples(combinedText, context.wing(), drawerId, context.kg());
-                return new MineExchangeResult(1, 0, 0);
-            }
-            return new MineExchangeResult(0, 0, 1);
+            context.store().addDrawer(drawer, vector);
+            extractTriples(combinedText, context.wing(), drawerId, context.kg());
+            return new MineExchangeResult(1, 0, 0);
         } catch (Exception e) {
             LOG.warn("Failed to mine exchange", e);
             return new MineExchangeResult(0, 0, 0);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Abstract base for file tools. Provides shared static utilities for
@@ -273,7 +274,7 @@ public abstract class FileTool extends Tool {
      * @see com.github.catatafishen.agentbridge.ui.EdtFreezeRecovery
      */
     private static final long FOLLOW_FILE_COOLDOWN_MS = 2_000;
-    private static volatile long lastFollowFileMs;
+    private static final AtomicLong lastFollowFileMs = new AtomicLong();
 
     /**
      * Notifies the {@link AgentEditSession} that a file is about to be modified.
@@ -350,12 +351,13 @@ public abstract class FileTool extends Tool {
         }
 
         long now = System.currentTimeMillis();
-        if (now - lastFollowFileMs < FOLLOW_FILE_COOLDOWN_MS) {
+        long prev = lastFollowFileMs.get();
+        if (now - prev < FOLLOW_FILE_COOLDOWN_MS
+            || !lastFollowFileMs.compareAndSet(prev, now)) {
             LOG.info("followFileIfEnabled throttled: " + pathStr
                 + " (cooldown " + FOLLOW_FILE_COOLDOWN_MS + "ms)");
             return;
         }
-        lastFollowFileMs = now;
 
         EdtUtil.invokeLater(() -> {
             AtomicBoolean nav = NAVIGATING.computeIfAbsent(project, k -> new AtomicBoolean(false));

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
@@ -254,6 +254,28 @@ public abstract class FileTool extends Tool {
     private static volatile long lastProjectViewSelectMs;
 
     /**
+     * Minimum interval between file-open navigations. When multiple tool calls
+     * arrive in a burst (e.g. 10+ read_file calls within 1 second), each one
+     * triggers {@code followFileIfEnabled}, which opens the file in the editor.
+     * Opening a file triggers IntelliJ's VCS integration (git log, git blame for
+     * annotations), and cascading git operations can block EDT for tens of seconds.
+     *
+     * <p>This cooldown ensures only the first file-open in a burst window actually
+     * navigates; subsequent calls within the window are silently dropped. The
+     * {@link #NAVIGATING} guard prevents <i>reentrant</i> calls within a single
+     * EDT dispatch, but does not prevent sequential {@code invokeLater} dispatches
+     * from opening many files in rapid succession — this cooldown fills that gap.
+     *
+     * <p><b>Incident reference:</b> 2026-05-09: 10+ simultaneous read_file calls
+     * triggered VCS annotations on each file → git log (54s) + git blame (80s)
+     * blocked EDT for 72 seconds → permanent JCEF OSR freeze.
+     *
+     * @see com.github.catatafishen.agentbridge.ui.EdtFreezeRecovery
+     */
+    private static final long FOLLOW_FILE_COOLDOWN_MS = 2_000;
+    private static volatile long lastFollowFileMs;
+
+    /**
      * Notifies the {@link AgentEditSession} that a file is about to be modified.
      * Starts the session (if the review setting is enabled), captures a before-snapshot,
      * and sets the agent-edit marker so the session's document listener can distinguish
@@ -326,6 +348,14 @@ public abstract class FileTool extends Tool {
             LOG.debug("followFileIfEnabled skipped: setting disabled for project " + project.getName());
             return;
         }
+
+        long now = System.currentTimeMillis();
+        if (now - lastFollowFileMs < FOLLOW_FILE_COOLDOWN_MS) {
+            LOG.info("followFileIfEnabled throttled: " + pathStr
+                + " (cooldown " + FOLLOW_FILE_COOLDOWN_MS + "ms)");
+            return;
+        }
+        lastFollowFileMs = now;
 
         EdtUtil.invokeLater(() -> {
             AtomicBoolean nav = NAVIGATING.computeIfAbsent(project, k -> new AtomicBoolean(false));

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/RenameFileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/RenameFileTool.java
@@ -3,7 +3,7 @@ package com.github.catatafishen.agentbridge.psi.tools.file;
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
 import com.github.catatafishen.agentbridge.psi.McpErrorCode;
 import com.github.catatafishen.agentbridge.psi.ToolError;
-import com.github.catatafishen.agentbridge.psi.ToolUtils;
+
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupRespondTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/PopupRespondTool.java
@@ -194,6 +194,9 @@ public final class PopupRespondTool extends QualityTool {
             }
             return result;
         } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
             LOG.warn("popup_respond: replay of '" + taken.originalTool() + "' failed", e);
             return "Error: replay failed: " + e.getMessage();
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/ConversationSchema.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/db/ConversationSchema.java
@@ -284,7 +284,15 @@ final class ConversationSchema {
                 is_mcp            INTEGER
             )
             """);
-        stmt.execute("INSERT INTO tool_call_events SELECT * FROM tool_call_events_old");
+        stmt.execute("""
+            INSERT INTO tool_call_events (event_id, tool_name, tool_kind, category, client_id,
+                display_name, arguments, result, input_size_bytes, output_size_bytes, duration_ms,
+                success, error_message, status, file_path, auto_denied, denial_reason, is_mcp)
+            SELECT event_id, tool_name, tool_kind, category, client_id,
+                display_name, arguments, result, input_size_bytes, output_size_bytes, duration_ms,
+                success, error_message, status, file_path, auto_denied, denial_reason, is_mcp
+            FROM tool_call_events_old
+            """);
         stmt.execute("DROP TABLE tool_call_events_old");
         stmt.execute("CREATE INDEX idx_tc_tool_name ON tool_call_events(tool_name)");
         stmt.execute("CREATE INDEX idx_tc_client ON tool_call_events(client_id)");

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -1572,6 +1572,9 @@ class ChatConsolePanel(
      * Detects when the panel moves to a different monitor (or the underlying
      * display changes) and forces JCEF's OSR renderer to recover. All logic
      * lives in [MonitorSwitchRecovery]; see issue #237.
+     *
+     * Also registers with [EdtFreezeRecovery] to recover after prolonged EDT
+     * blocks (e.g. cascading VCS operations blocking EDT for 30+ seconds).
      */
     private fun setupMonitorChangeListener() {
         val b = browser ?: return
@@ -1580,6 +1583,9 @@ class ChatConsolePanel(
             onRecovered = { recoverBrowserStateAfterMonitorSwitch() },
             parentDisposable = this,
         ).also { it.install() }
+
+        val freezeRecovery = EdtFreezeRecovery.getInstance(this)
+        freezeRecovery.register(b) { recoverBrowserStateAfterMonitorSwitch() }
     }
 
     // ── Permission requests ────────────────────────────────────────

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -1584,7 +1584,7 @@ class ChatConsolePanel(
             parentDisposable = this,
         ).also { it.install() }
 
-        val freezeRecovery = EdtFreezeRecovery.getInstance(this)
+        val freezeRecovery = project.getService(EdtFreezeRecovery::class.java)
         freezeRecovery.register(b) { recoverBrowserStateAfterMonitorSwitch() }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/EdtFreezeRecovery.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/EdtFreezeRecovery.kt
@@ -1,8 +1,9 @@
 package com.github.catatafishen.agentbridge.ui
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.project.Project
 import com.intellij.ui.jcef.JBCefBrowser
 import javax.swing.SwingUtilities
 import javax.swing.Timer
@@ -10,6 +11,9 @@ import javax.swing.Timer
 /**
  * Detects prolonged EDT (Event Dispatch Thread) freezes and forces JCEF OSR
  * recovery on all registered browsers when a freeze ends.
+ *
+ * Registered as a project-level service so all [ChatConsolePanel] instances
+ * within the same project share a single heartbeat timer and recovery registry.
  *
  * ## Why this exists
  *
@@ -49,8 +53,9 @@ import javax.swing.Timer
  * See `DEVELOPMENT.md` § "JCEF OSR Freeze After Prolonged EDT Block" for
  * the full chain of events.
  */
-internal class EdtFreezeRecovery private constructor(
-    parentDisposable: Disposable,
+@Service(Service.Level.PROJECT)
+internal class EdtFreezeRecovery(
+    @Suppress("unused") private val project: Project,
 ) : Disposable {
 
     private val log = Logger.getInstance(EdtFreezeRecovery::class.java)
@@ -80,7 +85,6 @@ internal class EdtFreezeRecovery private constructor(
     }.apply { isRepeats = true }
 
     init {
-        Disposer.register(parentDisposable, this)
         heartbeatTimer.start()
         log.info("EDT freeze recovery installed (interval=${HEARTBEAT_INTERVAL_MS}ms, threshold=${FREEZE_THRESHOLD_MS}ms)")
     }
@@ -130,19 +134,5 @@ internal class EdtFreezeRecovery private constructor(
     companion object {
         private const val HEARTBEAT_INTERVAL_MS = 5_000
         private const val FREEZE_THRESHOLD_MS = 30_000
-
-        private val instances = java.util.concurrent.ConcurrentHashMap<Disposable, EdtFreezeRecovery>()
-
-        /**
-         * Gets or creates the singleton recovery instance for the given parent disposable.
-         * Typically called once per project with the project as parent.
-         */
-        fun getInstance(parentDisposable: Disposable): EdtFreezeRecovery {
-            return instances.computeIfAbsent(parentDisposable) { parent ->
-                val recovery = EdtFreezeRecovery(parent)
-                Disposer.register(parent) { instances.remove(parent) }
-                recovery
-            }
-        }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/EdtFreezeRecovery.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/EdtFreezeRecovery.kt
@@ -1,0 +1,148 @@
+package com.github.catatafishen.agentbridge.ui
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.util.Disposer
+import com.intellij.ui.jcef.JBCefBrowser
+import javax.swing.SwingUtilities
+import javax.swing.Timer
+
+/**
+ * Detects prolonged EDT (Event Dispatch Thread) freezes and forces JCEF OSR
+ * recovery on all registered browsers when a freeze ends.
+ *
+ * ## Why this exists
+ *
+ * JCEF's off-screen rendering (OSR) depends on Swing's EDT paint cycle to
+ * display frames. When EDT is blocked for a long time (e.g. 30+ seconds due
+ * to cascading VCS `git log` / `git blame` operations triggered by bulk file
+ * opens), the JCEF compositor and Swing component can desynchronize:
+ *
+ * 1. CEF's renderer thread continues delivering frames via `onPaint()`.
+ * 2. Swing can't process `repaint()` calls because EDT is frozen.
+ * 3. After EDT unblocks, CEF may stop delivering new frames because it
+ *    believes the last frame was acknowledged (the callback returned),
+ *    but the Swing component never actually painted it.
+ * 4. Without a `wasResized()` or `invalidate()` signal, no fresh frame
+ *    is ever sent — the panel appears permanently frozen.
+ *
+ * The JS engine remains alive (`executeJs` calls succeed, DOM is updated),
+ * but the visual viewport is stuck on the pre-freeze frame.
+ *
+ * ## How it works
+ *
+ * A Swing [Timer] fires every [HEARTBEAT_INTERVAL_MS] on EDT. Each tick
+ * records `System.nanoTime()`. If the delta between consecutive heartbeats
+ * exceeds [FREEZE_THRESHOLD_MS], a freeze is detected. When detected, all
+ * registered browsers are recovered using the same sequence as
+ * [MonitorSwitchRecovery]: `setWindowVisibility(false/true)` +
+ * `notifyScreenInfoChanged()` + `wasResized()` + `invalidate()`.
+ *
+ * ## Incident reference
+ *
+ * First observed 2026-05-09: 10+ simultaneous `read_file` MCP tool calls
+ * each opened a file in the editor via `followFileIfEnabled`, triggering
+ * IntelliJ VCS annotations (`git log` 54s + `git blame` 80s). EDT was
+ * blocked for 72 seconds. JCEF chat panel never recovered visually despite
+ * `executeJs` calls continuing to flow.
+ *
+ * See `DEVELOPMENT.md` § "JCEF OSR Freeze After Prolonged EDT Block" for
+ * the full chain of events.
+ */
+internal class EdtFreezeRecovery private constructor(
+    parentDisposable: Disposable,
+) : Disposable {
+
+    private val log = Logger.getInstance(EdtFreezeRecovery::class.java)
+
+    private data class BrowserEntry(
+        val browser: JBCefBrowser,
+        val onRecovered: () -> Unit,
+    )
+
+    private val browsers = mutableListOf<BrowserEntry>()
+    private var lastHeartbeatNanos = System.nanoTime()
+
+    private val heartbeatTimer = Timer(HEARTBEAT_INTERVAL_MS) {
+        val now = System.nanoTime()
+        val deltaMs = (now - lastHeartbeatNanos) / 1_000_000
+        lastHeartbeatNanos = now
+
+        if (deltaMs > FREEZE_THRESHOLD_MS) {
+            log.error(
+                "EDT was unresponsive for ${deltaMs}ms (threshold: ${FREEZE_THRESHOLD_MS}ms). " +
+                    "Triggering JCEF OSR recovery on ${browsers.size} browser(s). " +
+                    "This is typically caused by blocking operations on EDT such as " +
+                    "VCS annotations (git log/blame) triggered by bulk file opens."
+            )
+            recoverAll()
+        }
+    }.apply { isRepeats = true }
+
+    init {
+        Disposer.register(parentDisposable, this)
+        heartbeatTimer.start()
+        log.info("EDT freeze recovery installed (interval=${HEARTBEAT_INTERVAL_MS}ms, threshold=${FREEZE_THRESHOLD_MS}ms)")
+    }
+
+    /**
+     * Register a JCEF browser for freeze recovery.
+     * [onRecovered] is called after the OSR refresh (e.g. to replay DOM state).
+     */
+    fun register(browser: JBCefBrowser, onRecovered: () -> Unit) {
+        browsers.add(BrowserEntry(browser, onRecovered))
+    }
+
+    fun unregister(browser: JBCefBrowser) {
+        browsers.removeAll { it.browser === browser }
+    }
+
+    private fun recoverAll() {
+        for (entry in browsers.toList()) {
+            recoverBrowser(entry)
+        }
+    }
+
+    private fun recoverBrowser(entry: BrowserEntry) {
+        val cef = entry.browser.cefBrowser
+        val comp = entry.browser.component
+        log.error(
+            "Recovering JCEF browser: isShowing=${comp.isShowing} " +
+                "size=${comp.width}x${comp.height}"
+        )
+        runCatching { cef.setWindowVisibility(false) }
+        runCatching { cef.setWindowVisibility(true) }
+        runCatching { cef.notifyScreenInfoChanged() }
+        if (comp.width > 0 && comp.height > 0) {
+            runCatching { cef.wasResized(comp.width, comp.height) }
+        }
+        runCatching { cef.invalidate() }
+        SwingUtilities.invokeLater {
+            runCatching { entry.onRecovered() }
+        }
+    }
+
+    override fun dispose() {
+        heartbeatTimer.stop()
+        browsers.clear()
+    }
+
+    companion object {
+        private const val HEARTBEAT_INTERVAL_MS = 5_000
+        private const val FREEZE_THRESHOLD_MS = 30_000
+
+        private val instances = java.util.concurrent.ConcurrentHashMap<Disposable, EdtFreezeRecovery>()
+
+        /**
+         * Gets or creates the singleton recovery instance for the given parent disposable.
+         * Typically called once per project with the project as parent.
+         */
+        fun getInstance(parentDisposable: Disposable): EdtFreezeRecovery {
+            return instances.computeIfAbsent(parentDisposable) { parent ->
+                val recovery = EdtFreezeRecovery(parent)
+                Disposer.register(parent) { instances.remove(parent) }
+                recovery
+            }
+        }
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/RunConfigurationServiceStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/RunConfigurationServiceStaticMethodsTest.java
@@ -14,7 +14,10 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for private static methods in {@link RunConfigurationService} via reflection.
@@ -96,11 +99,22 @@ class RunConfigurationServiceStaticMethodsTest {
             assertNull(call(args, "application"));
         }
 
-        @Test
-        void normalArgsAllowed() throws Exception {
+        static Stream<Arguments> allowedProgramArgs() {
+            return Stream.of(
+                Arguments.of("--verbose --port 8080", "application"),
+                // "test" alone doesn't match general abuse patterns, only gradle-specific check
+                Arguments.of("test --info", "application"),
+                // null configType means we only run general abuse detection (test alone won't match)
+                Arguments.of("test --info", null)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("allowedProgramArgs")
+        void allowedArgsReturnsNull(String programArgs, String configType) throws Exception {
             JsonObject args = new JsonObject();
-            args.addProperty("program_args", "--verbose --port 8080");
-            assertNull(call(args, "application"));
+            args.addProperty("program_args", programArgs);
+            assertNull(call(args, configType));
         }
 
         static Stream<Arguments> blockedCommands() {
@@ -120,22 +134,6 @@ class RunConfigurationServiceStaticMethodsTest {
             assertNotNull(result);
             assertTrue(result.contains(expectedSubstring),
                 "Expected result to contain '" + expectedSubstring + "' but was: " + result);
-        }
-
-        @Test
-        void gradleTestTaskAllowedForNonGradleType() throws Exception {
-            JsonObject args = new JsonObject();
-            args.addProperty("program_args", "test --info");
-            // "test" alone doesn't match general abuse patterns, only gradle-specific check
-            assertNull(call(args, "application"));
-        }
-
-        @Test
-        void nullConfigTypeAllowed() throws Exception {
-            JsonObject args = new JsonObject();
-            args.addProperty("program_args", "test --info");
-            // null configType means we only run general abuse detection (test alone won't match)
-            assertNull(call(args, null));
         }
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/RunConfigurationServiceStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/RunConfigurationServiceStaticMethodsTest.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonPrimitive;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -87,6 +88,7 @@ class RunConfigurationServiceStaticMethodsTest {
     }
 
     @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class CheckProgramArgsAbuse {
 
         private String call(JsonObject args, String configType) throws Exception {
@@ -99,7 +101,7 @@ class RunConfigurationServiceStaticMethodsTest {
             assertNull(call(args, "application"));
         }
 
-        static Stream<Arguments> allowedProgramArgs() {
+        Stream<Arguments> allowedProgramArgs() {
             return Stream.of(
                 Arguments.of("--verbose --port 8080", "application"),
                 // "test" alone doesn't match general abuse patterns, only gradle-specific check
@@ -117,7 +119,7 @@ class RunConfigurationServiceStaticMethodsTest {
             assertNull(call(args, configType));
         }
 
-        static Stream<Arguments> blockedCommands() {
+        Stream<Arguments> blockedCommands() {
             return Stream.of(
                 Arguments.of("git push origin main", "application", "Error:"),
                 Arguments.of("test --info", "gradle", "run_tests"),

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/ToolCallArgParserTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/ToolCallArgParserTest.java
@@ -5,8 +5,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -262,34 +266,22 @@ class ToolCallArgParserTest {
     @DisplayName("extractDiffFromArgs")
     class ExtractDiffFromArgs {
 
-        @Test
+        static Stream<Arguments> validDiffPairs() {
+            return Stream.of(
+                Arguments.of("{\"old_str\":\"foo\",\"new_str\":\"bar\"}", "foo", "bar"),
+                Arguments.of("{\"old_str\":\"\",\"new_str\":\"added\"}", "", "added"),
+                Arguments.of("{\"old_str\":\"removed\",\"new_str\":\"\"}", "removed", "")
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("validDiffPairs")
         @DisplayName("extracts old_str and new_str pair")
-        void extractsOldAndNewStr() {
-            Pair<String, String> result =
-                parser.extractDiffFromArgs("{\"old_str\":\"foo\",\"new_str\":\"bar\"}");
+        void extractsDiffPair(String json, String expectedOld, String expectedNew) {
+            Pair<String, String> result = parser.extractDiffFromArgs(json);
             assertNotNull(result);
-            assertEquals("foo", result.getFirst());
-            assertEquals("bar", result.getSecond());
-        }
-
-        @Test
-        @DisplayName("returns pair when old_str is blank but new_str is not")
-        void returnsWhenOldStrBlankNewStrNot() {
-            Pair<String, String> result =
-                parser.extractDiffFromArgs("{\"old_str\":\"\",\"new_str\":\"added\"}");
-            assertNotNull(result);
-            assertEquals("", result.getFirst());
-            assertEquals("added", result.getSecond());
-        }
-
-        @Test
-        @DisplayName("returns pair when new_str is blank but old_str is not")
-        void returnsWhenNewStrBlankOldStrNot() {
-            Pair<String, String> result =
-                parser.extractDiffFromArgs("{\"old_str\":\"removed\",\"new_str\":\"\"}");
-            assertNotNull(result);
-            assertEquals("removed", result.getFirst());
-            assertEquals("", result.getSecond());
+            assertEquals(expectedOld, result.getFirst());
+            assertEquals(expectedNew, result.getSecond());
         }
 
         @ParameterizedTest

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/ToolCallArgParserTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/ToolCallArgParserTest.java
@@ -4,6 +4,7 @@ import kotlin.Pair;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -264,9 +265,10 @@ class ToolCallArgParserTest {
 
     @Nested
     @DisplayName("extractDiffFromArgs")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ExtractDiffFromArgs {
 
-        static Stream<Arguments> validDiffPairs() {
+        Stream<Arguments> validDiffPairs() {
             return Stream.of(
                 Arguments.of("{\"old_str\":\"foo\",\"new_str\":\"bar\"}", "foo", "bar"),
                 Arguments.of("{\"old_str\":\"\",\"new_str\":\"added\"}", "", "added"),

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/HttpRequestRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/HttpRequestRendererTest.java
@@ -2,6 +2,7 @@ package com.github.catatafishen.agentbridge.ui.renderers;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -26,9 +27,10 @@ class HttpRequestRendererTest {
     // ── parseStatusLine ──────────────────────────────────────
 
     @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ParseStatusLine {
 
-        static Stream<Arguments> validStatusLines() {
+        Stream<Arguments> validStatusLines() {
             return Stream.of(
                 Arguments.of("HTTP 200 (123ms)\n\nbody", 200, "(123ms)"),
                 Arguments.of("HTTP 404 Not Found\n\n--- Body ---\nNo page", 404, "Not Found"),

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/HttpRequestRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/HttpRequestRendererTest.java
@@ -3,11 +3,18 @@ package com.github.catatafishen.agentbridge.ui.renderers;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
+import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for the pure parsing methods in {@link HttpRequestRenderer}.
@@ -21,49 +28,29 @@ class HttpRequestRendererTest {
     @Nested
     class ParseStatusLine {
 
-        @Test
-        void parsesNewFormat() {
-            var info = HttpRequestRenderer.parseStatusLine("HTTP 200 (123ms)\n\nbody");
-            assertNotNull(info);
-            assertEquals(200, info.code());
-            assertEquals("(123ms)", info.detail());
+        static Stream<Arguments> validStatusLines() {
+            return Stream.of(
+                Arguments.of("HTTP 200 (123ms)\n\nbody", 200, "(123ms)"),
+                Arguments.of("HTTP 404 Not Found\n\n--- Body ---\nNo page", 404, "Not Found"),
+                Arguments.of("HTTP 500 Internal Server Error", 500, "Internal Server Error"),
+                Arguments.of("HTTP 301 Moved Permanently\n\nLocation: /new", 301, "Moved Permanently"),
+                Arguments.of("HTTP 204 No Content", 204, "No Content")
+            );
         }
 
-        @Test
-        void parsesOldFormatWithMessage() {
-            var info = HttpRequestRenderer.parseStatusLine("HTTP 404 Not Found\n\n--- Body ---\nNo page");
+        @ParameterizedTest
+        @MethodSource("validStatusLines")
+        void parsesValidStatusLine(String input, int expectedCode, String expectedDetail) {
+            var info = HttpRequestRenderer.parseStatusLine(input);
             assertNotNull(info);
-            assertEquals(404, info.code());
-            assertEquals("Not Found", info.detail());
-        }
-
-        @Test
-        void parsesServerError() {
-            var info = HttpRequestRenderer.parseStatusLine("HTTP 500 Internal Server Error");
-            assertNotNull(info);
-            assertEquals(500, info.code());
-            assertEquals("Internal Server Error", info.detail());
-        }
-
-        @Test
-        void parsesRedirect() {
-            var info = HttpRequestRenderer.parseStatusLine("HTTP 301 Moved Permanently\n\nLocation: /new");
-            assertNotNull(info);
-            assertEquals(301, info.code());
+            assertEquals(expectedCode, info.code());
+            assertEquals(expectedDetail, info.detail());
         }
 
         @ParameterizedTest
         @ValueSource(strings = {"Not an HTTP response", "", "HTTP200", "HTTP abc OK"})
         void returnsNullForInvalidInput(String input) {
             assertNull(HttpRequestRenderer.parseStatusLine(input));
-        }
-
-        @Test
-        void parsesCodeOnlyWithDetail() {
-            var info = HttpRequestRenderer.parseStatusLine("HTTP 204 No Content");
-            assertNotNull(info);
-            assertEquals(204, info.code());
-            assertEquals("No Content", info.detail());
         }
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/InspectionResultRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/InspectionResultRendererTest.java
@@ -4,6 +4,7 @@ import kotlin.text.MatchResult;
 import kotlin.text.Regex;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -56,6 +57,7 @@ class InspectionResultRendererTest {
     }
 
     @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class FindingPatternRegex {
 
         @Test
@@ -69,7 +71,7 @@ class InspectionResultRendererTest {
             assertEquals("Unused variable 'x'", match.getGroupValues().get(4));
         }
 
-        static Stream<Arguments> findingPatternCases() {
+        Stream<Arguments> findingPatternCases() {
             return Stream.of(
                 Arguments.of("com/example/Foo.kt:10 [WARNING/SpellCheckingInspection] Typo in 'teh'", 3, "WARNING/SpellCheckingInspection"),
                 Arguments.of("File.java:1 [WEAK_WARNING] Redundant cast", 3, "WEAK_WARNING"),

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/InspectionResultRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/InspectionResultRendererTest.java
@@ -5,8 +5,12 @@ import kotlin.text.Regex;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -65,34 +69,26 @@ class InspectionResultRendererTest {
             assertEquals("Unused variable 'x'", match.getGroupValues().get(4));
         }
 
-        @Test
-        void matchesFindingWithToolId() {
-            String line = "com/example/Foo.kt:10 [WARNING/SpellCheckingInspection] Typo in 'teh'";
-            MatchResult match = FINDING_PATTERN.matchEntire(line);
-            assertNotNull(match);
-            assertEquals("WARNING/SpellCheckingInspection", match.getGroupValues().get(3));
+        static Stream<Arguments> findingPatternCases() {
+            return Stream.of(
+                Arguments.of("com/example/Foo.kt:10 [WARNING/SpellCheckingInspection] Typo in 'teh'", 3, "WARNING/SpellCheckingInspection"),
+                Arguments.of("File.java:1 [WEAK_WARNING] Redundant cast", 3, "WEAK_WARNING"),
+                Arguments.of("very/deep/nested/path/to/file/Example.java:999 [INFO] Message", 1, "very/deep/nested/path/to/file/Example.java")
+            );
         }
 
-        @Test
-        void matchesWeakWarning() {
-            String line = "File.java:1 [WEAK_WARNING] Redundant cast";
-            MatchResult match = FINDING_PATTERN.matchEntire(line);
+        @ParameterizedTest
+        @MethodSource("findingPatternCases")
+        void matchesFindingPattern(String input, int groupIndex, String expectedValue) {
+            MatchResult match = FINDING_PATTERN.matchEntire(input);
             assertNotNull(match);
-            assertEquals("WEAK_WARNING", match.getGroupValues().get(3));
+            assertEquals(expectedValue, match.getGroupValues().get(groupIndex));
         }
 
         @ParameterizedTest
         @ValueSource(strings = {"", "Found 5 problems across 3 files"})
         void doesNotMatchNonFindingInput(String input) {
             assertNull(FINDING_PATTERN.matchEntire(input));
-        }
-
-        @Test
-        void matchesLongPath() {
-            String line = "very/deep/nested/path/to/file/Example.java:999 [INFO] Message";
-            MatchResult match = FINDING_PATTERN.matchEntire(line);
-            assertNotNull(match);
-            assertEquals("very/deep/nested/path/to/file/Example.java", match.getGroupValues().get(1));
         }
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TodoRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TodoRendererTest.java
@@ -2,7 +2,7 @@ package com.github.catatafishen.agentbridge.ui.renderers;
 
 import kotlin.text.MatchResult;
 import kotlin.text.Regex;
-import org.junit.jupiter.api.Test;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;


### PR DESCRIPTION
## Problem

A prolonged EDT freeze (30+ seconds) permanently stalls the JCEF off-screen renderer. The JS engine remains alive (`executeJs` succeeds, DOM updates), but the visual viewport is stuck on the pre-freeze frame.

**Incident (2026-05-09):** 10+ simultaneous `read_file` MCP tool calls → each opened a file in the editor → triggered IntelliJ VCS annotations (`git log` 54s + `git blame` 80s) → EDT blocked 72 seconds → JCEF chat pane permanently frozen.

## Changes

### 1. `EdtFreezeRecovery` (new class)
EDT heartbeat monitor using a Swing Timer (5s interval). When the delta between heartbeats exceeds 30s, triggers JCEF OSR recovery on all registered browsers:
- `setWindowVisibility(false/true)` — tears down OSR compositor
- `notifyScreenInfoChanged()` — CEF re-reads device scale
- `wasResized()` + `invalidate()` — forces fresh frame delivery
- Logs at **ERROR** level so these events are immediately visible

### 2. `followFileIfEnabled` cooldown (`FileTool.java`)
2-second cooldown between file-open navigations. When 10+ tool calls arrive in a burst, only the first opens a file; subsequent calls within the window are throttled. Prevents cascading VCS operations that block EDT.

### 3. Documentation (`DEVELOPMENT.md`)
Full chain-of-events documentation and debugging steps for similar JCEF freeze issues.

## Testing
- Gradle compile passes clean
- Recovery uses the same proven sequence as `MonitorSwitchRecovery`