### PR TITLE
Multiple usability features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ external-debug/
 .agentbridge/*
 # But version-control the hook configs and scripts (project policy)
 !.agentbridge/hooks/
+
+fixtures/dotnet/obj/

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/AbstractClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/AbstractClient.java
@@ -179,6 +179,15 @@ public abstract class AbstractClient {
         return List.of();
     }
 
+    /**
+     * Available slash commands with descriptions (populated from session/new and available_commands_update).
+     * Returns command info objects with name and optional description for display in the autocomplete popup.
+     * Override in subclasses that preserve descriptions from the wire protocol.
+     */
+    public List<SlashCommandInfo> getAvailableCommandDetails() {
+        return List.of();
+    }
+
     // ─── Agents (custom agent definitions, e.g. intellij-default/intellij-explore) ──
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/SlashCommandInfo.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/SlashCommandInfo.java
@@ -1,0 +1,7 @@
+package com.github.catatafishen.agentbridge.client;
+
+/**
+ * Represents a slash command with an optional description for display in the autocomplete popup.
+ */
+public record SlashCommandInfo(String name, String description) {
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/AcpClient.java
@@ -13,6 +13,7 @@ import com.github.catatafishen.agentbridge.client.AbstractClient;
 import com.github.catatafishen.agentbridge.client.ClientPromptException;
 import com.github.catatafishen.agentbridge.client.ClientSessionException;
 import com.github.catatafishen.agentbridge.client.ClientStartException;
+import com.github.catatafishen.agentbridge.client.SlashCommandInfo;
 import com.github.catatafishen.agentbridge.client.acp.transport.JsonRpcErrorCodes;
 import com.github.catatafishen.agentbridge.client.acp.transport.JsonRpcException;
 import com.github.catatafishen.agentbridge.client.acp.transport.JsonRpcTransport;
@@ -144,6 +145,7 @@ public abstract class AcpClient extends AbstractClient {
     private final List<Model> availableModels = new ArrayList<>();
     private final List<AbstractClient.AgentMode> availableModes = new ArrayList<>();
     private final List<String> availableCommandNames = new ArrayList<>();
+    private final List<NewSessionResponse.AvailableCommand> availableCommandDetails = new ArrayList<>();
     private @Nullable String currentModeSlug = null;
     private @Nullable String currentModelId = null;
     private @Nullable String currentAgentSlug = null;
@@ -616,9 +618,11 @@ public abstract class AcpClient extends AbstractClient {
 
     private void updateCommands(List<NewSessionResponse.AvailableCommand> commands) {
         List<String> names = new ArrayList<>();
+        availableCommandDetails.clear();
         for (NewSessionResponse.AvailableCommand cmd : commands) {
             if (cmd.name() != null && !cmd.name().isBlank()) {
                 names.add(cmd.name());
+                availableCommandDetails.add(cmd);
             }
         }
         updateCommandNames(names);
@@ -1104,6 +1108,19 @@ public abstract class AcpClient extends AbstractClient {
     public final List<String> getAvailableCommands() {
         // Defensive snapshot — see getAvailableModels() for rationale.
         return List.copyOf(availableCommandNames);
+    }
+
+    @Override
+    public List<SlashCommandInfo> getAvailableCommandDetails() {
+        List<SlashCommandInfo> result = new ArrayList<>();
+        for (NewSessionResponse.AvailableCommand cmd : availableCommandDetails) {
+            String name = cmd.name();
+            if (name == null || name.isBlank()) continue;
+            if (!name.startsWith("/")) name = "/" + name;
+            String desc = cmd.description();
+            result.add(new SlashCommandInfo(name, desc != null ? desc : ""));
+        }
+        return result;
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -1388,6 +1388,11 @@ class ChatToolWindowContent(
             showEmptyPromptWarning()
             return
         }
+        // Intercept built-in slash commands locally (e.g. /session-restart, /session-clear)
+        if (rawText.startsWith("/") && executeBuiltInSlashCommand(rawText)) {
+            promptTextArea.text = ""
+            return
+        }
         consolePanel.disableQuickReplies()
         statusBanner?.dismissCurrent()
         // Auto-clean approved review rows when a brand-new user turn starts (not nudge / queued follow-up).
@@ -2680,6 +2685,9 @@ class ChatToolWindowContent(
         val trimmed = prompt.trim()
         if (trimmed.isEmpty()) return
 
+        // Intercept built-in slash commands locally (e.g. /session-restart, /session-clear)
+        if (trimmed.startsWith("/") && executeBuiltInSlashCommand(trimmed)) return
+
         // Intercept Kiro slash commands
         val client = agentManager.getClient()
         if (client is KiroClient && trimmed.startsWith("/")) {
@@ -2753,6 +2761,24 @@ class ChatToolWindowContent(
     fun resetSessionKeepingHistory() {
         resetSessionState()
         updateSessionInfo()
+    }
+
+    /**
+     * Execute a built-in slash command that should be handled locally rather than sent to the agent.
+     * @return true if the command was handled (caller should return early)
+     */
+    private fun executeBuiltInSlashCommand(command: String): Boolean {
+        return when {
+            command.equals("/session-restart", ignoreCase = true) -> {
+                resetSessionKeepingHistory()
+                true
+            }
+            command.equals("/session-clear", ignoreCase = true) -> {
+                resetSession()
+                true
+            }
+            else -> false
+        }
     }
 
     private fun notifyIfUnfocused(toolCallCount: Int) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptEditorLogic.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptEditorLogic.kt
@@ -1,5 +1,7 @@
 package com.github.catatafishen.agentbridge.ui
 
+import com.github.catatafishen.agentbridge.client.SlashCommandInfo
+
 /**
  * Pure decision logic extracted from [PromptEditorSetup]'s event handlers.
  * Stateless — all methods are deterministic functions of their inputs.
@@ -18,13 +20,13 @@ object PromptEditorLogic {
     }
 
     /**
-     * Filters slash-command names that match the given input prefix.
+     * Filters slash-command info objects whose name matches the given input prefix.
      * Input must start with "/" and contain no newlines to qualify.
      */
     @JvmStatic
-    fun filterSlashCommands(input: String, commandNames: List<String>): List<String> {
+    fun filterSlashCommands(input: String, commands: List<SlashCommandInfo>): List<SlashCommandInfo> {
         if (!input.startsWith("/") || input.contains("\n")) return emptyList()
-        return commandNames.filter { it.startsWith(input, ignoreCase = true) }
+        return commands.filter { it.name.startsWith(input, ignoreCase = true) }
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptEditorSetup.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptEditorSetup.kt
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.ui
 
+import com.github.catatafishen.agentbridge.client.SlashCommandInfo
 import com.github.catatafishen.agentbridge.services.ActiveAgentManager
 import com.github.catatafishen.agentbridge.services.AgentNudgeService
 import com.intellij.icons.AllIcons
@@ -9,10 +10,16 @@ import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.ui.EditorTextField
+import com.intellij.ui.components.JBList
+import java.awt.Component
+import java.awt.Dimension
 import java.awt.Image
 import java.awt.KeyboardFocusManager
 import java.awt.Toolkit
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
 import javax.swing.JComponent
+import javax.swing.JList
 import javax.swing.KeyStroke
 import javax.swing.ListSelectionModel
 import javax.swing.SwingUtilities
@@ -122,10 +129,14 @@ internal class PromptEditorSetup(
     fun checkSlashCommandAutocomplete() {
         // Use non-blocking accessor — must never trigger lazy client startup on EDT
         val client = agentManager.getClientIfReady() ?: return
-        val commandNames = client.availableCommands
-        if (commandNames.isEmpty()) return
+        val commands = mutableListOf(
+            SlashCommandInfo("/session-restart", "Restart the current session (keep history)"),
+            SlashCommandInfo("/session-clear", "Clear the current session and start fresh")
+        )
+        commands.addAll(client.availableCommandDetails)
+        if (commands.isEmpty()) return
 
-        val matches = PromptEditorLogic.filterSlashCommands(promptTextArea.text, commandNames)
+        val matches = PromptEditorLogic.filterSlashCommands(promptTextArea.text, commands)
 
         if (matches.isEmpty()) {
             autocompletePopup?.cancel()
@@ -135,16 +146,72 @@ internal class PromptEditorSetup(
         showAutocompletePopup(matches)
     }
 
-    private fun showAutocompletePopup(commands: List<String>) {
+    private fun showAutocompletePopup(commands: List<SlashCommandInfo>) {
         autocompletePopup?.cancel()
 
-        autocompletePopup = JBPopupFactory.getInstance()
-            .createPopupChooserBuilder(commands)
-            .setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
-            .setItemChosenCallback { selected -> promptTextArea.text = selected.toString() }
+        val list = object : JBList<SlashCommandInfo>(commands) {
+            override fun getPreferredSize(): Dimension {
+                val size = super.getPreferredSize()
+                val maxWidth = (promptTextArea.width * 0.9).toInt().coerceAtLeast(300)
+                return Dimension(size.width.coerceAtMost(maxWidth), size.height)
+            }
+        }.apply {
+            selectionMode = ListSelectionModel.SINGLE_SELECTION
+            cellRenderer = object : javax.swing.DefaultListCellRenderer() {
+                override fun getListCellRendererComponent(
+                    list: JList<*>?,
+                    value: Any?,
+                    index: Int,
+                    isSelected: Boolean,
+                    cellHasFocus: Boolean
+                ): Component {
+                    val cmd = value as? SlashCommandInfo ?: return this
+                    val display = if (cmd.description.isNotEmpty()) {
+                        "${cmd.name}  —  ${cmd.description}"
+                    } else cmd.name
+                    super.getListCellRendererComponent(list, display, index, isSelected, cellHasFocus)
+                    return this
+                }
+            }
+            addKeyListener(object : KeyAdapter() {
+                override fun keyPressed(e: KeyEvent) {
+                    if (e.keyCode != KeyEvent.VK_BACK_SPACE) return
+                    autocompletePopup?.cancel()
+                    autocompletePopup = null
+                    val editor = promptTextArea.editor ?: return
+                    val caret = editor.caretModel.offset
+                    // Find the last non-slash character and delete the slash prefix
+                    val text = editor.document.text
+                    val slashIdx = text.lastIndexOf('/', (caret - 1).coerceAtMost(text.length - 1))
+                    if (slashIdx >= 0) {
+                        com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction(project) {
+                            editor.document.deleteString(slashIdx, slashIdx + 1)
+                            editor.caretModel.moveToOffset(slashIdx.coerceAtMost(editor.document.textLength))
+                        }
+                    }
+                }
+            })
+        }
+
+        val popup = JBPopupFactory.getInstance()
+            .createComponentPopupBuilder(list, list)
+            .setTitle("Commands")
+            .setResizable(false)
+            .setMovable(false)
+            .setCancelOnClickOutside(true)
+            .setCancelKeyEnabled(true)
             .createPopup()
 
-        autocompletePopup?.showInBestPositionFor(promptTextArea.editor ?: return)
+        list.addListSelectionListener { e ->
+            if (!e.valueIsAdjusting) {
+                val selected = list.selectedValue ?: return@addListSelectionListener
+                popup.cancel()
+                promptTextArea.text = selected.name
+            }
+        }
+
+        autocompletePopup = popup
+        popup.showInBestPositionFor(promptTextArea.editor ?: return)
     }
 
     private fun registerEnterSend(contentComponent: JComponent) {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/PromptEditorSetupTest.kt
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/PromptEditorSetupTest.kt
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.ui
 
+import com.github.catatafishen.agentbridge.client.SlashCommandInfo
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -59,31 +60,42 @@ class PromptEditorSetupTest {
     @Nested
     inner class FilterSlashCommandsTest {
 
-        private val commands = listOf("/help", "/new", "/history", "/clear")
+        private val commands = listOf(
+            SlashCommandInfo("/help", "Show available commands"),
+            SlashCommandInfo("/new", "Start a new conversation"),
+            SlashCommandInfo("/history", "Show conversation history"),
+            SlashCommandInfo("/clear", "Clear the chat")
+        )
 
         @Test
         fun `matches prefix case-insensitive`() {
-            assertEquals(listOf("/help", "/history"), PromptEditorLogic.filterSlashCommands("/h", commands))
+            assertEquals(
+                listOf(SlashCommandInfo("/help", "Show available commands"), SlashCommandInfo("/history", "Show conversation history")),
+                PromptEditorLogic.filterSlashCommands("/h", commands)
+            )
         }
 
         @Test
         fun `exact match returns command`() {
-            assertEquals(listOf("/help"), PromptEditorLogic.filterSlashCommands("/help", commands))
+            assertEquals(
+                listOf(SlashCommandInfo("/help", "Show available commands")),
+                PromptEditorLogic.filterSlashCommands("/help", commands)
+            )
         }
 
         @Test
         fun `no slash prefix returns empty`() {
-            assertEquals(emptyList<String>(), PromptEditorLogic.filterSlashCommands("help", commands))
+            assertEquals(emptyList<SlashCommandInfo>(), PromptEditorLogic.filterSlashCommands("help", commands))
         }
 
         @Test
         fun `contains newline returns empty`() {
-            assertEquals(emptyList<String>(), PromptEditorLogic.filterSlashCommands("/h\nsomething", commands))
+            assertEquals(emptyList<SlashCommandInfo>(), PromptEditorLogic.filterSlashCommands("/h\nsomething", commands))
         }
 
         @Test
         fun `no matches returns empty`() {
-            assertEquals(emptyList<String>(), PromptEditorLogic.filterSlashCommands("/xyz", commands))
+            assertEquals(emptyList<SlashCommandInfo>(), PromptEditorLogic.filterSlashCommands("/xyz", commands))
         }
 
         @Test
@@ -93,7 +105,7 @@ class PromptEditorSetupTest {
 
         @Test
         fun `empty command list returns empty`() {
-            assertEquals(emptyList<String>(), PromptEditorLogic.filterSlashCommands("/h", emptyList()))
+            assertEquals(emptyList<SlashCommandInfo>(), PromptEditorLogic.filterSlashCommands("/h", emptyList()))
         }
     }
 


### PR DESCRIPTION
Implementation of two chat features

- /session-restart → resetSessionKeepingHistory() (restart, keep history)
- /session-clear → resetSession() (clear and restart fresh)

Available commands and description popup (sample images below)

Backspace to delete front-slash menu when typing

Sample images:

<img width="662" height="792" alt="rider64_DedqVgriRe" src="https://github.com/user-attachments/assets/42a7c303-be55-49b8-ad61-b6383379ef32" />
<img width="473" height="144" alt="rider64_WCKzfjuJaf" src="https://github.com/user-attachments/assets/8fc5221a-3b91-49fa-bc86-f54378cf2d81" />
