### PR TITLE
A fix for invalid paths on Windows when accessing the "." path

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
@@ -215,6 +215,14 @@ public final class ToolUtils {
     public static VirtualFile resolveVirtualFile(Project project, String path) {
         String normalized = path.replace('\\', '/');
 
+        // "." and "./" mean "project root" — resolve immediately so they don't fall
+        // through to LocalFileSystem.findFileByPath which uses the JVM's CWD (which
+        // on Windows defaults to C:\Windows\System32 when launched from a shortcut).
+        if (".".equals(normalized) || "./".equals(normalized)) {
+            String basePath = project.getBasePath();
+            return basePath != null ? LocalFileSystem.getInstance().findFileByPath(basePath) : null;
+        }
+
         VirtualFile jarFile = resolveJarPath(normalized);
         if (jarFile != null) return jarFile;
 
@@ -236,6 +244,14 @@ public final class ToolUtils {
      */
     public static VirtualFile refreshAndFindVirtualFile(Project project, String path) {
         String normalized = path.replace('\\', '/');
+
+        // "." and "./" mean "project root" — resolve immediately to avoid relying on
+        // the JVM CWD (which on Windows defaults to C:\Windows\System32).
+        if (".".equals(normalized) || "./".equals(normalized)) {
+            String basePath = project.getBasePath();
+            return basePath != null
+                ? LocalFileSystem.getInstance().refreshAndFindFileByPath(basePath) : null;
+        }
 
         VirtualFile jarFile = resolveJarPath(normalized);
         if (jarFile != null) return jarFile;
@@ -268,7 +284,11 @@ public final class ToolUtils {
             }
             if (basePath != null) {
                 String base = basePath.replace('\\', '/');
-                String relative = virtualPath.startsWith(base + "/") ? virtualPath.substring(base.length() + 1) : virtualPath;
+                // Case-insensitive prefix match for Windows (avoid drive-letter casing mismatch).
+                String relative = virtualPath.regionMatches(true, 0, base, 0, base.length())
+                    && virtualPath.length() > base.length()
+                    && virtualPath.charAt(base.length()) == '/'
+                    ? virtualPath.substring(base.length() + 1) : virtualPath;
                 String needle = normalized.startsWith("/") ? normalized.substring(1) : normalized;
                 if (relative.equals(needle)) {
                     match[0] = vf;
@@ -287,7 +307,13 @@ public final class ToolUtils {
         if (file.contains(JAR_SEPARATOR)) return JAR_URL_PREFIX + file;
         if (basePath == null) return filePath;
         String base = basePath.replace('\\', '/');
-        if (file.startsWith(base + "/")) return file.substring(base.length() + 1);
+        // On Windows, paths are case-insensitive — use regionMatches to compare without
+        // allocating a new String, and to avoid drive-letter case mismatches (e.g. C: vs c:).
+        if (file.regionMatches(true, 0, base, 0, base.length())
+            && file.length() > base.length()
+            && file.charAt(base.length()) == '/') {
+            return file.substring(base.length() + 1);
+        }
         return file;
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/ListProjectFilesTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/ListProjectFilesTool.java
@@ -80,7 +80,11 @@ public final class ListProjectFilesTool extends NavigationTool {
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) {
-        String dir = args.has(PARAM_DIRECTORY) ? args.get(PARAM_DIRECTORY).getAsString() : "";
+        String dirRaw = args.has(PARAM_DIRECTORY) ? args.get(PARAM_DIRECTORY).getAsString() : "";
+        // "." and "./" mean "project root" — resolve to empty string so no filtering
+        // is applied (shows all project files). Without this, the prefix filter
+        // relPath.startsWith(".") would never match any project-relative path.
+        String dir = (".".equals(dirRaw) || "./".equals(dirRaw)) ? "" : dirRaw;
         String pattern = args.has(PARAM_PATTERN) ? args.get(PARAM_PATTERN).getAsString() : "";
         String sort = args.has("sort") ? args.get("sort").getAsString() : "name";
         long minSize = args.has(PARAM_MIN_SIZE) ? args.get(PARAM_MIN_SIZE).getAsLong() : -1;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
@@ -266,7 +266,12 @@ public abstract class NavigationTool extends Tool {
         if (p.contains(ToolUtils.JAR_SEPARATOR)) return ToolUtils.JAR_URL_PREFIX + p;
         if (basePath != null) {
             String base = basePath.replace('\\', '/');
-            if (p.startsWith(base + "/")) return p.substring(base.length() + 1);
+            // Case-insensitive prefix match for Windows (avoid drive-letter casing mismatch).
+            if (p.regionMatches(true, 0, base, 0, base.length())
+                && p.length() > base.length()
+                && p.charAt(base.length()) == '/') {
+                return p.substring(base.length() + 1);
+            }
         }
         // Unknown external path: emit only the filename to avoid leaking home-dir paths
         int lastSlash = p.lastIndexOf('/');


### PR DESCRIPTION
On Windows, when there are MCP calls that try to access path ".":

<img width="399" height="298" alt="rider64_nXoUTjoav3" src="https://github.com/user-attachments/assets/381410f8-3ca0-45ca-99a8-8a2947ba084c" />

It initially defaults to C:\Windows\System32:

<img width="373" height="347" alt="rider64_Fynp6xLWny" src="https://github.com/user-attachments/assets/5ef9bef3-0564-4942-b5f2-9bbe662467f9" />

This fixes it:

<img width="432" height="326" alt="image" src="https://github.com/user-attachments/assets/21762ff5-e0af-40d6-8738-604a77e5cc39" />

Funnily enough this fix was written by AgentBridge
