### PR TITLE
fix: TodoPanel.resolveSessionDir should not start the agent client

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ActiveAgentManager.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ActiveAgentManager.java
@@ -266,14 +266,13 @@ public final class ActiveAgentManager implements Disposable {
      * Returns the agent client only if already started and healthy.
      * Does NOT trigger lazy start — returns {@code null} if the client is not ready.
      * Use this from EDT-sensitive code paths that must not block.
+     *
+     * @deprecated Use {@link #getClientIfRunning()}
      */
+    @Deprecated
     @Nullable
     public AbstractClient getClientIfReady() {
-        AbstractClient client = acpClient;
-        if (!started || client == null || !client.isHealthy()) {
-            return null;
-        }
-        return client;
+        return getClientIfRunning();
     }
 
     /**
@@ -309,7 +308,7 @@ public final class ActiveAgentManager implements Disposable {
      */
     @Nullable
     public AbstractClient getClientIfRunning() {
-        if (started && acpClient != null && acpClient.isHealthy()) {
+        if (isClientHealthy()) {
             return acpClient;
         }
         return null;
@@ -317,7 +316,7 @@ public final class ActiveAgentManager implements Disposable {
 
     @Nullable
     public String checkAuthentication() {
-        if (started && acpClient != null && acpClient.isHealthy()) {
+        if (isClientHealthy()) {
             return acpClient.checkAuthentication();
         }
         // No pre-start credential probing — auth state is observed at runtime from the
@@ -329,7 +328,7 @@ public final class ActiveAgentManager implements Disposable {
      * Start the agent process for the active profile.
      */
     public synchronized void start() {
-        if (started && acpClient != null && acpClient.isHealthy()) {
+        if (isClientHealthy()) {
             LOG.debug("Agent client already running for " + getActiveProfile().getDisplayName());
             return;
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/TodoPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/TodoPanel.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.ui.side;
 
+import com.github.catatafishen.agentbridge.client.AbstractClient;
 import com.github.catatafishen.agentbridge.services.ActiveAgentManager;
 import com.github.catatafishen.agentbridge.ui.MarkdownRenderer;
 import com.github.catatafishen.agentbridge.ui.util.EmptyStateStyles;
@@ -342,7 +343,8 @@ final class TodoPanel extends JPanel implements Disposable {
     private @Nullable Path resolveSessionDir() {
         try {
             ActiveAgentManager manager = ActiveAgentManager.getInstance(project);
-            return manager.getClient().getSessionDirectory();
+            AbstractClient client = manager.getClientIfRunning();
+            return client != null ? client.getSessionDirectory() : null;
         } catch (Exception ignored) {
             return null;
         }


### PR DESCRIPTION
## Description

Opening the Todo panel triggers a UI refresh that inadvertently started the agent client, causing a startup error for any agent that isn't installed — including the Copilot default for users who never configured an agent.

## Technical summary

Replace `getClient()` with `getClientIfRunning()` in `TodoPanel.resolveSessionDir()`.

 `resolveSessionDir` documents that it returns `null` "if no agent is running or the session dir is unknown" — it was never intended to start the agent. Yet it called `getClient()`,  which starts the agent if not already running. The two contracts directly contradict each other.

 Swapping to `getClientIfRunning()` aligns the implementation with the documented intent: the method now returns `null` when no agent is running, instead of triggering a startup side-effect.

## Why

The implementation mismatch caused a visible bug: opening the Todo panel on a fresh project (no agent configured) would trigger the default Copilot profile to start, immediately failing with a "GitHub Copilot binary not found" error — even for users who have never used or  configured Copilot:

```
java.io.IOException: GitHub Copilot binary 'copilot' not found in PATH. Please install it or configure the path in Settings → Tools → AgentBridge → GitHub Copilot                                                                     
      at com.github.catatafishen.agentbridge.client.acp.AcpClient.validateResolvedBinary(AcpClient.java:1623)                                                                                                                            
      at com.github.catatafishen.agentbridge.client.acp.AcpClient.launchProcess(AcpClient.java:1503)                                                                                                                                     
      at com.github.catatafishen.agentbridge.client.acp.AcpClient.start(AcpClient.java:279)                                                                                                                                              
      at com.github.catatafishen.agentbridge.services.ActiveAgentManager.start(ActiveAgentManager.java:374)                                                                                                                              
      at com.github.catatafishen.agentbridge.services.ActiveAgentManager.getClient(ActiveAgentManager.java:260)                                                                                                                          
      at com.github.catatafishen.agentbridge.ui.side.TodoPanel.resolveSessionDir(TodoPanel.java:345)                                                                                                                                     
      at com.github.catatafishen.agentbridge.ui.side.TodoPanel.refresh(TodoPanel.java:201)                                                                                                                                               
      at com.github.catatafishen.agentbridge.ui.side.SidePanel.selectTab(SidePanel.java:136)                                                                                                                                             
      at com.github.catatafishen.agentbridge.ui.side.SidePanel$2.mouseClicked(SidePanel.java:282)                                                                                                                                        
      at java.desktop/java.awt.Component.processMouseEvent(Component.java:6634)                                                                                                                                                          
      at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3400)                                                                                                                                                     
      ..                                                                                                                                                            
      at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:721)                                                                                                                                                       
      ..
```

The root issue is this incorrect call.

_Copilot being considered the default of agent is a choice one could debate, but has 'nothing' to do with the actual problem_.