### PR TITLE
fix: reuse and cap agent terminal tabs

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/CloseTerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/CloseTerminalTool.java
@@ -8,7 +8,9 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Closes an integrated terminal tab created by AgentBridge.
@@ -32,6 +34,7 @@ public final class CloseTerminalTool extends TerminalTool {
     @Override
     public @NotNull String description() {
         return "Close an AgentBridge-created terminal tab when it is no longer needed. "
+            + "This closes the tab but does not stop a running command in it. "
             + "Refuses to close user-created terminal tabs. Use list_terminals to find tab names.";
     }
 
@@ -65,14 +68,34 @@ public final class CloseTerminalTool extends TerminalTool {
 
         EdtUtil.invokeLater(() -> closeTerminal(tabName, resultFuture));
 
+        return awaitCloseResult(resultFuture, 10, TimeUnit.SECONDS);
+    }
+
+    static @NotNull String awaitCloseResult(
+        @NotNull CompletableFuture<String> resultFuture,
+        long timeout,
+        @NotNull TimeUnit unit
+    ) {
         try {
-            return resultFuture.get(10, TimeUnit.SECONDS);
+            return resultFuture.get(timeout, unit);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            return "Terminal close timed out.";
+            return "Error: Terminal close interrupted.";
+        } catch (TimeoutException e) {
+            return "Error: Terminal close timed out.";
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            LOG.warn("Terminal close failed", cause);
+            return "Error: Failed to close terminal: " + failureDetail(cause);
         } catch (Exception e) {
-            return "Terminal close timed out.";
+            LOG.warn("Terminal close failed", e);
+            return "Error: Failed to close terminal: " + failureDetail(e);
         }
+    }
+
+    private static @NotNull String failureDetail(@NotNull Throwable failure) {
+        String message = failure.getMessage();
+        return message == null || message.isBlank() ? failure.getClass().getSimpleName() : message;
     }
 
     private void closeTerminal(String tabName, CompletableFuture<String> resultFuture) {
@@ -80,21 +103,24 @@ public final class CloseTerminalTool extends TerminalTool {
             var content = resolveTerminalContent(tabName);
             if (content == null) {
                 resultFuture.complete(
-                    "No terminal tab found matching '" + tabName + "'. Use list_terminals to see available tabs.");
+                    "Error: No terminal tab found matching '" + tabName
+                        + "'. Use list_terminals to see available tabs.");
                 return;
             }
 
             String displayName = content.getDisplayName();
             AgentTabTracker tracker = AgentTabTracker.getInstance(project);
             if (displayName == null || !tracker.isTrackedTerminalTab(displayName)) {
+                String rejectedName = displayName != null ? displayName : tabName;
                 resultFuture.complete(
-                    "Refusing to close terminal '" + tabName + "' because it was not created by AgentBridge.");
+                    "Error: Refusing to close terminal '" + rejectedName
+                        + "' because it was not created by AgentBridge.");
                 return;
             }
 
             var toolWindow = ToolWindowManager.getInstance(project).getToolWindow(TERMINAL_TOOL_WINDOW_ID);
             if (toolWindow == null || !toolWindow.getContentManager().removeContent(content, true)) {
-                resultFuture.complete("Failed to close terminal '" + displayName + "'.");
+                resultFuture.complete("Error: Failed to close terminal '" + displayName + "'.");
                 return;
             }
 
@@ -102,7 +128,8 @@ public final class CloseTerminalTool extends TerminalTool {
             resultFuture.complete("Closed AgentBridge terminal '" + displayName + "'.");
         } catch (Exception e) {
             LOG.warn("Failed to close terminal: " + tabName, e);
-            resultFuture.complete("Failed to close terminal '" + tabName + "': " + e.getMessage());
+            resultFuture.complete(
+                "Error: Failed to close terminal '" + tabName + "': " + failureDetail(e));
         }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/CloseTerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/CloseTerminalTool.java
@@ -1,0 +1,108 @@
+package com.github.catatafishen.agentbridge.psi.tools.terminal;
+
+import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.github.catatafishen.agentbridge.services.AgentTabTracker;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindowManager;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Closes an integrated terminal tab created by AgentBridge.
+ */
+public final class CloseTerminalTool extends TerminalTool {
+
+    public CloseTerminalTool(Project project) {
+        super(project);
+    }
+
+    @Override
+    public @NotNull String id() {
+        return "close_terminal";
+    }
+
+    @Override
+    public @NotNull String displayName() {
+        return "Close Terminal";
+    }
+
+    @Override
+    public @NotNull String description() {
+        return "Close an AgentBridge-created terminal tab when it is no longer needed. "
+            + "Refuses to close user-created terminal tabs. Use list_terminals to find tab names.";
+    }
+
+    @Override
+    public @NotNull Kind kind() {
+        return Kind.EDIT;
+    }
+
+    @Override
+    public boolean isDestructive() {
+        return true;
+    }
+
+    @Override
+    public @NotNull String permissionTemplate() {
+        return "Close terminal: {tab_name}";
+    }
+
+    @Override
+    public @NotNull JsonObject inputSchema() {
+        return schema(
+            Param.required(JSON_TAB_NAME, TYPE_STRING,
+                "Name of the AgentBridge-created terminal tab to close")
+        );
+    }
+
+    @Override
+    public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        String tabName = args.get(JSON_TAB_NAME).getAsString();
+        CompletableFuture<String> resultFuture = new CompletableFuture<>();
+
+        EdtUtil.invokeLater(() -> closeTerminal(tabName, resultFuture));
+
+        try {
+            return resultFuture.get(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Terminal close timed out.";
+        } catch (Exception e) {
+            return "Terminal close timed out.";
+        }
+    }
+
+    private void closeTerminal(String tabName, CompletableFuture<String> resultFuture) {
+        try {
+            var content = resolveTerminalContent(tabName);
+            if (content == null) {
+                resultFuture.complete(
+                    "No terminal tab found matching '" + tabName + "'. Use list_terminals to see available tabs.");
+                return;
+            }
+
+            String displayName = content.getDisplayName();
+            AgentTabTracker tracker = AgentTabTracker.getInstance(project);
+            if (displayName == null || !tracker.isTrackedTerminalTab(displayName)) {
+                resultFuture.complete(
+                    "Refusing to close terminal '" + tabName + "' because it was not created by AgentBridge.");
+                return;
+            }
+
+            var toolWindow = ToolWindowManager.getInstance(project).getToolWindow(TERMINAL_TOOL_WINDOW_ID);
+            if (toolWindow == null || !toolWindow.getContentManager().removeContent(content, true)) {
+                resultFuture.complete("Failed to close terminal '" + displayName + "'.");
+                return;
+            }
+
+            tracker.untrackTerminalTab(displayName);
+            resultFuture.complete("Closed AgentBridge terminal '" + displayName + "'.");
+        } catch (Exception e) {
+            LOG.warn("Failed to close terminal: " + tabName, e);
+            resultFuture.complete("Failed to close terminal '" + tabName + "': " + e.getMessage());
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/ListTerminalsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/ListTerminalsTool.java
@@ -46,7 +46,7 @@ public final class ListTerminalsTool extends TerminalTool {
         appendOpenTerminalTabs(result);
         appendDefaultShell(result);
 
-        result.append("\n\nTip: Use read_terminal_output or write_terminal_input with tab_name to interact with a listed tab.");
+        result.append("\n\nTip: Reuse AgentBridge tabs with run_in_terminal, interact with read_terminal_output/write_terminal_input, and close unused tabs with close_terminal.");
         return result.toString();
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/RunInTerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/RunInTerminalTool.java
@@ -37,6 +37,8 @@ public final class RunInTerminalTool extends TerminalTool {
         return """
             Run a command in IntelliJ's integrated terminal. Returns terminal output. \
             Use for interactive commands that need stdin (prompts, REPL). \
+            Reuses the most recent agent-created terminal by default. Set new_tab only for a truly parallel interactive process. \
+            Close an agent terminal with close_terminal when it is no longer needed. \
             For non-interactive commands with captured output, prefer run_command.
 
             When the terminal is waiting for input:
@@ -68,7 +70,7 @@ public final class RunInTerminalTool extends TerminalTool {
         return schema(
             Param.required(JSON_COMMAND, TYPE_STRING, "The command to run in the terminal"),
             Param.optional(JSON_TAB_NAME, TYPE_STRING, "Name for the terminal tab. If omitted, reuses the most recent agent-created tab or creates a new one"),
-            Param.optional(JSON_NEW_TAB, TYPE_BOOLEAN, "If true, always create a new terminal tab instead of reusing an existing one"),
+            Param.optional(JSON_NEW_TAB, TYPE_BOOLEAN, "If true, create a separate terminal tab. Use only for a parallel interactive process; AgentBridge allows at most 3 agent-created terminals"),
             Param.optional(JSON_SHELL, TYPE_STRING, "Shell to use (e.g., 'bash', 'zsh'). If omitted, uses the default shell")
         );
     }
@@ -95,7 +97,7 @@ public final class RunInTerminalTool extends TerminalTool {
                 sendTerminalCommand(result.widget(), command);
 
                 resultFuture.complete("Command sent to terminal '" + result.tabName() + "': " + command +
-                    "\n\nNote: Use read_terminal_output to read terminal content, or run_command if you need output returned directly.");
+                    "\n\nNote: Reuse is the default. Use read_terminal_output for content, close_terminal when done, or run_command for captured output.");
 
             } catch (ClassNotFoundException e) {
                 resultFuture.complete("Terminal plugin not available. Use run_command tool instead.");

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/RunInTerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/RunInTerminalTool.java
@@ -96,14 +96,17 @@ public final class RunInTerminalTool extends TerminalTool {
                 var result = getOrCreateTerminalWidget(managerClass, manager, tabName, newTab, shell, command);
                 sendTerminalCommand(result.widget(), command);
 
-                resultFuture.complete("Command sent to terminal '" + result.tabName() + "': " + command +
+                String terminalState = result.reused() ? "reused" : "new";
+                resultFuture.complete("Command sent to " + terminalState + " terminal '" + result.tabName() + "': " + command +
                     "\n\nNote: Reuse is the default. Use read_terminal_output for content, close_terminal when done, or run_command for captured output.");
 
             } catch (ClassNotFoundException e) {
-                resultFuture.complete("Terminal plugin not available. Use run_command tool instead.");
+                resultFuture.complete("Error: Terminal plugin not available. Use run_command tool instead.");
+            } catch (IllegalStateException e) {
+                resultFuture.complete(formatCapacityError(e));
             } catch (Exception e) {
                 LOG.warn("Failed to open terminal", e);
-                resultFuture.complete("Failed to open terminal: " + e.getMessage() + ". Use run_command tool instead.");
+                resultFuture.complete("Error: Failed to open terminal: " + e.getMessage() + ". Use run_command tool instead.");
             }
         });
 
@@ -115,6 +118,10 @@ public final class RunInTerminalTool extends TerminalTool {
         } catch (Exception e) {
             return "Terminal opened (response timed out, but command was likely sent).";
         }
+    }
+
+    static @NotNull String formatCapacityError(@NotNull IllegalStateException error) {
+        return "Error: " + error.getMessage();
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalTool.java
@@ -97,15 +97,23 @@ public abstract class TerminalTool extends Tool {
     protected TerminalWidgetResult getOrCreateTerminalWidget(Class<?> managerClass, Object manager,
                                                              String tabName, boolean newTab,
                                                              String shell, String command) throws Exception {
-        // Try to reuse existing terminal tab
-        if (tabName != null && !newTab) {
-            Object widget = findTerminalWidgetByTabName(managerClass, tabName);
-            if (widget != null) {
-                return new TerminalWidgetResult(widget, tabName);
+        AgentTabTracker tracker = AgentTabTracker.getInstance(project);
+        if (!newTab) {
+            String reusableName = tabName != null ? tabName : tracker.findMostRecentOpenTerminalTabName();
+            if (reusableName != null) {
+                Object widget = findTerminalWidgetByTabName(managerClass, reusableName);
+                if (widget != null) {
+                    return new TerminalWidgetResult(widget, reusableName + " (reused)");
+                }
             }
         }
 
-        // Create new tab
+        if (!tracker.hasOpenTerminalCapacity()) {
+            throw new IllegalStateException(
+                "Agent terminal limit reached (" + AgentTabTracker.MAX_OPEN_AGENT_TERMINALS
+                    + "). Reuse an existing tab or close one with close_terminal.");
+        }
+
         String title = tabName != null ? tabName : "Agent: " + truncateForTitle(command);
         List<String> shellCommand = shell != null ? List.of(shell) : null;
         var createSession = managerClass.getMethod("createNewSession",
@@ -114,7 +122,7 @@ public abstract class TerminalTool extends Tool {
         // the new terminal tab from yanking the keyboard caret out of the chat prompt.
         boolean requestFocus = !PsiBridgeService.isChatToolWindowActive(project);
         Object widget = createSession.invoke(manager, project.getBasePath(), title, shellCommand, requestFocus, true);
-        AgentTabTracker.getInstance(project).trackTab(TERMINAL_TOOL_WINDOW_ID, title);
+        tracker.trackTab(TERMINAL_TOOL_WINDOW_ID, title);
         return new TerminalWidgetResult(widget, title + " (new)");
     }
 
@@ -142,7 +150,7 @@ public abstract class TerminalTool extends Tool {
 
                     for (var content : toolWindow.getContentManager().getContents()) {
                         String displayName = content.getDisplayName();
-                        if (displayName != null && displayName.contains(tabName)) {
+                        if (AgentTabTracker.terminalTabNameMatches(tabName, displayName)) {
                             Object widget = findWidgetByContent.invoke(null, content);
                             if (widget != null) {
                                 LOG.info("Reusing terminal tab '" + displayName + "'");
@@ -177,7 +185,7 @@ public abstract class TerminalTool extends Tool {
 
                 for (var content : contentManager.getContents()) {
                     String name = content.getDisplayName();
-                    if (name != null && name.contains(tabName)) {
+                    if (AgentTabTracker.terminalTabNameMatches(tabName, name)) {
                         result[0] = content;
                         return;
                     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalTool.java
@@ -91,7 +91,7 @@ public abstract class TerminalTool extends Tool {
         return "'" + raw + "'";
     }
 
-    protected record TerminalWidgetResult(Object widget, String tabName) {
+    protected record TerminalWidgetResult(Object widget, String tabName, boolean reused) {
     }
 
     protected TerminalWidgetResult getOrCreateTerminalWidget(Class<?> managerClass, Object manager,
@@ -103,7 +103,7 @@ public abstract class TerminalTool extends Tool {
             if (reusableName != null) {
                 Object widget = findTerminalWidgetByTabName(managerClass, reusableName);
                 if (widget != null) {
-                    return new TerminalWidgetResult(widget, reusableName + " (reused)");
+                    return new TerminalWidgetResult(widget, reusableName, true);
                 }
             }
         }
@@ -123,7 +123,7 @@ public abstract class TerminalTool extends Tool {
         boolean requestFocus = !PsiBridgeService.isChatToolWindowActive(project);
         Object widget = createSession.invoke(manager, project.getBasePath(), title, shellCommand, requestFocus, true);
         tracker.trackTab(TERMINAL_TOOL_WINDOW_ID, title);
-        return new TerminalWidgetResult(widget, title + " (new)");
+        return new TerminalWidgetResult(widget, title, false);
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolFactory.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolFactory.java
@@ -17,6 +17,7 @@ public final class TerminalToolFactory {
     public static @NotNull List<Tool> create(@NotNull Project project) {
         return List.of(
             new RunInTerminalTool(project),
+            new CloseTerminalTool(project),
             new WriteTerminalInputTool(project),
             new ReadTerminalOutputTool(project),
             new ListTerminalsTool(project)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentTabTracker.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentTabTracker.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.services;
 
+import com.github.catatafishen.agentbridge.psi.EdtUtil;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.ui.RunContentDescriptor;
 import com.intellij.execution.ui.RunContentManager;
@@ -12,6 +13,7 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,11 +22,12 @@ import java.util.List;
  * Tracks tool window tabs created by the agent and closes them at turn boundaries.
  *
  * <p>Tools call {@link #trackTab(String, String)} when they create a tab.
- * At the start of a new turn, {@link #closeTrackedTabs()} closes all tracked
- * tabs from previous turns, respecting {@link CleanupSettings} for terminal
- * and running-process behavior.</p>
+ * At the start of a new turn, {@link #closeTrackedTabs()} closes tracked tabs
+ * that are safe to close and keeps skipped tabs tracked for later cleanup.</p>
  */
 public final class AgentTabTracker implements Disposable {
+
+    public static final int MAX_OPEN_AGENT_TERMINALS = 3;
 
     private static final Logger LOG = Logger.getInstance(AgentTabTracker.class);
     private static final String TERMINAL_TOOL_WINDOW_ID = "Terminal";
@@ -52,40 +55,82 @@ public final class AgentTabTracker implements Disposable {
     }
 
     public int countOpenTerminalTabs() {
-        List<String> trackedTerminalTabNames;
-        synchronized (this) {
-            trackedTerminalTabNames = new ArrayList<>();
-            for (TabRef ref : trackedTabs) {
-                if (TERMINAL_TOOL_WINDOW_ID.equals(ref.toolWindowId())) {
-                    trackedTerminalTabNames.add(ref.tabName());
+        return countMatchingTerminalTabs(trackedTerminalTabNames(), openTerminalDisplayNames());
+    }
+
+    public boolean hasOpenTerminalCapacity() {
+        return hasTerminalCapacity(countOpenTerminalTabs());
+    }
+
+    public @Nullable String findMostRecentOpenTerminalTabName() {
+        return mostRecentOpenTerminalTabName(trackedTerminalTabNames(), openTerminalDisplayNames());
+    }
+
+    public synchronized boolean isTrackedTerminalTab(@NotNull String displayName) {
+        for (TabRef ref : trackedTabs) {
+            if (TERMINAL_TOOL_WINDOW_ID.equals(ref.toolWindowId())
+                && terminalTabNameMatches(ref.tabName(), displayName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public synchronized void untrackTerminalTab(@NotNull String displayName) {
+        trackedTabs.removeIf(ref -> TERMINAL_TOOL_WINDOW_ID.equals(ref.toolWindowId())
+            && terminalTabNameMatches(ref.tabName(), displayName));
+    }
+
+    private synchronized List<String> trackedTerminalTabNames() {
+        List<String> names = new ArrayList<>();
+        for (TabRef ref : trackedTabs) {
+            if (TERMINAL_TOOL_WINDOW_ID.equals(ref.toolWindowId())) {
+                names.add(ref.tabName());
+            }
+        }
+        return names;
+    }
+
+    private List<String> openTerminalDisplayNames() {
+        List<String> names = new ArrayList<>();
+        EdtUtil.invokeAndWait(() -> {
+            ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(TERMINAL_TOOL_WINDOW_ID);
+            if (toolWindow == null) return;
+            for (Content content : toolWindow.getContentManager().getContents()) {
+                names.add(content.getDisplayName());
+            }
+        });
+        return names;
+    }
+
+    static boolean hasTerminalCapacity(int openAgentTerminalCount) {
+        return openAgentTerminalCount < MAX_OPEN_AGENT_TERMINALS;
+    }
+
+    static @Nullable String mostRecentOpenTerminalTabName(
+        List<String> trackedTerminalTabNames,
+        List<String> openDisplayNames
+    ) {
+        for (int trackedIndex = trackedTerminalTabNames.size() - 1; trackedIndex >= 0; trackedIndex--) {
+            String trackedName = trackedTerminalTabNames.get(trackedIndex);
+            for (String displayName : openDisplayNames) {
+                if (terminalTabNameMatches(trackedName, displayName)) {
+                    return displayName;
                 }
             }
         }
-        if (trackedTerminalTabNames.isEmpty()) return 0;
-
-        ToolWindow tw = ToolWindowManager.getInstance(project).getToolWindow(TERMINAL_TOOL_WINDOW_ID);
-        if (tw == null) return 0;
-
-        List<String> openDisplayNames = new ArrayList<>();
-        for (Content content : tw.getContentManager().getContents()) {
-            openDisplayNames.add(content.getDisplayName());
-        }
-        return countMatchingTerminalTabs(trackedTerminalTabNames, openDisplayNames);
+        return null;
     }
 
     /**
-     * Counts how many of the currently open tab display names correspond to a tracked agent
-     * terminal tab. A display name matches if it contains a tracked tab name (the IDE may append
-     * suffixes such as {@code " (1)"} for duplicate titles). Each open tab is counted at most once.
-     *
-     * <p>Pure predicate — no I/O, no IntelliJ API dependency.</p>
+     * Counts currently open terminal tabs that correspond to tracked agent tabs.
      */
     static int countMatchingTerminalTabs(List<String> trackedTerminalTabNames, List<String> openDisplayNames) {
         int count = 0;
         for (String displayName : openDisplayNames) {
             if (displayName == null) continue;
             for (String tabName : trackedTerminalTabNames) {
-                if (displayName.contains(tabName)) {
+                if (terminalTabNameMatches(tabName, displayName)) {
                     count++;
                     break;
                 }
@@ -94,29 +139,35 @@ public final class AgentTabTracker implements Disposable {
         return count;
     }
 
+    public static boolean terminalTabNameMatches(@Nullable String trackedName, @Nullable String displayName) {
+        if (trackedName == null || displayName == null) return false;
+        return displayName.equals(trackedName) || displayName.matches(
+            java.util.regex.Pattern.quote(trackedName) + " \\(\\d+\\)"
+        );
+    }
+
     /**
-     * Closes all tracked tabs from previous turns. Must be called at the start
-     * of a new turn. Respects cleanup settings.
+     * Closes tracked tabs from previous turns and retains tabs skipped by cleanup policy.
      */
     public void closeTrackedTabs() {
         CleanupSettings settings = CleanupSettings.getInstance(project);
         if (!settings.isAutoCloseAgentTabs()) return;
 
-        List<TabRef> toClose;
+        List<TabRef> candidates;
         synchronized (this) {
-            toClose = new ArrayList<>(trackedTabs);
-            trackedTabs.clear();
+            candidates = new ArrayList<>(trackedTabs);
         }
-
-        if (toClose.isEmpty()) return;
+        if (candidates.isEmpty()) return;
 
         boolean closeRunningTerminals = settings.isAutoCloseRunningTerminals();
         ApplicationManager.getApplication().invokeLater(() -> {
-            for (TabRef ref : toClose) {
+            for (TabRef ref : candidates) {
                 try {
-                    closeTab(ref, closeRunningTerminals);
+                    if (closeTab(ref, closeRunningTerminals)) {
+                        removeTrackedRef(ref);
+                    }
                 } catch (Exception e) {
-                    LOG.debug("Failed to close tab " + ref.toolWindowId + "/" + ref.tabName, e);
+                    LOG.debug("Failed to close tab " + ref.toolWindowId() + "/" + ref.tabName(), e);
                 }
             }
         });
@@ -124,14 +175,6 @@ public final class AgentTabTracker implements Disposable {
 
     /**
      * Determines whether a tab should be skipped during cleanup.
-     *
-     * <p>A tab should be skipped if:
-     * <ul>
-     *   <li>It is a Terminal tab and {@code closeRunningTerminals} is false.</li>
-     *   <li>It is a Run tab and its process is still active.</li>
-     * </ul>
-     *
-     * <p>Pure predicate — no I/O, no IntelliJ API dependency.</p>
      */
     static boolean shouldSkipClose(String toolWindowId, boolean closeRunningTerminals,
                                    boolean isProcessActive) {
@@ -141,31 +184,46 @@ public final class AgentTabTracker implements Disposable {
         return RUN_TOOL_WINDOW_ID.equals(toolWindowId) && isProcessActive;
     }
 
-    private void closeTab(TabRef ref, boolean closeRunningTerminals) {
-        boolean processActive = "Run".equals(ref.toolWindowId)
-            && isRunProcessStillActive(ref.tabName);
-        if (shouldSkipClose(ref.toolWindowId, closeRunningTerminals, processActive)) {
-            return;
+    /**
+     * @return true when the reference can be forgotten; false when it must be retried later.
+     */
+    private boolean closeTab(TabRef ref, boolean closeRunningTerminals) {
+        boolean processActive = RUN_TOOL_WINDOW_ID.equals(ref.toolWindowId())
+            && isRunProcessStillActive(ref.tabName());
+        if (shouldSkipClose(ref.toolWindowId(), closeRunningTerminals, processActive)) {
+            return false;
         }
 
-        ToolWindow tw = ToolWindowManager.getInstance(project).getToolWindow(ref.toolWindowId);
-        if (tw == null) return;
+        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(ref.toolWindowId());
+        if (toolWindow == null) return true;
 
-        ContentManager cm = tw.getContentManager();
-        for (Content content : cm.getContents()) {
+        ContentManager contentManager = toolWindow.getContentManager();
+        for (Content content : contentManager.getContents()) {
             String displayName = content.getDisplayName();
-            if (displayName != null && displayName.equals(ref.tabName)) {
-                cm.removeContent(content, true);
-                LOG.debug("Closed agent tab: " + ref.toolWindowId + "/" + ref.tabName);
-                break;
+            if (tabDisplayNameMatches(ref, displayName)) {
+                contentManager.removeContent(content, true);
+                LOG.debug("Closed agent tab: " + ref.toolWindowId() + "/" + displayName);
+                return true;
             }
         }
+        return true;
+    }
+
+    private static boolean tabDisplayNameMatches(TabRef ref, @Nullable String displayName) {
+        if (TERMINAL_TOOL_WINDOW_ID.equals(ref.toolWindowId())) {
+            return terminalTabNameMatches(ref.tabName(), displayName);
+        }
+        return ref.tabName().equals(displayName);
+    }
+
+    private synchronized void removeTrackedRef(TabRef ref) {
+        trackedTabs.remove(ref);
     }
 
     private boolean isRunProcessStillActive(String tabName) {
-        for (RunContentDescriptor desc : RunContentManager.getInstance(project).getAllDescriptors()) {
-            if (tabName.equals(desc.getDisplayName())) {
-                ProcessHandler handler = desc.getProcessHandler();
+        for (RunContentDescriptor descriptor : RunContentManager.getInstance(project).getAllDescriptors()) {
+            if (tabName.equals(descriptor.getDisplayName())) {
+                ProcessHandler handler = descriptor.getProcessHandler();
                 return handler != null && !handler.isProcessTerminated();
             }
         }
@@ -173,9 +231,7 @@ public final class AgentTabTracker implements Disposable {
     }
 
     @Override
-    public void dispose() {
-        synchronized (this) {
-            trackedTabs.clear();
-        }
+    public synchronized void dispose() {
+        trackedTabs.clear();
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentTabTracker.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentTabTracker.java
@@ -139,6 +139,9 @@ public final class AgentTabTracker implements Disposable {
         return count;
     }
 
+    /**
+     * Matches an agent-tracked base name against the IDE display name, which may include a numeric {@code (N)} suffix.
+     */
     public static boolean terminalTabNameMatches(@Nullable String trackedName, @Nullable String displayName) {
         if (trackedName == null || displayName == null) return false;
         return displayName.equals(trackedName) || displayName.matches(

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolStaticMethodsTest.java
@@ -10,8 +10,15 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class TerminalToolStaticMethodsTest {
 
@@ -27,7 +34,8 @@ class TerminalToolStaticMethodsTest {
         TerminalTool.TerminalWidgetResult result = tool.open(null, false);
 
         assertSame(widget, result.widget());
-        assertEquals("Agent: build (1) (reused)", result.tabName());
+        assertEquals("Agent: build (1)", result.tabName());
+        assertTrue(result.reused());
         verify(tracker, never()).hasOpenTerminalCapacity();
     }
 
@@ -46,6 +54,8 @@ class TerminalToolStaticMethodsTest {
 
         assertTrue(error.getMessage().contains("Agent terminal limit reached (3)"));
         assertTrue(error.getMessage().contains("close_terminal"));
+        assertEquals("Error: " + error.getMessage(), RunInTerminalTool.formatCapacityError(error));
+        assertFalse(RunInTerminalTool.formatCapacityError(error).contains("run_command"));
     }
 
     @Test
@@ -60,7 +70,8 @@ class TerminalToolStaticMethodsTest {
         TerminalTool.TerminalWidgetResult result = tool.open(null, false);
 
         assertSame(tool.createdWidget(), result.widget());
-        assertEquals("Agent: echo test (new)", result.tabName());
+        assertEquals("Agent: echo test", result.tabName());
+        assertFalse(result.reused());
         verify(tracker).trackTab("Terminal", "Agent: echo test");
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolStaticMethodsTest.java
@@ -1,13 +1,68 @@
 package com.github.catatafishen.agentbridge.psi.tools.terminal;
 
+import com.github.catatafishen.agentbridge.services.AgentTabTracker;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class TerminalToolStaticMethodsTest {
+
+    @Test
+    void reusesMostRecentTrackedTerminalWhenNoTabNameIsProvided() throws Exception {
+        Project project = mock(Project.class);
+        AgentTabTracker tracker = mock(AgentTabTracker.class);
+        Object widget = new Object();
+        when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+        when(tracker.findMostRecentOpenTerminalTabName()).thenReturn("Agent: build (1)");
+        TestTerminalTool tool = new TestTerminalTool(project, widget);
+
+        TerminalTool.TerminalWidgetResult result = tool.open(null, false);
+
+        assertSame(widget, result.widget());
+        assertEquals("Agent: build (1) (reused)", result.tabName());
+        verify(tracker, never()).hasOpenTerminalCapacity();
+    }
+
+    @Test
+    void rejectsNewTerminalWhenAgentTerminalLimitIsReached() {
+        Project project = mock(Project.class);
+        AgentTabTracker tracker = mock(AgentTabTracker.class);
+        when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+        when(tracker.hasOpenTerminalCapacity()).thenReturn(false);
+        TestTerminalTool tool = new TestTerminalTool(project, null);
+
+        IllegalStateException error = assertThrows(
+            IllegalStateException.class,
+            () -> tool.open("Agent: overflow", true)
+        );
+
+        assertTrue(error.getMessage().contains("Agent terminal limit reached (3)"));
+        assertTrue(error.getMessage().contains("close_terminal"));
+    }
+
+    @Test
+    void createsAndTracksTerminalWhenNoReusableTabExists() throws Exception {
+        Project project = mock(Project.class);
+        AgentTabTracker tracker = mock(AgentTabTracker.class);
+        when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+        when(project.getBasePath()).thenReturn("/repo");
+        when(tracker.hasOpenTerminalCapacity()).thenReturn(true);
+        TestTerminalTool tool = new TestTerminalTool(project, null);
+
+        TerminalTool.TerminalWidgetResult result = tool.open(null, false);
+
+        assertSame(tool.createdWidget(), result.widget());
+        assertEquals("Agent: echo test (new)", result.tabName());
+        verify(tracker).trackTab("Terminal", "Agent: echo test");
+    }
 
     // ── resolveInputEscapes ─────────────────────────────────
 
@@ -368,6 +423,74 @@ class TerminalToolStaticMethodsTest {
             String result = TerminalTool.truncateForTitle("a".repeat(100));
             assertEquals(40, result.length());
             assertTrue(result.endsWith("..."));
+        }
+    }
+
+    private static final class TestTerminalTool extends TerminalTool {
+        private final Object reusableWidget;
+        private final FakeTerminalManager manager = new FakeTerminalManager();
+
+        private TestTerminalTool(Project project, Object reusableWidget) {
+            super(project);
+            this.reusableWidget = reusableWidget;
+        }
+
+        private TerminalWidgetResult open(String tabName, boolean newTab) throws Exception {
+            return getOrCreateTerminalWidget(
+                FakeTerminalManager.class, manager, tabName, newTab, null, "echo test");
+        }
+
+        private Object createdWidget() {
+            return manager.widget;
+        }
+
+        @Override
+        protected Object findTerminalWidgetByTabName(Class<?> managerClass, String tabName) {
+            return reusableWidget;
+        }
+
+        @Override
+        public @NotNull String id() {
+            return "test_terminal";
+        }
+
+        @Override
+        public @NotNull String displayName() {
+            return "Test Terminal";
+        }
+
+        @Override
+        public @NotNull String description() {
+            return "Test terminal tool";
+        }
+
+        @Override
+        public @NotNull Kind kind() {
+            return Kind.EXECUTE;
+        }
+
+        @Override
+        public @NotNull JsonObject inputSchema() {
+            return new JsonObject();
+        }
+
+        @Override
+        public @NotNull String execute(@NotNull JsonObject args) {
+            return "unused";
+        }
+    }
+
+    public static final class FakeTerminalManager {
+        private final Object widget = new Object();
+
+        public Object createNewSession(
+            String basePath,
+            String title,
+            List<String> shellCommand,
+            boolean requestFocus,
+            boolean deferSessionStartUntilUiShown
+        ) {
+            return widget;
         }
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolsTest.java
@@ -13,9 +13,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 /**
- * Platform tests for the four terminal tools: {@link ListTerminalsTool},
- * {@link ReadTerminalOutputTool}, {@link WriteTerminalInputTool}, and
- * {@link RunInTerminalTool}, plus the {@link TerminalToolFactory}.
+ * Platform tests for the terminal tools: {@link ListTerminalsTool},
+ * {@link ReadTerminalOutputTool}, {@link WriteTerminalInputTool},
+ * {@link RunInTerminalTool}, and {@link CloseTerminalTool}, plus the
+ * {@link TerminalToolFactory}.
  *
  * <p>JUnit 3 style (extends {@link BasePlatformTestCase}): test methods must be
  * {@code public void testXxx()}. Run via Gradle only:
@@ -130,25 +131,27 @@ public class TerminalToolsTest extends BasePlatformTestCase {
 
     /**
      * {@link TerminalToolFactory#create} must return a list containing exactly the
-     * four expected tool instances. Availability of the terminal plugin is checked
+     * five expected tool instances. Availability of the terminal plugin is checked
      * at execution time (via reflection), not at factory creation time — there is
      * no guard to bypass at construction.
      */
-    public void testTerminalToolFactoryCreatesAllFourTools() {
+    public void testTerminalToolFactoryCreatesAllFiveTools() {
         List<Tool> tools = TerminalToolFactory.create(getProject());
 
         assertNotNull("Factory must not return null", tools);
-        assertEquals("Factory must create exactly 4 terminal tools", 4, tools.size());
+        assertEquals("Factory must create exactly 5 terminal tools", 5, tools.size());
 
         long listCount = tools.stream().filter(ListTerminalsTool.class::isInstance).count();
         long readCount = tools.stream().filter(ReadTerminalOutputTool.class::isInstance).count();
         long writeCount = tools.stream().filter(WriteTerminalInputTool.class::isInstance).count();
         long runCount = tools.stream().filter(RunInTerminalTool.class::isInstance).count();
+        long closeCount = tools.stream().filter(CloseTerminalTool.class::isInstance).count();
 
         assertEquals("Expected exactly one ListTerminalsTool", 1, listCount);
         assertEquals("Expected exactly one ReadTerminalOutputTool", 1, readCount);
         assertEquals("Expected exactly one WriteTerminalInputTool", 1, writeCount);
         assertEquals("Expected exactly one RunInTerminalTool", 1, runCount);
+        assertEquals("Expected exactly one CloseTerminalTool", 1, closeCount);
     }
 
     /**

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolsTest.java
@@ -21,10 +21,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Platform tests for the terminal tools: {@link ListTerminalsTool},
@@ -70,6 +74,8 @@ public class TerminalToolsTest extends BasePlatformTestCase {
     private WriteTerminalInputTool writeTerminalInputTool;
     private RunInTerminalTool runInTerminalTool;
     private CloseTerminalTool closeTerminalTool;
+    private boolean originalAutoCloseAgentTabs;
+    private boolean originalAutoCloseRunningTerminals;
 
     // ── Lifecycle ──────────────────────────────────────────────────────────────
 
@@ -88,14 +94,24 @@ public class TerminalToolsTest extends BasePlatformTestCase {
         writeTerminalInputTool = new WriteTerminalInputTool(getProject());
         runInTerminalTool = new RunInTerminalTool(getProject());
         closeTerminalTool = new CloseTerminalTool(getProject());
+
+        CleanupSettings cleanupSettings = CleanupSettings.getInstance(getProject());
+        originalAutoCloseAgentTabs = cleanupSettings.isAutoCloseAgentTabs();
+        originalAutoCloseRunningTerminals = cleanupSettings.isAutoCloseRunningTerminals();
     }
 
     @Override
     protected void tearDown() throws Exception {
         try {
-            ConversationDatabase.getInstance(getProject()).dispose();
+            CleanupSettings cleanupSettings = CleanupSettings.getInstance(getProject());
+            cleanupSettings.setAutoCloseAgentTabs(originalAutoCloseAgentTabs);
+            cleanupSettings.setAutoCloseRunningTerminals(originalAutoCloseRunningTerminals);
         } finally {
-            super.tearDown();
+            try {
+                ConversationDatabase.getInstance(getProject()).dispose();
+            } finally {
+                super.tearDown();
+            }
         }
     }
 
@@ -174,6 +190,7 @@ public class TerminalToolsTest extends BasePlatformTestCase {
         assertEquals("close_terminal", closeTerminalTool.id());
         assertEquals("Close Terminal", closeTerminalTool.displayName());
         assertTrue(closeTerminalTool.description().contains("Refuses to close user-created terminal tabs"));
+        assertTrue(closeTerminalTool.description().contains("does not stop a running command"));
         assertEquals(Tool.Kind.EDIT, closeTerminalTool.kind());
         assertTrue(closeTerminalTool.isDestructive());
         assertEquals("Close terminal: {tab_name}", closeTerminalTool.permissionTemplate());
@@ -184,20 +201,20 @@ public class TerminalToolsTest extends BasePlatformTestCase {
         String result = executeSync(closeTerminalTool, args("tab_name", "Agent: missing"));
 
         assertEquals(
-            "No terminal tab found matching 'Agent: missing'. Use list_terminals to see available tabs.",
+            "Error: No terminal tab found matching 'Agent: missing'. Use list_terminals to see available tabs.",
             result
         );
     }
 
-    public void testCloseTerminalRefusesUserCreatedTab() throws Exception {
-        TerminalWindowFixture fixture = installTerminalWindow(true, "Local");
+    public void testCloseTerminalRefusesUserCreatedTabUsingResolvedDisplayName() throws Exception {
+        TerminalWindowFixture fixture = installTerminalWindow(true, "Local (1)");
         AgentTabTracker tracker = mock(AgentTabTracker.class);
         replaceProjectService(AgentTabTracker.class, tracker);
 
         String result = executeSync(closeTerminalTool, args("tab_name", "Local"));
 
         assertEquals(
-            "Refusing to close terminal 'Local' because it was not created by AgentBridge.",
+            "Error: Refusing to close terminal 'Local (1)' because it was not created by AgentBridge.",
             result
         );
         verify(fixture.manager(), never()).removeContent(any(Content.class), eq(true));
@@ -216,7 +233,7 @@ public class TerminalToolsTest extends BasePlatformTestCase {
         verify(tracker).untrackTerminalTab("Agent: build (1)");
     }
 
-    public void testCloseTerminalReportsRemovalFailure() throws Exception {
+    public void testCloseTerminalReportsRemovalFailureAsError() throws Exception {
         TerminalWindowFixture fixture = installTerminalWindow(false, "Agent: build");
         AgentTabTracker tracker = mock(AgentTabTracker.class);
         when(tracker.isTrackedTerminalTab("Agent: build")).thenReturn(true);
@@ -224,9 +241,26 @@ public class TerminalToolsTest extends BasePlatformTestCase {
 
         String result = executeSync(closeTerminalTool, args("tab_name", "Agent: build"));
 
-        assertEquals("Failed to close terminal 'Agent: build'.", result);
+        assertEquals("Error: Failed to close terminal 'Agent: build'.", result);
         verify(fixture.manager()).removeContent(fixture.contents().getFirst(), true);
         verify(tracker, never()).untrackTerminalTab(any());
+    }
+
+    public void testCloseTerminalReportsExceptionalCompletionCause() {
+        CompletableFuture<String> resultFuture = new CompletableFuture<>();
+        resultFuture.completeExceptionally(new IllegalStateException("content manager failed"));
+
+        String result = CloseTerminalTool.awaitCloseResult(resultFuture, 10, TimeUnit.SECONDS);
+
+        assertEquals("Error: Failed to close terminal: content manager failed", result);
+    }
+
+    public void testCloseTerminalReportsTimeoutSeparately() {
+        CompletableFuture<String> resultFuture = new CompletableFuture<>();
+
+        String result = CloseTerminalTool.awaitCloseResult(resultFuture, 1, TimeUnit.MILLISECONDS);
+
+        assertEquals("Error: Terminal close timed out.", result);
     }
 
     public void testTrackerCountsAndSelectsOpenAgentTerminals() {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolsTest.java
@@ -2,15 +2,29 @@ package com.github.catatafishen.agentbridge.psi.tools.terminal;
 
 import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
 import com.github.catatafishen.agentbridge.psi.tools.Tool;
+import com.github.catatafishen.agentbridge.services.AgentTabTracker;
+import com.github.catatafishen.agentbridge.services.CleanupSettings;
+import com.github.catatafishen.agentbridge.session.db.ConversationDatabase;
 import com.google.gson.JsonObject;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.ComponentManager;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.testFramework.ServiceContainerUtil;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentManager;
 import com.intellij.util.ui.UIUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 /**
  * Platform tests for the terminal tools: {@link ListTerminalsTool},
@@ -55,6 +69,7 @@ public class TerminalToolsTest extends BasePlatformTestCase {
     private ReadTerminalOutputTool readTerminalOutputTool;
     private WriteTerminalInputTool writeTerminalInputTool;
     private RunInTerminalTool runInTerminalTool;
+    private CloseTerminalTool closeTerminalTool;
 
     // ── Lifecycle ──────────────────────────────────────────────────────────────
 
@@ -72,11 +87,16 @@ public class TerminalToolsTest extends BasePlatformTestCase {
         readTerminalOutputTool = new ReadTerminalOutputTool(getProject());
         writeTerminalInputTool = new WriteTerminalInputTool(getProject());
         runInTerminalTool = new RunInTerminalTool(getProject());
+        closeTerminalTool = new CloseTerminalTool(getProject());
     }
 
     @Override
     protected void tearDown() throws Exception {
-        super.tearDown();
+        try {
+            ConversationDatabase.getInstance(getProject()).dispose();
+        } finally {
+            super.tearDown();
+        }
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────
@@ -125,6 +145,132 @@ public class TerminalToolsTest extends BasePlatformTestCase {
             }
         }
         return future.get();
+    }
+
+    private TerminalWindowFixture installTerminalWindow(boolean removeSucceeds, String... displayNames) {
+        ToolWindowManager toolWindowManager = mock(ToolWindowManager.class);
+        ToolWindow toolWindow = mock(ToolWindow.class);
+        ContentManager contentManager = mock(ContentManager.class);
+        List<Content> contents = new ArrayList<>();
+        for (String displayName : displayNames) {
+            Content content = mock(Content.class);
+            when(content.getDisplayName()).thenReturn(displayName);
+            contents.add(content);
+        }
+        when(toolWindowManager.getToolWindow("Terminal")).thenReturn(toolWindow);
+        when(toolWindow.getContentManager()).thenReturn(contentManager);
+        when(contentManager.getContents()).thenReturn(contents.toArray(Content[]::new));
+        when(contentManager.removeContent(any(Content.class), eq(true))).thenReturn(removeSucceeds);
+        replaceProjectService(ToolWindowManager.class, toolWindowManager);
+        return new TerminalWindowFixture(contentManager, contents);
+    }
+
+    private <T> void replaceProjectService(Class<T> serviceClass, T instance) {
+        ServiceContainerUtil.replaceService(
+            (ComponentManager) getProject(), serviceClass, instance, getTestRootDisposable());
+    }
+
+    public void testCloseTerminalMetadataDescribesSafeAgentTabCleanup() {
+        assertEquals("close_terminal", closeTerminalTool.id());
+        assertEquals("Close Terminal", closeTerminalTool.displayName());
+        assertTrue(closeTerminalTool.description().contains("Refuses to close user-created terminal tabs"));
+        assertEquals(Tool.Kind.EDIT, closeTerminalTool.kind());
+        assertTrue(closeTerminalTool.isDestructive());
+        assertEquals("Close terminal: {tab_name}", closeTerminalTool.permissionTemplate());
+        assertTrue(closeTerminalTool.inputSchema().getAsJsonObject("properties").has("tab_name"));
+    }
+
+    public void testCloseTerminalMissingTabReturnsGuidance() throws Exception {
+        String result = executeSync(closeTerminalTool, args("tab_name", "Agent: missing"));
+
+        assertEquals(
+            "No terminal tab found matching 'Agent: missing'. Use list_terminals to see available tabs.",
+            result
+        );
+    }
+
+    public void testCloseTerminalRefusesUserCreatedTab() throws Exception {
+        TerminalWindowFixture fixture = installTerminalWindow(true, "Local");
+        AgentTabTracker tracker = mock(AgentTabTracker.class);
+        replaceProjectService(AgentTabTracker.class, tracker);
+
+        String result = executeSync(closeTerminalTool, args("tab_name", "Local"));
+
+        assertEquals(
+            "Refusing to close terminal 'Local' because it was not created by AgentBridge.",
+            result
+        );
+        verify(fixture.manager(), never()).removeContent(any(Content.class), eq(true));
+    }
+
+    public void testCloseTerminalRemovesAndUntracksAgentTab() throws Exception {
+        TerminalWindowFixture fixture = installTerminalWindow(true, "Agent: build (1)");
+        AgentTabTracker tracker = mock(AgentTabTracker.class);
+        when(tracker.isTrackedTerminalTab("Agent: build (1)")).thenReturn(true);
+        replaceProjectService(AgentTabTracker.class, tracker);
+
+        String result = executeSync(closeTerminalTool, args("tab_name", "Agent: build"));
+
+        assertEquals("Closed AgentBridge terminal 'Agent: build (1)'.", result);
+        verify(fixture.manager()).removeContent(fixture.contents().getFirst(), true);
+        verify(tracker).untrackTerminalTab("Agent: build (1)");
+    }
+
+    public void testCloseTerminalReportsRemovalFailure() throws Exception {
+        TerminalWindowFixture fixture = installTerminalWindow(false, "Agent: build");
+        AgentTabTracker tracker = mock(AgentTabTracker.class);
+        when(tracker.isTrackedTerminalTab("Agent: build")).thenReturn(true);
+        replaceProjectService(AgentTabTracker.class, tracker);
+
+        String result = executeSync(closeTerminalTool, args("tab_name", "Agent: build"));
+
+        assertEquals("Failed to close terminal 'Agent: build'.", result);
+        verify(fixture.manager()).removeContent(fixture.contents().getFirst(), true);
+        verify(tracker, never()).untrackTerminalTab(any());
+    }
+
+    public void testTrackerCountsAndSelectsOpenAgentTerminals() {
+        installTerminalWindow(true, "Local", "Agent: build", "Agent: test (1)");
+        AgentTabTracker tracker = new AgentTabTracker(getProject());
+        tracker.trackTab("Terminal", "Agent: build");
+        tracker.trackTab("Terminal", "Agent: test");
+
+        assertEquals(2, tracker.countOpenTerminalTabs());
+        assertTrue(tracker.hasOpenTerminalCapacity());
+        assertEquals("Agent: test (1)", tracker.findMostRecentOpenTerminalTabName());
+    }
+
+    public void testTurnCleanupClosesAndForgetsIdleTerminal() {
+        TerminalWindowFixture fixture = installTerminalWindow(true, "Agent: build");
+        CleanupSettings settings = CleanupSettings.getInstance(getProject());
+        settings.setAutoCloseAgentTabs(true);
+        settings.setAutoCloseRunningTerminals(true);
+        AgentTabTracker tracker = new AgentTabTracker(getProject());
+        tracker.trackTab("Terminal", "Agent: build");
+
+        tracker.closeTrackedTabs();
+        UIUtil.dispatchAllInvocationEvents();
+
+        verify(fixture.manager()).removeContent(fixture.contents().getFirst(), true);
+        assertFalse(tracker.isTrackedTerminalTab("Agent: build"));
+    }
+
+    public void testTurnCleanupRetainsRunningTerminalWhenClosingIsDisabled() {
+        TerminalWindowFixture fixture = installTerminalWindow(true, "Agent: build");
+        CleanupSettings settings = CleanupSettings.getInstance(getProject());
+        settings.setAutoCloseAgentTabs(true);
+        settings.setAutoCloseRunningTerminals(false);
+        AgentTabTracker tracker = new AgentTabTracker(getProject());
+        tracker.trackTab("Terminal", "Agent: build");
+
+        tracker.closeTrackedTabs();
+        UIUtil.dispatchAllInvocationEvents();
+
+        verify(fixture.manager(), never()).removeContent(any(Content.class), eq(true));
+        assertTrue(tracker.isTrackedTerminalTab("Agent: build"));
+    }
+
+    private record TerminalWindowFixture(ContentManager manager, List<Content> contents) {
     }
 
     // ── TerminalToolFactory ────────────────────────────────────────────────────

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentTabTrackerCountMatchingTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentTabTrackerCountMatchingTest.java
@@ -10,12 +10,15 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests for pure terminal-tab lifecycle helpers in {@link AgentTabTracker}.
- * No IntelliJ platform dependencies — runs as a plain JUnit test.
+ * Tests for terminal-tab lifecycle helpers in {@link AgentTabTracker}.
+ * Uses mocked IntelliJ types and does not require an IDE fixture or runtime.
  */
 @DisplayName("AgentTabTracker terminal lifecycle")
 class AgentTabTrackerCountMatchingTest {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentTabTrackerCountMatchingTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentTabTrackerCountMatchingTest.java
@@ -1,5 +1,9 @@
 package com.github.catatafishen.agentbridge.services;
 
+import com.github.catatafishen.agentbridge.psi.tools.Tool;
+import com.github.catatafishen.agentbridge.psi.tools.terminal.CloseTerminalTool;
+import com.github.catatafishen.agentbridge.psi.tools.terminal.TerminalToolFactory;
+import com.intellij.openapi.project.Project;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -7,13 +11,34 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
- * Tests for the pure helper {@link AgentTabTracker#countMatchingTerminalTabs}.
+ * Tests for pure terminal-tab lifecycle helpers in {@link AgentTabTracker}.
  * No IntelliJ platform dependencies — runs as a plain JUnit test.
  */
-@DisplayName("AgentTabTracker.countMatchingTerminalTabs")
+@DisplayName("AgentTabTracker terminal lifecycle")
 class AgentTabTrackerCountMatchingTest {
+
+    @Test
+    @DisplayName("terminal factory exposes a destructive close_terminal tool")
+    void terminalFactoryExposesCloseTerminal() {
+        List<Tool> tools = TerminalToolFactory.create(mock(Project.class));
+        assertEquals(5, tools.size());
+
+        Tool closeTool = tools.stream()
+            .filter(CloseTerminalTool.class::isInstance)
+            .findFirst()
+            .orElseThrow();
+
+        assertEquals("close_terminal", closeTool.id());
+        assertEquals(Tool.Kind.EDIT, closeTool.kind());
+        assertTrue(closeTool.isDestructive());
+        assertTrue(closeTool.inputSchema().toString().contains("\"tab_name\""));
+    }
 
     @Test
     @DisplayName("returns 0 when no tabs are tracked")
@@ -37,18 +62,24 @@ class AgentTabTrackerCountMatchingTest {
     }
 
     @Test
-    @DisplayName("matches when the display name contains the tracked tab name with an IDE-appended suffix")
+    @DisplayName("matches an IDE-appended numeric suffix")
     void matchesDisplayNameWithSuffix() {
         assertEquals(1, AgentTabTracker.countMatchingTerminalTabs(
             List.of("Agent: build"), List.of("Agent: build (1)")));
     }
 
     @Test
-    @DisplayName("counts each open tab at most once even if several tracked names match")
+    @DisplayName("does not match unrelated tabs containing the tracked name")
+    void ignoresPartialNameCollisions() {
+        assertEquals(0, AgentTabTracker.countMatchingTerminalTabs(
+            List.of("Agent"), List.of("Agent: build")));
+    }
+
+    @Test
+    @DisplayName("counts each open tab at most once")
     void countsEachOpenTabOnce() {
-        // Both tracked names are substrings of the single open tab — it must still count once.
         assertEquals(1, AgentTabTracker.countMatchingTerminalTabs(
-            List.of("Agent", "build"), List.of("Agent: build")));
+            List.of("Agent: build", "Agent: build"), List.of("Agent: build")));
     }
 
     @Test
@@ -64,5 +95,33 @@ class AgentTabTrackerCountMatchingTest {
     void ignoresNullDisplayNames() {
         assertEquals(1, AgentTabTracker.countMatchingTerminalTabs(
             List.of("Agent: build"), Arrays.asList(null, "Agent: build", null)));
+    }
+
+    @Test
+    @DisplayName("returns the newest tracked terminal that is still open")
+    void returnsMostRecentOpenTrackedTerminal() {
+        assertEquals("Agent: test (1)", AgentTabTracker.mostRecentOpenTerminalTabName(
+            List.of("Agent: build", "Agent: closed", "Agent: test"),
+            List.of("Local", "Agent: build", "Agent: test (1)")));
+    }
+
+    @Test
+    @DisplayName("returns null when every tracked terminal is closed")
+    void returnsNullWhenNoTrackedTerminalIsOpen() {
+        assertNull(AgentTabTracker.mostRecentOpenTerminalTabName(
+            List.of("Agent: build"), List.of("Local")));
+    }
+
+    @Test
+    @DisplayName("allows creation below the agent terminal limit")
+    void allowsCreationBelowLimit() {
+        assertEquals(3, AgentTabTracker.MAX_OPEN_AGENT_TERMINALS);
+        assertTrue(AgentTabTracker.hasTerminalCapacity(2));
+    }
+
+    @Test
+    @DisplayName("blocks creation at the agent terminal limit")
+    void blocksCreationAtLimit() {
+        assertFalse(AgentTabTracker.hasTerminalCapacity(3));
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentTabTrackerCountMatchingTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentTabTrackerCountMatchingTest.java
@@ -10,10 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -123,5 +120,39 @@ class AgentTabTrackerCountMatchingTest {
     @DisplayName("blocks creation at the agent terminal limit")
     void blocksCreationAtLimit() {
         assertFalse(AgentTabTracker.hasTerminalCapacity(3));
+    }
+
+    @Test
+    @DisplayName("tracks, recognizes, and untracks an AgentBridge terminal")
+    void tracksAndUntracksTerminalByDisplayName() {
+        AgentTabTracker tracker = new AgentTabTracker(mock(Project.class));
+        tracker.trackTab("Terminal", "Agent: build");
+        tracker.trackTab("Run", "Agent: tests");
+
+        assertTrue(tracker.isTrackedTerminalTab("Agent: build"));
+        assertTrue(tracker.isTrackedTerminalTab("Agent: build (2)"));
+        assertFalse(tracker.isTrackedTerminalTab("Agent: tests"));
+
+        tracker.untrackTerminalTab("Agent: build (2)");
+
+        assertFalse(tracker.isTrackedTerminalTab("Agent: build"));
+    }
+
+    @Test
+    @DisplayName("dispose forgets tracked terminals")
+    void disposeForgetsTrackedTerminals() {
+        AgentTabTracker tracker = new AgentTabTracker(mock(Project.class));
+        tracker.trackTab("Terminal", "Agent: build");
+
+        tracker.dispose();
+
+        assertFalse(tracker.isTrackedTerminalTab("Agent: build"));
+    }
+
+    @Test
+    @DisplayName("terminal matching rejects null names")
+    void terminalMatchingRejectsNullNames() {
+        assertFalse(AgentTabTracker.terminalTabNameMatches(null, "Agent: build"));
+        assertFalse(AgentTabTracker.terminalTabNameMatches("Agent: build", null));
     }
 }


### PR DESCRIPTION
## Summary

Agent-created terminal tabs were accumulating because run_in_terminal documented reuse as the default, but unnamed calls always created a new tab. Cleanup could also forget tracked terminals that it intentionally skipped, and there was no safe tool for an agent to close its own terminal tabs.

This change:

- reuses the most recently opened AgentBridge terminal when tab_name is omitted
- caps concurrently tracked AgentBridge terminals at 3 and returns an actionable reuse/close message at the limit
- adds a permissioned close_terminal tool that can close only AgentBridge-created terminals
- keeps skipped terminal tabs tracked so cleanup can retry later
- uses exact terminal-name matching, allowing only the IDE's numeric (N) suffix
- updates terminal tool descriptions/results to encourage reuse and explicit cleanup

The implementation deliberately avoids guessing whether a shell is idle from process names or prompt text: an interactive shell remains a live process, and prompt detection is shell/theme dependent.

## Verification

- gradlew.bat :plugin-core:assemble -x :plugin-core:buildChatUi
- lifecycle tracker tests: 13 passed
- terminal tool tests passed, including registration of all five terminal tools
