### PR TITLE
fix: commit pending documents before resolving symbols in editing tools

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editing/EditingTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editing/EditingTool.java
@@ -73,6 +73,11 @@ public abstract class EditingTool extends Tool {
     }
 
     protected @Nullable SymbolLocation resolveSymbol(String pathStr, String symbolName, @Nullable Integer lineHint) {
+        // Sync PSI with any pending document edits before reading symbol offsets.
+        // Without this, PSI-derived line numbers can be stale relative to the
+        // document, causing replaceString to use wrong offsets and triggering
+        // "Inconsistent FILE tree" on the subsequent commitDocument.
+        PsiDocumentManager.getInstance(project).commitAllDocuments();
         // Cast required: resolves ambiguity between runReadAction(Computable) and runReadAction(Runnable)
         return ApplicationManager.getApplication().runReadAction((Computable<SymbolLocation>) () -> {
             VirtualFile vf = resolveVirtualFile(pathStr);


### PR DESCRIPTION
## Problem

Users hit `Inconsistent java.FILE tree` errors when using `replace_symbol_body`, `insert_before_symbol`, or `insert_after_symbol`:

```
Inconsistent java.FILE tree in SingleRootFileViewProvider{vFile=.../HealthController.java, ...
  content=VirtualFileContent{size=787}, ...
nodeLength=787; fileLength=1234
  at ...AbstractFileViewProvider.checkLengthConsistency(...)
  at ...PsiDocumentManagerBase.commitToExistingPsi(...)
  at ...ReplaceSymbolBodyTool.lambda$execute$2(ReplaceSymbolBodyTool.java:127)
```

VFS/PSI saw 787 bytes; the document was already 1234 chars. They were out of sync **before** the tool started editing.

## Root cause

`EditingTool.resolveSymbol()` walked the PSI tree to compute symbol line numbers, but never committed pending document changes first. When a document had uncommitted edits (external file change picked up by VFS, prior tool's pending edit, user typing, etc.), the PSI tree was stale relative to the live document. The line numbers we derived from PSI `TextRange` then translated into the **wrong** offsets when looked up in the current document, and `Document.replaceString` corrupted the text. The subsequent `commitDocument` call could not reconcile the AST with the document and threw.

## Fix

Commit all pending documents at the top of `resolveSymbol` so PSI and document are guaranteed to be in sync before we compute the offsets we'll edit. All three editing tools share this base method, so the single fix covers all of them.

Build passes, no warnings introduced.