### PR TITLE
feat(opencode): add Scout agent to built-in agent list

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/OpenCodeClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/OpenCodeClient.java
@@ -33,6 +33,7 @@ public final class OpenCodeClient extends AcpClient {
     private static final String PLAN_AGENT = "plan";
     private static final String GENERAL_AGENT = "general";
     private static final String EXPLORE_AGENT = "explore";
+    private static final String SCOUT_AGENT = "scout";
     private static final String PROJECT_AGENT_DIR = ".opencode/agent";
     private static final String PROJECT_AGENTS_DIR = ".opencode/agents";
     private static final String DEPLOYED_AGENT_DIR = ".agent-work/opencode/agent";
@@ -78,7 +79,7 @@ public final class OpenCodeClient extends AcpClient {
         if (basePath != null) {
             agents.addAll(ProjectAgentScanner.scanAgentDirectories(
                 Path.of(basePath),
-                Set.of(BUILD_AGENT, PLAN_AGENT, GENERAL_AGENT, EXPLORE_AGENT),
+                Set.of(BUILD_AGENT, PLAN_AGENT, GENERAL_AGENT, EXPLORE_AGENT, SCOUT_AGENT),
                 PROJECT_AGENT_DIR,
                 PROJECT_AGENTS_DIR,
                 DEPLOYED_AGENT_DIR
@@ -92,7 +93,8 @@ public final class OpenCodeClient extends AcpClient {
             new AbstractClient.AgentMode(BUILD_AGENT, "Build", "Default primary agent with full tool access"),
             new AbstractClient.AgentMode(PLAN_AGENT, "Plan", "Read-only planning mode with guarded edits and bash"),
             new AbstractClient.AgentMode(GENERAL_AGENT, "General", "General-purpose subagent for complex tasks"),
-            new AbstractClient.AgentMode(EXPLORE_AGENT, "Explore", "Fast read-only subagent for codebase exploration")
+            new AbstractClient.AgentMode(EXPLORE_AGENT, "Explore", "Fast read-only subagent for codebase exploration"),
+            new AbstractClient.AgentMode(SCOUT_AGENT, "Scout", "Read-only subagent for external docs and dependency research")
         );
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatDataModel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatDataModel.kt
@@ -83,9 +83,11 @@ internal val SUB_AGENT_INFO = mapOf(
     // Built-in Claude Code agents (current casing from docs)
     "Explore" to SubAgentInfo("Explore"),
     "Plan" to SubAgentInfo("Plan"),
+    "Scout" to SubAgentInfo("Scout"),
     AGENT_TYPE_GENERAL to SubAgentInfo("General"),
     // Legacy / lowercase aliases
     "explore" to SubAgentInfo("Explore"),
+    "scout" to SubAgentInfo("Scout"),
     "task" to SubAgentInfo("Task Agent"),
     // Custom intellij-* agents (recommended in startup instructions)
     "intellij-explore" to SubAgentInfo("Explore"),

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/OpenCodeClientBehaviorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/OpenCodeClientBehaviorTest.java
@@ -103,10 +103,10 @@ class OpenCodeClientBehaviorTest {
         List<AbstractClient.AgentMode> agents = client.getAvailableAgents();
 
         assertEquals(
-            List.of("build", "plan", "general", "explore", "shared", "local"),
+            List.of("build", "plan", "general", "explore", "scout", "shared", "local"),
             agents.stream().map(AbstractClient.AgentMode::slug).toList()
         );
-        assertEquals("Shared Primary", agents.get(4).name());
+        assertEquals("Shared Primary", agents.get(5).name());
         assertTrue(agents.stream().noneMatch(agent -> "Shadow Build".equals(agent.name())));
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/OpenCodeClientStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/OpenCodeClientStaticMethodsTest.java
@@ -135,17 +135,19 @@ class OpenCodeClientStaticMethodsTest {
     class BuiltInAgents {
 
         @Test
-        @DisplayName("returns OpenCode's 4 native agents in display order")
+        @DisplayName("returns OpenCode's 5 native agents in display order")
         void returnsNativeAgents() {
             var agents = OpenCodeClient.builtInAgents();
 
-            assertEquals(4, agents.size());
+            assertEquals(5, agents.size());
             assertEquals("build", agents.get(0).slug());
             assertEquals("plan", agents.get(1).slug());
             assertEquals("general", agents.get(2).slug());
             assertEquals("explore", agents.get(3).slug());
+            assertEquals("scout", agents.get(4).slug());
             assertEquals("Build", agents.get(0).name());
             assertEquals("Plan", agents.get(1).name());
+            assertEquals("Scout", agents.get(4).name());
         }
     }
 


### PR DESCRIPTION
**Problem:** The plugin's OpenCode integration was missing the **Scout** agent — a documented built-in subagent for external docs and dependency research (https://opencode.ai/docs/agents).

**Changes:**
- **OpenCodeClient.java** — Add `SCOUT_AGENT = "scout"` constant, include Scout in `builtInAgents()`, and add to built-in slugs set so project agents can't shadow it
- **ChatDataModel.kt** — Add `"Scout"` and `"scout"` to `SUB_AGENT_INFO` display-name lookup
- **Tests** — Update expected count 4→5 and slug order assertions

**Verification:** Tests updated to expect the new agent. `builtInAgents()` returns 5 agents (build, plan, general, explore, scout) in order.