### PR TITLE
feat: use IDE terminal shell for hooks; add showInRunPanel support

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/RunPanelExecutor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/RunPanelExecutor.java
@@ -1,0 +1,146 @@
+package com.github.catatafishen.agentbridge.psi.tools;
+
+import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
+import com.github.catatafishen.agentbridge.services.AgentTabTracker;
+import com.intellij.execution.RunContentExecutor;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Shared utility for running processes in the IDE Run panel with output capture and timeout.
+ *
+ * <p>Used by {@link Tool} subclasses (via {@code executeInRunPanel}) and by
+ * {@link com.github.catatafishen.agentbridge.services.hooks.HookExecutor} when
+ * {@code showInRunPanel: true} is configured on a hook entry.
+ *
+ * <p>The chat-focus heuristic (don't steal keyboard focus when the chat window is active)
+ * is applied consistently in both callers because the check is performed inside
+ * {@link EdtUtil#invokeLater}, at the moment the Run panel tab is actually created.
+ */
+public final class RunPanelExecutor {
+
+    private RunPanelExecutor() {
+    }
+
+    /**
+     * Result of a process run via the IDE Run panel.
+     *
+     * @param exitCode exit code of the process, or {@code -1} on timeout
+     * @param output   combined stdout/stderr text collected by the process listener
+     * @param timedOut {@code true} if the process was killed due to the timeout
+     */
+    public record RunResult(int exitCode, String output, boolean timedOut) {
+    }
+
+    /**
+     * Show an already-created {@link Process} in the IDE Run panel, collect its output,
+     * and block until it exits or the timeout elapses.
+     *
+     * <p>The caller is responsible for writing stdin to {@code process.getOutputStream()}
+     * (typically in a separate thread before calling this method) because
+     * {@link OSProcessHandler} does not provide direct stdin injection.
+     *
+     * @param project     project context for the Run panel
+     * @param process     the already-started process (stdin may still be open)
+     * @param commandLine human-readable command line string shown in the Run panel header
+     * @param title       tab title in the Run tool window
+     * @param timeoutSec  maximum seconds to wait before force-killing the process
+     * @return a {@link RunResult} describing the outcome
+     * @throws Exception if the process handler cannot be set up (not thrown for non-zero exits)
+     */
+    @SuppressWarnings("java:S112")
+    public static @NotNull RunResult execute(@NotNull Project project,
+                                             @NotNull Process process,
+                                             @NotNull String commandLine,
+                                             @NotNull String title,
+                                             int timeoutSec) throws Exception {
+        CompletableFuture<Integer> exitFuture = new CompletableFuture<>();
+        StringBuilder output = new StringBuilder();
+
+        OSProcessHandler processHandler = new OSProcessHandler(process, commandLine);
+        processHandler.addProcessListener(new ProcessListener() {
+            @Override
+            public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
+                output.append(event.getText());
+            }
+
+            @Override
+            public void processTerminated(@NotNull ProcessEvent event) {
+                exitFuture.complete(event.getExitCode());
+            }
+        });
+
+        EdtUtil.invokeLater(() -> {
+            try {
+                // Evaluate chat-active state here on the EDT, not before invokeLater, to avoid
+                // a stale capture: RunContentExecutor.run() is the actual UI operation,
+                // and the user's focus may have changed between the check and this point.
+                //
+                // RunContentExecutor exposes TWO independent flags, both defaulting to true:
+                //   - withActivateToolWindow → setActivateToolWindowWhenAdded (window activation)
+                //   - withFocusToolWindow    → setAutoFocusContent           (tab content focus)
+                // Even with activateToolWindow=false, setAutoFocusContent(true) still steals
+                // keyboard focus into the new console tab when it is added to an already-visible
+                // Run window. Both must be gated together to keep focus on the chat prompt.
+                boolean chatActive = PsiBridgeService.isChatToolWindowActive(project);
+                new RunContentExecutor(project, processHandler)
+                    .withTitle(title)
+                    .withActivateToolWindow(!chatActive)
+                    .withFocusToolWindow(!chatActive)
+                    .run();
+            } catch (Exception e) {
+                // RunContentExecutor.run() may have already called startNotify() before
+                // throwing (e.g. if the Run panel fails to register the content descriptor).
+                // Only call startNotify() here if the process was not yet started, so the
+                // process output listeners can still receive events and the exit future completes.
+                if (!processHandler.isStartNotified()) {
+                    processHandler.startNotify();
+                }
+            }
+        });
+
+        AgentTabTracker.getInstance(project).trackTab("Run", title);
+
+        try {
+            int exitCode = exitFuture.get(timeoutSec, TimeUnit.SECONDS);
+            return new RunResult(exitCode, output.toString(), false);
+        } catch (TimeoutException e) {
+            processHandler.destroyProcess();
+            return new RunResult(-1, output.toString(), true);
+        }
+    }
+
+    /**
+     * Convenience overload: create a process from a {@link GeneralCommandLine} and run it in the
+     * IDE Run panel. Equivalent to calling
+     * {@link #execute(Project, Process, String, String, int)} with
+     * {@code cmd.createProcess()} and {@code cmd.getCommandLineString()}.
+     *
+     * <p>Use this overload when no stdin injection is needed. For hooks that pipe JSON into
+     * stdin, create the process manually and use the other overload.
+     *
+     * @param project    project context for the Run panel
+     * @param cmd        command to run
+     * @param title      tab title in the Run tool window
+     * @param timeoutSec maximum seconds to wait
+     * @return a {@link RunResult} describing the outcome
+     * @throws Exception if process creation or Run panel setup fails
+     */
+    @SuppressWarnings("java:S112")
+    public static @NotNull RunResult execute(@NotNull Project project,
+                                             @NotNull GeneralCommandLine cmd,
+                                             @NotNull String title,
+                                             int timeoutSec) throws Exception {
+        return execute(project, cmd.createProcess(), cmd.getCommandLineString(), title, timeoutSec);
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/Tool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/Tool.java
@@ -1,24 +1,12 @@
 package com.github.catatafishen.agentbridge.psi.tools;
 
-import com.github.catatafishen.agentbridge.psi.EdtUtil;
-import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
 import com.github.catatafishen.agentbridge.psi.ToolUtils;
-import com.github.catatafishen.agentbridge.services.AgentTabTracker;
 import com.github.catatafishen.agentbridge.services.ToolDefinition;
 import com.google.gson.JsonObject;
-import com.intellij.execution.RunContentExecutor;
-import com.intellij.execution.process.OSProcessHandler;
-import com.intellij.execution.process.ProcessEvent;
-import com.intellij.execution.process.ProcessListener;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Abstract base class for all individual tool implementations.
@@ -182,61 +170,8 @@ public abstract class Tool implements ToolDefinition {
     protected ProcessResult executeInRunPanel(
         com.intellij.execution.configurations.GeneralCommandLine cmd,
         String title, int timeoutSec) throws Exception {
-        CompletableFuture<Integer> exitFuture = new CompletableFuture<>();
-        StringBuilder output = new StringBuilder();
-
-        Process process = cmd.createProcess();
-        OSProcessHandler processHandler = new OSProcessHandler(process, cmd.getCommandLineString());
-        processHandler.addProcessListener(new ProcessListener() {
-            @Override
-            public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
-                output.append(event.getText());
-            }
-
-            @Override
-            public void processTerminated(@NotNull ProcessEvent event) {
-                exitFuture.complete(event.getExitCode());
-            }
-        });
-
-        EdtUtil.invokeLater(() -> {
-            try {
-                // Evaluate chat-active state here on the EDT, not before invokeLater, to avoid
-                // a stale capture: RunContentExecutor.run() is the actual UI operation,
-                // and the user's focus may have changed between the check and this point.
-                //
-                // RunContentExecutor exposes TWO independent flags, both defaulting to true:
-                //   - withActivateToolWindow → setActivateToolWindowWhenAdded (window activation)
-                //   - withFocusToolWindow    → setAutoFocusContent           (tab content focus)
-                // Even with activateToolWindow=false, setAutoFocusContent(true) still steals
-                // keyboard focus into the new console tab when it is added to an already-visible
-                // Run window. Both must be gated together to keep focus on the chat prompt.
-                boolean chatActive = PsiBridgeService.isChatToolWindowActive(project);
-                new RunContentExecutor(project, processHandler)
-                    .withTitle(title)
-                    .withActivateToolWindow(!chatActive)
-                    .withFocusToolWindow(!chatActive)
-                    .run();
-            } catch (Exception e) {
-                // RunContentExecutor.run() may have already called startNotify() before
-                // throwing (e.g. if the Run panel fails to register the content descriptor).
-                // Only call startNotify() here if the process was not yet started, so the
-                // process output listeners can still receive events and the exit future completes.
-                if (!processHandler.isStartNotified()) {
-                    processHandler.startNotify();
-                }
-            }
-        });
-
-        AgentTabTracker.getInstance(project).trackTab("Run", title);
-
-        try {
-            int exitCode = exitFuture.get(timeoutSec, TimeUnit.SECONDS);
-            return new ProcessResult(exitCode, output.toString(), false);
-        } catch (TimeoutException e) {
-            processHandler.destroyProcess();
-            return new ProcessResult(-1, output.toString(), true);
-        }
+        RunPanelExecutor.RunResult result = RunPanelExecutor.execute(project, cmd, title, timeoutSec);
+        return new ProcessResult(result.exitCode(), result.output(), result.timedOut());
     }
 
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/hooks/HookEntryConfig.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/hooks/HookEntryConfig.java
@@ -35,6 +35,8 @@ import java.util.Map;
  * @param env           extra environment variables merged into the script process
  * @param prependString optional static text prepended to tool output (null for permission hooks)
  * @param appendString  optional static text appended to tool output (null for permission hooks)
+ * @param showInRunPanel if true and the entry is not async, the script process is shown in the
+ *                       IDE Run panel instead of running silently in the background
  */
 public record HookEntryConfig(
     @Nullable String script,
@@ -43,7 +45,8 @@ public record HookEntryConfig(
     boolean async,
     @NotNull Map<String, String> env,
     @Nullable String prependString,
-    @Nullable String appendString
+    @Nullable String appendString,
+    boolean showInRunPanel
 ) {
 
     private static final int DEFAULT_TIMEOUT = 10;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/hooks/HookExecutor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/hooks/HookExecutor.java
@@ -1,12 +1,16 @@
 package com.github.catatafishen.agentbridge.services.hooks;
 
+import com.github.catatafishen.agentbridge.psi.tools.RunPanelExecutor;
 import com.github.catatafishen.agentbridge.services.ProcessStreamUtils;
+import com.github.catatafishen.agentbridge.settings.ShellEnvironment;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
+import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,6 +27,13 @@ import java.util.concurrent.TimeUnit;
 /**
  * Executes hook scripts with the stdin/stdout JSON protocol.
  * Handles timeout enforcement, failSilently behavior, async mode, and result parsing.
+ *
+ * <p>Shell discovery delegates to {@link ShellEnvironment#getShellPath(Project)} which
+ * consults IntelliJ's configured terminal shell — no disk scanning is performed here.
+ *
+ * <p>When a hook entry has {@code showInRunPanel: true} and is not async, the process
+ * is shown in the IDE Run panel via {@link RunPanelExecutor} so the user can observe
+ * its output in real time.
  */
 public final class HookExecutor {
 
@@ -36,7 +47,8 @@ public final class HookExecutor {
     private HookExecutor() {
     }
 
-    public static @NotNull HookResult execute(@NotNull HookEntryConfig entry,
+    public static @NotNull HookResult execute(@NotNull Project project,
+                                              @NotNull HookEntryConfig entry,
                                               @NotNull HookTrigger trigger,
                                               @NotNull HookPayload payload,
                                               @NotNull ToolHookConfig config,
@@ -47,12 +59,12 @@ public final class HookExecutor {
         }
 
         if (entry.async()) {
-            startAsync(scriptPath, entry, payload, config.toolId(), projectEnv);
+            startAsync(project, scriptPath, entry, payload, config, projectEnv);
             return new HookResult.NoOp();
         }
 
         try {
-            String stdout = runScript(scriptPath, entry, payload, projectEnv);
+            String stdout = runScript(project, scriptPath, entry, payload, config, projectEnv);
             return parseResult(trigger, stdout);
         } catch (IOException e) {
             if (entry.failSilently()) {
@@ -64,40 +76,108 @@ public final class HookExecutor {
         }
     }
 
-    private static void startAsync(@NotNull Path scriptPath,
+    private static void startAsync(@NotNull Project project,
+                                   @NotNull Path scriptPath,
                                    @NotNull HookEntryConfig entry,
                                    @NotNull HookPayload payload,
-                                   @NotNull String toolId,
+                                   @NotNull ToolHookConfig config,
                                    @NotNull Map<String, String> projectEnv) {
         CompletableFuture.runAsync(() -> {
             try {
-                runScript(scriptPath, entry, payload, projectEnv);
+                runScript(project, scriptPath, entry, payload, config, projectEnv);
             } catch (IOException e) {
-                LOG.warn("Async hook script failed for tool '" + toolId + "': " + e.getMessage());
+                LOG.warn("Async hook script failed for tool '" + config.toolId() + "': " + e.getMessage());
             }
         });
     }
 
-    private static @NotNull String runScript(@NotNull Path scriptPath,
+    private static @NotNull String runScript(@NotNull Project project,
+                                             @NotNull Path scriptPath,
                                              @NotNull HookEntryConfig entry,
                                              @NotNull HookPayload payload,
+                                             @NotNull ToolHookConfig config,
                                              @NotNull Map<String, String> projectEnv) throws IOException {
-        List<String> command = buildCommand(scriptPath);
-        ProcessBuilder builder = new ProcessBuilder(command);
-        builder.directory(scriptPath.getParent().toFile());
+        List<String> command = buildCommand(scriptPath, project);
+        GeneralCommandLine cmd = new GeneralCommandLine(command);
+        cmd.setWorkDirectory(scriptPath.getParent().toFile());
 
         // Layer environment variables: project context → per-entry overrides → argument values
-        Map<String, String> env = builder.environment();
-        env.putAll(projectEnv);
-
+        cmd.withEnvironment(projectEnv);
         if (!entry.env().isEmpty()) {
-            env.putAll(entry.env());
+            cmd.withEnvironment(entry.env());
+        }
+        cmd.withEnvironment(HookEnvironmentProvider.getArgumentEnvironment(payload.arguments()));
+
+        // Route to the IDE Run panel when configured and the entry is synchronous
+        if (entry.showInRunPanel() && !entry.async()) {
+            return runInPanel(project, cmd, entry, payload, config.toolId());
+        }
+        return runDirect(cmd, entry, payload);
+    }
+
+    /**
+     * Run the hook process in the IDE Run panel so the user can observe its output.
+     * JSON payload is written to stdin asynchronously immediately after process creation,
+     * before the Run panel registers the process handler.
+     */
+    private static @NotNull String runInPanel(@NotNull Project project,
+                                              @NotNull GeneralCommandLine cmd,
+                                              @NotNull HookEntryConfig entry,
+                                              @NotNull HookPayload payload,
+                                              @NotNull String toolId) throws IOException {
+        byte[] stdinBytes = GSON.toJson(payload).getBytes(StandardCharsets.UTF_8);
+
+        Process process;
+        try {
+            process = cmd.createProcess();
+        } catch (Exception e) {
+            throw new IOException("Failed to start hook process: " + e.getMessage(), e);
         }
 
-        Map<String, String> argEnv = HookEnvironmentProvider.getArgumentEnvironment(payload.arguments());
-        env.putAll(argEnv);
+        // Write JSON to stdin in a background thread; the hook reads it as it runs.
+        // Errors are swallowed — some hooks may not read stdin at all.
+        CompletableFuture.runAsync(() -> {
+            try (var stdin = process.getOutputStream()) {
+                stdin.write(stdinBytes);
+            } catch (IOException ignored) {
+                // Hook may not consume stdin; ignore broken-pipe errors
+            }
+        });
 
-        Process process = builder.start();
+        String title = "Hook: " + toolId;
+        RunPanelExecutor.RunResult result;
+        try {
+            result = RunPanelExecutor.execute(project, process, cmd.getCommandLineString(), title, entry.timeout());
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Hook Run panel execution failed: " + e.getMessage(), e);
+        }
+
+        if (result.timedOut()) {
+            throw new IOException("Hook timed out after " + entry.timeout() + "s");
+        }
+        if (result.exitCode() != 0) {
+            String detail = result.output().isBlank() ? "" : ": " + truncate(result.output().trim());
+            throw new IOException("Hook exited with code " + result.exitCode() + detail);
+        }
+        return result.output();
+    }
+
+    /**
+     * Run the hook process directly (no Run panel), capturing stdout/stderr and injecting
+     * the JSON payload via stdin.
+     */
+    private static @NotNull String runDirect(@NotNull GeneralCommandLine cmd,
+                                             @NotNull HookEntryConfig entry,
+                                             @NotNull HookPayload payload) throws IOException {
+        Process process;
+        try {
+            process = cmd.createProcess();
+        } catch (Exception e) {
+            throw new IOException("Failed to start hook process: " + e.getMessage(), e);
+        }
+
         CompletableFuture<String> stdout = readAsync(process.getInputStream());
         CompletableFuture<String> stderr = readAsync(process.getErrorStream());
 
@@ -116,7 +196,7 @@ public final class HookExecutor {
 
         if (!finished) {
             process.destroyForcibly();
-            throw new IOException("Hook timed out after " + entry.timeout() + "s: " + scriptPath);
+            throw new IOException("Hook timed out after " + entry.timeout() + "s");
         }
 
         String out = await(stdout, "stdout");
@@ -207,8 +287,6 @@ public final class HookExecutor {
         };
     }
 
-    private static final String DEFAULT_SHELL = "/bin/sh";
-
     /**
      * Build the command list used to invoke the hook script.
      * <ul>
@@ -217,10 +295,11 @@ public final class HookExecutor {
      *       line (e.g. {@code #!/usr/bin/env bash} → {@code bash scriptPath}).
      *       If the shebang uses {@code /usr/bin/env}, the resolver token after {@code env}
      *       is extracted so that e.g. {@code #!/usr/bin/env python3} works correctly.</li>
-     *   <li>Scripts with no readable shebang fall back to {@code /bin/sh}.</li>
+     *   <li>Scripts with no readable shebang fall back to the IntelliJ-configured shell
+     *       (via {@link ShellEnvironment#getShellPath(Project)}).</li>
      * </ul>
      */
-    private static @NotNull List<String> buildCommand(@NotNull Path scriptPath) {
+    private static @NotNull List<String> buildCommand(@NotNull Path scriptPath, @NotNull Project project) {
         List<String> cmd = new ArrayList<>();
         String fileName = scriptPath.getFileName().toString().toLowerCase();
         if (fileName.endsWith(".ps1")) {
@@ -229,7 +308,7 @@ public final class HookExecutor {
             cmd.add("Bypass");
             cmd.add("-File");
         } else {
-            cmd.add(resolveInterpreter(scriptPath));
+            cmd.add(resolveInterpreter(scriptPath, project));
         }
         cmd.add(scriptPath.toAbsolutePath().toString());
         return cmd;
@@ -237,22 +316,22 @@ public final class HookExecutor {
 
     /**
      * Extract the interpreter from the script's shebang line.
-     * Returns {@code /bin/sh} as a safe fallback when the shebang is absent or unreadable.
+     * Falls back to the IntelliJ-configured terminal shell when the shebang is absent or unreadable.
      */
-    private static @NotNull String resolveInterpreter(@NotNull Path scriptPath) {
+    private static @NotNull String resolveInterpreter(@NotNull Path scriptPath, @NotNull Project project) {
         try (java.io.BufferedReader reader = java.nio.file.Files.newBufferedReader(scriptPath)) {
             String firstLine = reader.readLine();
-            if (firstLine == null || !firstLine.startsWith("#!")) return DEFAULT_SHELL;
+            if (firstLine == null || !firstLine.startsWith("#!")) return ShellEnvironment.getShellPath(project);
             String shebang = firstLine.substring(2).trim();
             // /usr/bin/env python3  →  python3
             if (shebang.startsWith("/usr/bin/env ")) {
                 String[] parts = shebang.substring("/usr/bin/env ".length()).trim().split("\\s+");
-                return parts[0].isEmpty() ? DEFAULT_SHELL : parts[0];
+                return parts[0].isEmpty() ? ShellEnvironment.getShellPath(project) : parts[0];
             }
             // /bin/bash  or  /usr/bin/python3  →  use as-is
             return shebang.split("\\s+")[0];
         } catch (java.io.IOException e) {
-            return DEFAULT_SHELL;
+            return ShellEnvironment.getShellPath(project);
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/hooks/HookPipeline.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/hooks/HookPipeline.java
@@ -98,7 +98,7 @@ public final class HookPipeline {
             toolName, arguments, project.getName(), Instant.now().toString());
 
         for (HookEntryConfig entry : entries) {
-            HookResult result = HookExecutor.execute(entry, HookTrigger.PERMISSION, payload, config, projectEnv);
+            HookResult result = HookExecutor.execute(project, entry, HookTrigger.PERMISSION, payload, config, projectEnv);
             if (result instanceof HookResult.PermissionDecision(boolean allowed, String reason) && !allowed) {
                 String resolvedReason = reason != null ? reason : "Denied by permission hook";
                 LOG.info("Permission hook denied tool " + toolName + ": " + resolvedReason);
@@ -131,7 +131,7 @@ public final class HookPipeline {
             HookPayload payload = HookPayload.forPreExecution(
                 toolName, currentArgs, project.getName(), Instant.now().toString());
 
-            HookResult result = HookExecutor.execute(entry, HookTrigger.PRE, payload, config, projectEnv);
+            HookResult result = HookExecutor.execute(project, entry, HookTrigger.PRE, payload, config, projectEnv);
 
             if (result instanceof HookResult.PreHookFailure(String error)) {
                 LOG.info("Pre-hook blocked tool " + toolName + ": " + error);
@@ -182,7 +182,7 @@ public final class HookPipeline {
                 toolName, arguments, currentOutput, isError, project.getName(),
                 Instant.now().toString(), durationMs);
 
-            HookResult result = HookExecutor.execute(entry, HookTrigger.SUCCESS, payload, config, projectEnv);
+            HookResult result = HookExecutor.execute(project, entry, HookTrigger.SUCCESS, payload, config, projectEnv);
             if (result instanceof HookResult.OutputModification mod) {
                 currentOutput = applyOutputText(mod, currentOutput);
                 if (mod.stateOverride() != null) {
@@ -217,7 +217,7 @@ public final class HookPipeline {
                 toolName, arguments, currentOutput, isError, project.getName(),
                 Instant.now().toString(), durationMs);
 
-            HookResult result = HookExecutor.execute(entry, HookTrigger.FAILURE, payload, config, projectEnv);
+            HookResult result = HookExecutor.execute(project, entry, HookTrigger.FAILURE, payload, config, projectEnv);
             if (result instanceof HookResult.OutputModification mod) {
                 String modifiedOutput = applyOutputText(mod, currentOutput);
                 if (modifiedOutput != null) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/hooks/HookRegistry.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/hooks/HookRegistry.java
@@ -216,9 +216,10 @@ public final class HookRegistry {
             ? obj.get("prependString").getAsString() : null;
         String appendString = (trigger != HookTrigger.PERMISSION && obj.has("appendString"))
             ? obj.get("appendString").getAsString() : null;
+        boolean showInRunPanel = obj.has("showInRunPanel") && obj.get("showInRunPanel").getAsBoolean();
 
         return new HookEntryConfig(script, timeout, failSilently, async, Map.copyOf(env),
-            prependString, appendString);
+            prependString, appendString, showInRunPanel);
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/hooks/ToolHookConfig.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/hooks/ToolHookConfig.java
@@ -102,6 +102,7 @@ public record ToolHookConfig(
             obj.addProperty("failSilently", false);
         }
         if (entry.async()) obj.addProperty("async", true);
+        if (entry.showInRunPanel()) obj.addProperty("showInRunPanel", true);
         if (!entry.env().isEmpty()) {
             JsonObject envObj = new JsonObject();
             entry.env().forEach(envObj::addProperty);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ShellEnvironment.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ShellEnvironment.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.settings;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedReader;
@@ -155,5 +156,76 @@ public class ShellEnvironment {
             path = System.getenv("PATH");
         }
         return path != null ? path : "";
+    }
+
+    /**
+     * Returns the shell to use for executing hook scripts, consulting IntelliJ's terminal
+     * settings for the given project via reflection.
+     *
+     * <p>Resolution order:
+     * <ol>
+     *   <li>IntelliJ's {@code TerminalProjectOptionsProvider.getShellPath()} — if the result
+     *       is a recognised POSIX shell (sh, bash, zsh, dash, fish) it is returned directly.</li>
+     *   <li>The {@code $SHELL} environment variable (Unix only).</li>
+     *   <li>{@code /bin/sh} on Unix; {@code "sh"} on Windows (resolved via {@code PATH},
+     *       e.g. Git Bash adds {@code sh} to the system PATH on Windows).</li>
+     * </ol>
+     *
+     * <p>No disk scanning is performed.
+     *
+     * @param project the current project
+     * @return the resolved shell executable path (never blank)
+     */
+    @NotNull
+    public static String getShellPath(@NotNull Project project) {
+        try {
+            Class<?> cls = Class.forName("org.jetbrains.plugins.terminal.TerminalProjectOptionsProvider");
+            Object settings = cls.getMethod("getInstance", Project.class).invoke(null, project);
+            String path = (String) settings.getClass().getMethod("getShellPath").invoke(settings);
+            if (path != null && !path.isBlank() && isPosixShell(path)) {
+                return path;
+            }
+        } catch (Exception e) {
+            LOG.info("Could not read IntelliJ terminal shell path via reflection: " + e.getMessage());
+        }
+        return getShellPath();
+    }
+
+    /**
+     * Returns a fallback shell path without consulting any project settings.
+     * On Unix returns {@code $SHELL} (or {@code /bin/sh} if unset).
+     * On Windows returns {@code "sh"} (resolved via {@code PATH}, e.g. Git Bash).
+     *
+     * <p>No disk scanning is performed.
+     *
+     * @return the shell executable path (never blank)
+     */
+    @NotNull
+    public static String getShellPath() {
+        String os = System.getProperty("os.name", "").toLowerCase();
+        if (os.contains("win")) {
+            return "sh";
+        }
+        String envShell = System.getenv("SHELL");
+        return (envShell != null && !envShell.isBlank()) ? envShell : "/bin/sh";
+    }
+
+    /**
+     * Returns {@code true} if the given shell path (or bare name) refers to a POSIX-compatible
+     * shell that can be used to run hook scripts.
+     */
+    private static boolean isPosixShell(@NotNull String shellPath) {
+        String name = shellPath;
+        int lastSlash = Math.max(shellPath.lastIndexOf('/'), shellPath.lastIndexOf('\\'));
+        if (lastSlash >= 0) {
+            name = shellPath.substring(lastSlash + 1);
+        }
+        // Strip extension (e.g. bash.exe on Windows)
+        int dotIdx = name.lastIndexOf('.');
+        if (dotIdx > 0) name = name.substring(0, dotIdx);
+        return switch (name.toLowerCase()) {
+            case "sh", "bash", "zsh", "dash", "fish" -> true;
+            default -> false;
+        };
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolHookDialog.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolHookDialog.kt
@@ -297,7 +297,7 @@ class ToolHookDialog(
         section.entries.add(
             HookEntryConfig(
                 script, timeoutSpinner.value as Int, failSilently, asyncBox.isSelected,
-                emptyMap(), prepend, append
+                emptyMap(), prepend, append, false
             )
         )
         rebuildEntryRows(section, panel)


### PR DESCRIPTION
## Summary

Two missed requirements from the original hook system design.

### 1. Use IntelliJ's configured terminal shell (not disk scanning)

Previously ShellEnvironment scanned the filesystem for shells on Windows. This looks suspicious and reinvents what IntelliJ already provides.

Now: getShellPath(Project) queries TerminalProjectOptionsProvider via reflection — same pattern as TerminalTool. Falls back to $SHELL / /bin/sh on Unix, or 'sh' on Windows.

### 2. Show hook execution in IDE Run panel

Hook entries can set showInRunPanel: true to show script execution as an IDE Run panel tab:

    { "type": "script", "script": "scripts/my-hook.sh", "showInRunPanel": true }

When set, JSON stdin is written asynchronously and execution routes through RunPanelExecutor.

### 3. Extract RunPanelExecutor utility

Tool.executeInRunPanel() extracted to standalone RunPanelExecutor (usable by both Tool and HookExecutor). Tool delegates to it (60 -> 7 lines).

## Files Changed

- ShellEnvironment: getShellPath(Project) via reflection; no-arg fallback; removed all disk scanning
- HookExecutor: GeneralCommandLine instead of ProcessBuilder; Project param; runInPanel/runDirect dispatch
- RunPanelExecutor: new shared utility extracted from Tool
- HookEntryConfig: add showInRunPanel field
- HookRegistry / ToolHookConfig: parse and serialize showInRunPanel
- HookPipeline: pass project to all executor call sites
- Tool.executeInRunPanel(): delegates to RunPanelExecutor