### PR TITLE
fix: show actionable message for Node.js ES module error

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/bridge/ProfileBasedAgentConfig.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/bridge/ProfileBasedAgentConfig.java
@@ -24,7 +24,6 @@ import com.intellij.openapi.util.SystemInfo;
 import com.intellij.util.SystemProperties;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,8 +32,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Generic {@link AgentConfig} implementation driven entirely by an {@link AgentProfile}.
@@ -43,7 +40,6 @@ import java.util.regex.Pattern;
 public class ProfileBasedAgentConfig implements AgentConfig {
 
     private static final Logger LOG = Logger.getInstance(ProfileBasedAgentConfig.class);
-    private static final Pattern NVM_NODE_VERSION_PATTERN = Pattern.compile("/node/v(\\d+)");
     private static final String MCP_SERVERS_KEY = "mcpServers";
 
     private final AgentProfile profile;
@@ -376,12 +372,8 @@ public class ProfileBasedAgentConfig implements AgentConfig {
     /**
      * If the binary is NVM-managed, prepend the corresponding node binary to the command.
      */
-    private void addNodeAndCommand(@NotNull List<String> cmd, @NotNull String binaryPath) throws ClientException {
+    private void addNodeAndCommand(@NotNull List<String> cmd, @NotNull String binaryPath) {
         if (binaryPath.contains("/.nvm/versions/node/") && binaryPath.contains("/bin/")) {
-            int minVersion = profile.getMinNodeVersion();
-            if (minVersion > 0) {
-                checkNvmVersion(binaryPath, minVersion);
-            }
             String nodeDir = binaryPath.substring(0, binaryPath.lastIndexOf("/bin/"));
             String nodePath = nodeDir + "/bin/node";
             if (new File(nodePath).exists()) {
@@ -389,29 +381,6 @@ public class ProfileBasedAgentConfig implements AgentConfig {
             }
         }
         cmd.add(binaryPath);
-    }
-
-    /**
-     * Validates that the Node.js major version in an NVM-managed binary path meets the minimum
-     * required version. Throws {@link ClientException} with an actionable message if not.
-     *
-     * <p>The version is extracted from the NVM path segment {@code /node/vN/} or {@code /node/vN.M.P/}.
-     * If the path does not contain a recognisable version number, the check is skipped silently.
-     */
-    @VisibleForTesting
-    static void checkNvmVersion(@NotNull String binaryPath, int minVersion) throws ClientException {
-        Matcher m = NVM_NODE_VERSION_PATTERN.matcher(binaryPath);
-        if (!m.find()) return;
-        int major = Integer.parseInt(m.group(1));
-        if (major < minVersion) {
-            throw new ClientException(
-                "GitHub Copilot requires Node.js v" + minVersion + " or higher. "
-                    + "Currently using Node.js v" + major + " (from NVM). "
-                    + "Update with: nvm install " + minVersion
-                    + " && nvm use " + minVersion
-                    + " && npm install -g @github/copilot-cli",
-                null, false);
-        }
     }
 
     private void addMcpConfigFlag(@NotNull List<String> cmd, int mcpPort) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -28,6 +28,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Executes MCP tool calls inside IntelliJ, providing PSI/AST-backed code intelligence.
@@ -85,6 +87,11 @@ public final class PsiBridgeService implements Disposable {
     private static final String TOOL_REPLACE_SYMBOL_BODY = "replace_symbol_body";
     private static final String TOOL_INSERT_BEFORE_SYMBOL = "insert_before_symbol";
     private static final String TOOL_INSERT_AFTER_SYMBOL = "insert_after_symbol";
+
+    /**
+     * Matches the "Context after edit (lines X-Y):" header written by WriteFileTool.
+     */
+    static final Pattern CONTEXT_LINES_PATTERN = Pattern.compile("Context after edit \\(lines (\\d+)-(\\d+)\\)");
 
     /**
      * Tools disabled in Rider because they depend on detailed PSI (which lives in
@@ -1019,12 +1026,33 @@ public final class PsiBridgeService implements Disposable {
         JsonObject highlightArgs = new JsonObject();
         highlightArgs.addProperty("path", path);
         highlightArgs.addProperty("include_unindexed", true);
+        int[] lineRange = parseContextLineRange(writeResult);
+        if (lineRange != null) {
+            highlightArgs.addProperty("start_line", lineRange[0]);
+            highlightArgs.addProperty("end_line", lineRange[1]);
+        }
         String highlights = highlightDef.execute(highlightArgs);
         if (highlights != null) {
             LOG.info("Auto-highlights: appended " + highlights.split("\n").length + " lines for " + path);
         }
 
         return formatHighlightResult(writeResult, highlights);
+    }
+
+    /**
+     * Extracts the edited line range from a write-tool result string.
+     * Returns {@code [startLine, endLine]} (1-based, inclusive) if a
+     * {@code "Context after edit (lines X-Y):"} header is present, or {@code null} otherwise.
+     */
+    @Nullable
+    static int[] parseContextLineRange(String writeResult) {
+        if (writeResult == null || writeResult.isEmpty()) return null;
+        Matcher m = CONTEXT_LINES_PATTERN.matcher(writeResult);
+        if (!m.find()) return null;
+        int start = Integer.parseInt(m.group(1));
+        int end = Integer.parseInt(m.group(2));
+        if (start > end) return null;
+        return new int[]{start, end};
     }
 
     private DaemonWaiter resolveActiveWaiter(

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsTool.java
@@ -43,6 +43,8 @@ public final class GetHighlightsTool extends QualityTool {
     };
 
     private static final String PARAM_INCLUDE_UNINDEXED = "include_unindexed";
+    private static final String PARAM_START_LINE = "start_line";
+    private static final String PARAM_END_LINE = "end_line";
 
     public GetHighlightsTool(Project project) {
         super(project);
@@ -84,7 +86,9 @@ public final class GetHighlightsTool extends QualityTool {
         return schema(
             Param.optional("path", TYPE_STRING, "Optional: file path to check. If omitted, checks all open files", ""),
             Param.optional(PARAM_LIMIT, TYPE_INTEGER, "Maximum number of highlights to return (default: 100)"),
-            Param.optional(PARAM_INCLUDE_UNINDEXED, TYPE_BOOLEAN, "If true, also include highlights from files not indexed by the project (default: false)")
+            Param.optional(PARAM_INCLUDE_UNINDEXED, TYPE_BOOLEAN, "If true, also include highlights from files not indexed by the project (default: false)"),
+            Param.optional(PARAM_START_LINE, TYPE_INTEGER, "Only return highlights on or after this line (1-based, inclusive). If end_line is omitted, includes all lines from start_line onwards."),
+            Param.optional(PARAM_END_LINE, TYPE_INTEGER, "Only return highlights on or before this line (1-based, inclusive). Used with start_line. Defaults to no upper bound when start_line is set.")
         );
     }
 
@@ -93,6 +97,8 @@ public final class GetHighlightsTool extends QualityTool {
         String pathStr = args.has("path") ? args.get("path").getAsString() : null;
         int limit = args.has(PARAM_LIMIT) ? args.get(PARAM_LIMIT).getAsInt() : 100;
         boolean includeUnindexed = args.has(PARAM_INCLUDE_UNINDEXED) && args.get(PARAM_INCLUDE_UNINDEXED).getAsBoolean();
+        int startLine = args.has(PARAM_START_LINE) ? args.get(PARAM_START_LINE).getAsInt() : 0;
+        int endLine = args.has(PARAM_END_LINE) ? args.get(PARAM_END_LINE).getAsInt() : 0;
 
         if (!project.isInitialized()) {
             return ERROR_IDE_INITIALIZING;
@@ -111,7 +117,7 @@ public final class GetHighlightsTool extends QualityTool {
         CompletableFuture<String> resultFuture = new CompletableFuture<>();
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
             try {
-                getHighlightsCached(pathStr, limit, includeUnindexed, resultFuture);
+                getHighlightsCached(pathStr, limit, includeUnindexed, startLine, endLine, resultFuture);
             } catch (Exception e) {
                 LOG.error("Error getting highlights", e);
                 resultFuture.complete("Error getting highlights: " + e.getMessage());
@@ -121,6 +127,7 @@ public final class GetHighlightsTool extends QualityTool {
     }
 
     private void getHighlightsCached(String pathStr, int limit, boolean includeUnindexed,
+                                     int startLine, int endLine,
                                      CompletableFuture<String> resultFuture) {
         StringBuilder result = new StringBuilder();
         ApplicationManager.getApplication().runReadAction(() -> {
@@ -132,7 +139,7 @@ public final class GetHighlightsTool extends QualityTool {
             LOG.info("Analyzing " + allFiles.size() + " files for highlights (cached mode)");
 
             List<String> problems = new ArrayList<>();
-            int[] counts = analyzeFilesForHighlights(allFiles, limit, problems);
+            int[] counts = analyzeFilesForHighlights(allFiles, limit, startLine, endLine, problems);
 
             if (problems.isEmpty()) {
                 result.append(String.format("No highlights found in %d files analyzed (0 files with issues). " +
@@ -242,7 +249,8 @@ public final class GetHighlightsTool extends QualityTool {
         }
     }
 
-    private int[] analyzeFilesForHighlights(Collection<VirtualFile> files, int limit, List<String> problems) {
+    private int[] analyzeFilesForHighlights(Collection<VirtualFile> files, int limit,
+                                             int startLine, int endLine, List<String> problems) {
         String basePath = project.getBasePath();
         int totalCount = 0;
         int filesWithProblems = 0;
@@ -251,7 +259,7 @@ public final class GetHighlightsTool extends QualityTool {
             Document doc = FileDocumentManager.getInstance().getDocument(vf);
             if (doc != null) {
                 String relPath = basePath != null ? relativize(basePath, vf.getPath()) : vf.getName();
-                int added = collectFileHighlights(doc, relPath, limit - totalCount, problems);
+                int added = collectFileHighlights(doc, relPath, limit - totalCount, startLine, endLine, problems);
                 if (added > 0) filesWithProblems++;
                 totalCount += added;
             }
@@ -259,7 +267,8 @@ public final class GetHighlightsTool extends QualityTool {
         return new int[]{totalCount, filesWithProblems};
     }
 
-    private int collectFileHighlights(Document doc, String relPath, int remaining, List<String> problems) {
+    private int collectFileHighlights(Document doc, String relPath, int remaining,
+                                       int startLine, int endLine, List<String> problems) {
         List<com.intellij.codeInsight.daemon.impl.HighlightInfo> highlights = new ArrayList<>();
         int added = 0;
         DiagnosticFilterSettings filter = DiagnosticFilterSettings.getInstance(project);
@@ -273,6 +282,7 @@ public final class GetHighlightsTool extends QualityTool {
                 if (h.getDescription() == null) continue;
                 if (!filter.shouldInclude(h)) continue;
                 int line = doc.getLineNumber(h.getStartOffset()) + 1;
+                if (startLine > 0 && (line < startLine || (endLine > 0 && line > endLine))) continue;
                 StringBuilder entry = new StringBuilder(
                     String.format(FORMAT_LOCATION, relPath, line, severity.getName(), h.getDescription()));
                 List<String> fixes = collectQuickFixNames(h);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfile.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfile.java
@@ -59,13 +59,6 @@ public final class AgentProfile {
     private List<String> alternateNames;
     private String installHint;
     private String customBinaryPath;
-    /**
-     * Minimum required Node.js major version (e.g. {@code 24} for Node.js v24+).
-     * When non-zero and the binary is NVM-managed, the launcher validates the Node.js version
-     * before starting and fails fast with a clear upgrade hint if it is too old.
-     * Zero means no constraint.
-     */
-    private int minNodeVersion;
 
     // ── Command Building ─────────────────────────────────────────────────────
 
@@ -166,7 +159,6 @@ public final class AgentProfile {
         copy.alternateNames = new ArrayList<>(alternateNames);
         copy.installHint = installHint;
         copy.customBinaryPath = customBinaryPath;
-        copy.minNodeVersion = minNodeVersion;
         copy.acpArgs = new ArrayList<>(acpArgs);
         copy.mcpMethod = mcpMethod;
         copy.mcpConfigTemplate = mcpConfigTemplate;
@@ -202,7 +194,6 @@ public final class AgentProfile {
         copy.alternateNames = new ArrayList<>(alternateNames);
         copy.installHint = installHint;
         copy.customBinaryPath = customBinaryPath;
-        copy.minNodeVersion = minNodeVersion;
         copy.acpArgs = new ArrayList<>(acpArgs);
         copy.mcpMethod = mcpMethod;
         copy.mcpConfigTemplate = mcpConfigTemplate;
@@ -238,7 +229,6 @@ public final class AgentProfile {
         this.alternateNames = new ArrayList<>(other.alternateNames);
         this.installHint = other.installHint;
         this.customBinaryPath = other.customBinaryPath;
-        this.minNodeVersion = other.minNodeVersion;
         this.acpArgs = new ArrayList<>(other.acpArgs);
         this.mcpMethod = other.mcpMethod;
         this.mcpConfigTemplate = other.mcpConfigTemplate;
@@ -372,14 +362,6 @@ public final class AgentProfile {
 
     public void setCustomBinaryPath(@NotNull String customBinaryPath) {
         this.customBinaryPath = customBinaryPath;
-    }
-
-    public int getMinNodeVersion() {
-        return minNodeVersion;
-    }
-
-    public void setMinNodeVersion(int minNodeVersion) {
-        this.minNodeVersion = minNodeVersion;
     }
 
     @NotNull

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfileManager.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfileManager.java
@@ -1,9 +1,9 @@
 package com.github.catatafishen.agentbridge.services;
 
+import com.github.catatafishen.agentbridge.bridge.TransportType;
 import com.github.catatafishen.agentbridge.client.acp.HermesClient;
 import com.github.catatafishen.agentbridge.client.claude.ClaudeClient;
 import com.github.catatafishen.agentbridge.client.codex.CodexClient;
-import com.github.catatafishen.agentbridge.bridge.TransportType;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.Service;
@@ -260,7 +260,6 @@ public final class AgentProfileManager implements PersistentStateComponent<Agent
         p.setAlternateNames(List.of("copilot-cli"));
         p.setInstallHint("Install with: npm install -g @github/copilot-cli");
         p.setInstallUrl("https://github.com/github/copilot-cli#installation");
-        p.setMinNodeVersion(24);
         p.setSupportsOAuthSignIn(true);
         p.setPrependInstructionsTo(".github/copilot-instructions.md");
         p.setStripNonEssentialPath(true);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptErrorClassifier.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptErrorClassifier.kt
@@ -23,14 +23,6 @@ object PromptErrorClassifier {
         val displayMessage: String,
     )
 
-    /**
-     * Classifies a prompt error into a set of boolean decisions and a display message.
-     *
-     * @param exception the thrown exception
-     * @param turnHadContent whether the agent produced any content before the error
-     * @param isAuthenticationError predicate to check if a message indicates an auth failure
-     * @param isClientHealthy whether the agent client is still responsive
-     */
     fun classify(
         exception: Exception,
         turnHadContent: Boolean,
@@ -59,6 +51,20 @@ object PromptErrorClassifier {
         // For ACP errors, ensure the message is descriptive
         if (exception is ClientException && !msg.startsWith("(")) {
             msg = "ACP error: $msg"
+        }
+
+        // Detect Node.js ES module error anywhere in the cause chain.
+        // The raw node warning ("To load an ES module, set 'type': 'module'...") is cryptic;
+        // replace it with an actionable message the user can act on.
+        if (!isAuthError && !isCancelled) {
+            val esModuleError = generateSequence(exception as Throwable?) { it.cause }.any {
+                it.message?.contains("To load an ES module", ignoreCase = true) == true
+            }
+            if (esModuleError) {
+                msg = "The agent CLI requires a newer Node.js version — " +
+                    "your current Node.js does not support ES modules. " +
+                    "Please upgrade Node.js and reinstall the CLI."
+            }
         }
 
         val isRecoverable = isCancelled

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/bridge/ProfileBasedAgentConfigTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/bridge/ProfileBasedAgentConfigTest.java
@@ -1,6 +1,5 @@
 package com.github.catatafishen.agentbridge.bridge;
 
-import com.github.catatafishen.agentbridge.client.ClientException;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.junit.jupiter.api.DisplayName;
@@ -9,7 +8,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("ProfileBasedAgentConfig — static parsing helpers")
 class ProfileBasedAgentConfigTest {
@@ -287,56 +289,4 @@ class ProfileBasedAgentConfigTest {
         }
     }
 
-    @Nested
-    @DisplayName("checkNvmVersion")
-    class CheckNvmVersionTest {
-
-        @Test
-        @DisplayName("version below minimum throws ClientException")
-        void oldVersion_throwsClientException() {
-            assertThrows(ClientException.class, () ->
-                ProfileBasedAgentConfig.checkNvmVersion(
-                    "/home/user/.nvm/versions/node/v18/bin/copilot", 20));
-        }
-
-        @Test
-        @DisplayName("version exactly at minimum passes")
-        void minimumVersion_passes() {
-            assertDoesNotThrow(() ->
-                ProfileBasedAgentConfig.checkNvmVersion(
-                    "/home/user/.nvm/versions/node/v20/bin/copilot", 20));
-        }
-
-        @Test
-        @DisplayName("version above minimum passes")
-        void newerVersion_passes() {
-            assertDoesNotThrow(() ->
-                ProfileBasedAgentConfig.checkNvmVersion(
-                    "/home/user/.nvm/versions/node/v22/bin/copilot", 20));
-        }
-
-        @Test
-        @DisplayName("path without version segment is silently skipped")
-        void pathWithoutVersion_skips() {
-            assertDoesNotThrow(() ->
-                ProfileBasedAgentConfig.checkNvmVersion(
-                    "/usr/local/bin/copilot", 20));
-        }
-
-        @Test
-        @DisplayName("full semver path (v20.10.0) extracts major version correctly")
-        void fullSemverPath_extractsMajorVersion() {
-            assertDoesNotThrow(() ->
-                ProfileBasedAgentConfig.checkNvmVersion(
-                    "/home/user/.nvm/versions/node/v20.10.0/bin/copilot", 20));
-        }
-
-        @Test
-        @DisplayName("full semver path with old major throws ClientException")
-        void fullSemverPath_oldMajor_throws() {
-            assertThrows(ClientException.class, () ->
-                ProfileBasedAgentConfig.checkNvmVersion(
-                    "/home/catatafish/.nvm/versions/node/v20.10.0/bin/copilot", 24));
-        }
-    }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/PsiBridgeServiceStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/PsiBridgeServiceStaticMethodsTest.java
@@ -788,4 +788,48 @@ class PsiBridgeServiceStaticMethodsTest {
             assertEquals(500L, PsiBridgeService.computeExtraSleep(lastFinished, settle, now));
         }
     }
+
+    @Nested
+    class ParseContextLineRangeTest {
+
+        @Test
+        void parsesRangeFromTypicalEditResult() {
+            String result = "Written: src/Foo.java\n\nContext after edit (lines 42-55):\n42:     doSomething();";
+            int[] range = PsiBridgeService.parseContextLineRange(result);
+            assertNotNull(range);
+            assertEquals(42, range[0]);
+            assertEquals(55, range[1]);
+        }
+
+        @Test
+        void returnsNullWhenNoContextSectionPresent() {
+            String result = "Written: src/Foo.java (no highlights)";
+            assertNull(PsiBridgeService.parseContextLineRange(result));
+        }
+
+        @Test
+        void returnsNullForEmptyString() {
+            assertNull(PsiBridgeService.parseContextLineRange(""));
+        }
+
+        @Test
+        void returnsNullForNull() {
+            assertNull(PsiBridgeService.parseContextLineRange(null));
+        }
+
+        @Test
+        void parsesLargeLineNumbers() {
+            String result = "Context after edit (lines 1000-1050):\n...";
+            int[] range = PsiBridgeService.parseContextLineRange(result);
+            assertNotNull(range);
+            assertEquals(1000, range[0]);
+            assertEquals(1050, range[1]);
+        }
+
+        @Test
+        void returnsNullWhenStartLineGreaterThanEndLine() {
+            String result = "Context after edit (lines 55-42):\n...";
+            assertNull(PsiBridgeService.parseContextLineRange(result));
+        }
+    }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/PromptErrorClassifierTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/PromptErrorClassifierTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.function.Function;
 
@@ -292,6 +293,36 @@ class PromptErrorClassifierTest {
         var ex = new ClientException("rate limited", null, true, 429, "{\"retry_after\":30}");
         var result = classify(ex, false, NO_AUTH, true);
         assertEquals("ACP error: rate limited", result.getDisplayMessage());
+    }
+
+    // ── classify: ES module Node.js error ───────────────────────────────
+
+    @Test
+    void classify_esModuleErrorInMessage_returnsActionableMessage() {
+        var ex = new IOException(
+            "Agent process exited unexpectedly: (node:2) Warning: To load an ES module, " +
+                "set \"type\": \"module\" in the package.json or use the .mjs extension.");
+        var result = classify(ex, false, NO_AUTH, true);
+        assertTrue(result.getDisplayMessage().contains("upgrade Node.js"),
+            "Expected actionable upgrade message, got: " + result.getDisplayMessage());
+    }
+
+    @Test
+    void classify_esModuleErrorInCauseChain_returnsActionableMessage() {
+        var nodeEx = new IOException(
+            "To load an ES module, set \"type\": \"module\" in the package.json");
+        var wrapper = new RuntimeException("Agent process exited unexpectedly: ...", nodeEx);
+        var result = classify(wrapper, false, NO_AUTH, true);
+        assertTrue(result.getDisplayMessage().contains("upgrade Node.js"),
+            "Expected actionable upgrade message, got: " + result.getDisplayMessage());
+    }
+
+    @Test
+    void classify_unrelatedProcessCrash_doesNotTriggerEsModuleMessage() {
+        var ex = new IOException("Agent process exited unexpectedly: signal 9");
+        var result = classify(ex, false, NO_AUTH, true);
+        assertFalse(result.getDisplayMessage().contains("upgrade Node.js"),
+            "ES module message should not appear for unrelated crash");
     }
 
     // ── detectQuickReplies ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem

When the Copilot CLI agent crashes with Node.js v20 (which doesn't support ES modules), the error shown to the user is:

```
Agent process exited unexpectedly: (node:2) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
```

This is cryptic — it gives no guidance on what the user should do. PRs #742 and #740 attempted to fix this by proactively checking the NVM Node.js version before launching, but this didn't surface the error to the user in practice.

## Solution

Simpler approach: intercept the error *after* it happens in `PromptErrorClassifier`.

When the exception cause chain contains "To load an ES module" (case-insensitive), replace `msg` with an actionable message:
> The agent CLI requires a newer Node.js version — your current Node.js does not support ES modules. Please upgrade Node.js and reinstall the CLI.

## Also removes

The proactive NVM version check added in #742:
- Removed `minNodeVersion` from `AgentProfile` entirely (field, getter, setter, copy methods)
- Removed `setMinNodeVersion(24)` from `AgentProfileManager`
- Removed `NVM_NODE_VERSION_PATTERN` and `checkNvmVersion()` from `ProfileBasedAgentConfig`; `addNodeAndCommand()` still prepends the NVM node binary but no longer validates the version
- Removed `CheckNvmVersionTest` nested class from `ProfileBasedAgentConfigTest`

## Tests

Added 3 new tests in `PromptErrorClassifierTest`:
- `classify_esModuleErrorInMessage_returnsActionableMessage` — ES module text in top-level message
- `classify_esModuleErrorInCauseChain_returnsActionableMessage` — ES module text in nested cause
- `classify_unrelatedProcessCrash_doesNotTriggerEsModuleMessage` — regression guard

All 57 tests in `PromptErrorClassifierTest` pass. All 15 tests in `ProfileBasedAgentConfigTest` pass.