### PR TITLE
fix: isolate and reuse agent terminal sessions

### DIFF
--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -409,7 +409,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           REF_NAME: ${{ github.ref_name }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$IS_FORK" = "true" ]; then
+            echo "Fork PR token is read-only; matrix remains available in the job summary."
+            exit 0
+          fi
           if [ "$EVENT_NAME" = "pull_request" ]; then
             PR="$PR_NUMBER"
           else

--- a/docs/MCP-ARCHITECTURE.md
+++ b/docs/MCP-ARCHITECTURE.md
@@ -194,7 +194,7 @@ custom MCP clients) that cannot use the stdio-based subprocess model.
 | Class                          | Role                                                            |
 |--------------------------------|-----------------------------------------------------------------|
 | `McpHttpServer`                | Starts `com.sun.net.httpserver.HttpServer`, registers endpoints |
-| `McpProtocolHandler`           | Stateless JSON-RPC handler (shared by all transports)           |
+| `McpProtocolHandler`           | JSON-RPC handler; propagates transport-session ownership         |
 | `McpSseTransport`              | SSE session management, `/sse` and `/message` endpoints         |
 | `SseSession`                   | Single SSE client connection (event stream, keep-alive)         |
 | `McpServerSettings`            | Persistent settings: port, auto-start, transport mode           |
@@ -209,10 +209,16 @@ Configured in **Settings → Tools → AgentBridge → MCP Server → General**.
 
 Single request/response model — the simplest transport for MCP.
 
-| Endpoint  | Method | Description                          |
-|-----------|--------|--------------------------------------|
-| `/mcp`    | POST   | JSON-RPC request → JSON-RPC response |
-| `/health` | GET    | Server status check                  |
+| Endpoint  | Method | Description                                           |
+|-----------|--------|-------------------------------------------------------|
+| `/mcp`    | POST   | JSON-RPC request → JSON-RPC response                  |
+| `/mcp`    | DELETE | End the `Mcp-Session-Id` session and release resources |
+| `/health` | GET    | Server status check                                   |
+
+The initialize response returns `Mcp-Session-Id`. Clients echo that header on
+subsequent requests. AgentBridge uses the transport session as the ownership
+boundary for stateful resources, so concurrent agents cannot read, write, reuse,
+or close one another's integrated terminals.
 
 Client config:
 
@@ -316,11 +322,13 @@ tool documentation. Summary of categories:
 - `http_request` - Make HTTP calls (for API testing)
 - `run_command` - Execute shell commands in project directory
 
-### 8. Terminal & Logs (6 tools)
+### 8. Terminal & Logs (8 tools)
 
-- `run_in_terminal` - Execute commands in IntelliJ terminal tabs
-- `list_terminals` - List available shells and terminal tabs
-- `read_terminal_output` - Read terminal content
+- `run_in_terminal` - Execute commands in an owner-scoped terminal and return a stable `terminal_id`
+- `list_terminals` - List only the current MCP session's terminal resources
+- `read_terminal_output` - Read an owned terminal by stable ID
+- `write_terminal_input` - Send input to an owned terminal by stable ID
+- `close_terminal` - Release an owned terminal explicitly
 - `read_run_output` - Read Run panel output
 - `read_ide_log` - Read IntelliJ's idea.log
 - `get_notifications` - Get IDE notifications

--- a/ide-integration-tests/src/test/kotlin/com/github/catatafishen/agentbridge/integration/IdeBench.kt
+++ b/ide-integration-tests/src/test/kotlin/com/github/catatafishen/agentbridge/integration/IdeBench.kt
@@ -206,17 +206,19 @@ object IdeBench {
                 // Everything is driven over the plugin's MCP server — the same boundary an agent
                 // (and the bug reporter) uses — so we deliberately do NOT depend on the Driver UI
                 // DSL. The lambda body just keeps the IDE alive while we issue HTTP calls.
-                val mcp = McpClient(port = MCP_PORT)
-                val version = mcp.awaitHealthy(timeout = ide.bootTimeout)
-                println("[integration] ${ide.key}: MCP healthy — plugin version $version")
+                McpClient(port = MCP_PORT).use { mcp ->
+                    val version = mcp.awaitHealthy(timeout = ide.bootTimeout)
+                    println("[integration] ${ide.key}: MCP healthy — plugin version $version")
+                    mcp.initialize()
 
-                // Gate on indexing + backend warm-up via the plugin's own tool: more reliable than
-                // guessing the Driver's wait DSL, and exercises the MCP path end-to-end.
-                val indexing = mcp.callTool("get_indexing_status", mapOf("wait" to true, "timeout" to 300))
-                println("[integration] ${ide.key}: get_indexing_status → $indexing")
+                    // Gate on indexing + backend warm-up via the plugin's own tool: more reliable than
+                    // guessing the Driver's wait DSL, and exercises the MCP path end-to-end.
+                    val indexing = mcp.callTool("get_indexing_status", mapOf("wait" to true, "timeout" to 300))
+                    println("[integration] ${ide.key}: get_indexing_status → $indexing")
 
-                block(ide, mcp)
-                passed = true
+                    block(ide, mcp)
+                    passed = true
+                }
             }
         } finally {
             if (!passed) IdeLogDump.dump(context.paths.testHome)

--- a/ide-integration-tests/src/test/kotlin/com/github/catatafishen/agentbridge/integration/McpClient.kt
+++ b/ide-integration-tests/src/test/kotlin/com/github/catatafishen/agentbridge/integration/McpClient.kt
@@ -16,16 +16,25 @@ import kotlin.time.toJavaDuration
  * tools against a real running IDE.
  *
  * Contract (STREAMABLE_HTTP transport):
- *   GET  http://127.0.0.1:{port}/health  → {"status":"ok","version":...}
- *   POST http://127.0.0.1:{port}/mcp     → JSON-RPC 2.0 tools/call
+ *   GET    http://127.0.0.1:{port}/health  → {"status":"ok","version":...}
+ *   POST   http://127.0.0.1:{port}/mcp     → initialize, then tools/call with Mcp-Session-Id
+ *   DELETE http://127.0.0.1:{port}/mcp     → release the transport session
  */
-class McpClient(private val port: Int, private val host: String = "127.0.0.1") {
+class McpClient(private val port: Int, private val host: String = "127.0.0.1") : AutoCloseable {
+
+    private companion object {
+        const val SESSION_HEADER = "Mcp-Session-Id"
+        const val PROTOCOL_HEADER = "MCP-Protocol-Version"
+        const val PROTOCOL_VERSION = "2025-11-25"
+        const val ACCEPT = "application/json, text/event-stream"
+    }
 
     private val http: HttpClient = HttpClient.newBuilder()
         .connectTimeout(10.seconds.toJavaDuration())
         .build()
 
     private val baseUrl = "http://$host:$port"
+    private var sessionId: String? = null
 
     /** Polls /health until it reports status=ok, or fails after [timeout]. Returns the plugin version. */
     fun awaitHealthy(timeout: kotlin.time.Duration): String {
@@ -57,12 +66,74 @@ class McpClient(private val port: Int, private val host: String = "127.0.0.1") {
         throw AssertionError("MCP server at $baseUrl did not become healthy within $timeout (last: $lastError)")
     }
 
+    /** Initializes the Streamable HTTP transport and retains its server-issued session ID. */
+    fun initialize(timeout: Duration = Duration.ofSeconds(30)) {
+        check(sessionId == null) { "MCP transport session is already initialized" }
+
+        val params = JsonObject().apply {
+            addProperty("protocolVersion", PROTOCOL_VERSION)
+            add("capabilities", JsonObject())
+            add("clientInfo", JsonObject().apply {
+                addProperty("name", "agentbridge-ide-integration-tests")
+                addProperty("version", "1.0")
+            })
+        }
+        val request = JsonObject().apply {
+            addProperty("jsonrpc", "2.0")
+            addProperty("id", 1)
+            addProperty("method", "initialize")
+            add("params", params)
+        }
+
+        val resp = http.send(
+            HttpRequest.newBuilder(URI.create("$baseUrl/mcp"))
+                .timeout(timeout)
+                .header("Content-Type", "application/json")
+                .header("Accept", ACCEPT)
+                .POST(HttpRequest.BodyPublishers.ofString(request.toString()))
+                .build(),
+            HttpResponse.BodyHandlers.ofString()
+        )
+        check(resp.statusCode() == 200) { "initialize → HTTP ${resp.statusCode()}: ${resp.body()}" }
+
+        val json = JsonParser.parseString(resp.body()).asJsonObject
+        check(!json.has("error") && json.get("result")?.isJsonObject == true) {
+            "initialize → invalid JSON-RPC response: ${resp.body()}"
+        }
+        val establishedSessionId = resp.headers().firstValue(SESSION_HEADER).orElseThrow {
+            IllegalStateException("initialize response did not include $SESSION_HEADER")
+        }
+        sessionId = establishedSessionId
+
+        val initialized = JsonObject().apply {
+            addProperty("jsonrpc", "2.0")
+            addProperty("method", "notifications/initialized")
+        }
+        val initializedResponse = http.send(
+            HttpRequest.newBuilder(URI.create("$baseUrl/mcp"))
+                .timeout(timeout)
+                .header("Content-Type", "application/json")
+                .header("Accept", ACCEPT)
+                .header(SESSION_HEADER, establishedSessionId)
+                .header(PROTOCOL_HEADER, PROTOCOL_VERSION)
+                .POST(HttpRequest.BodyPublishers.ofString(initialized.toString()))
+                .build(),
+            HttpResponse.BodyHandlers.discarding()
+        )
+        check(initializedResponse.statusCode() == 202) {
+            "notifications/initialized → HTTP ${initializedResponse.statusCode()}"
+        }
+    }
+
     /**
      * Calls a tool via JSON-RPC tools/call and returns the concatenated text content.
      * Throws on HTTP/transport errors only. JSON-RPC errors are returned as plain strings
      * so the test assertion message includes the actual MCP error instead of a stack trace.
      */
     fun callTool(name: String, arguments: Map<String, Any>, timeout: Duration = Duration.ofSeconds(60)): String {
+        val currentSessionId = checkNotNull(sessionId) {
+            "MCP transport session is not initialized; call initialize() first"
+        }
         val args = JsonObject()
         for ((k, v) in arguments) {
             when (v) {
@@ -86,6 +157,9 @@ class McpClient(private val port: Int, private val host: String = "127.0.0.1") {
             HttpRequest.newBuilder(URI.create("$baseUrl/mcp"))
                 .timeout(timeout)
                 .header("Content-Type", "application/json")
+                .header("Accept", ACCEPT)
+                .header(SESSION_HEADER, currentSessionId)
+                .header(PROTOCOL_HEADER, PROTOCOL_VERSION)
                 .POST(HttpRequest.BodyPublishers.ofString(request.toString()))
                 .build(),
             HttpResponse.BodyHandlers.ofString()
@@ -107,5 +181,24 @@ class McpClient(private val port: Int, private val host: String = "127.0.0.1") {
             }
         }
         return sb.toString()
+    }
+
+    /** Ends the transport session so server-owned resources are released after each IDE run. */
+    override fun close() {
+        val currentSessionId = sessionId ?: return
+
+        val resp = http.send(
+            HttpRequest.newBuilder(URI.create("$baseUrl/mcp"))
+                .timeout(Duration.ofSeconds(10))
+                .header(SESSION_HEADER, currentSessionId)
+                .header(PROTOCOL_HEADER, PROTOCOL_VERSION)
+                .DELETE()
+                .build(),
+            HttpResponse.BodyHandlers.discarding()
+        )
+        check(resp.statusCode() == 204) {
+            "DELETE /mcp → HTTP ${resp.statusCode()}"
+        }
+        sessionId = null
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/CloseTerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/CloseTerminalTool.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Closes an integrated terminal tab created by AgentBridge.
+ * Closes an integrated terminal owned by the current MCP session.
  */
 public final class CloseTerminalTool extends TerminalTool {
 
@@ -33,9 +33,9 @@ public final class CloseTerminalTool extends TerminalTool {
 
     @Override
     public @NotNull String description() {
-        return "Close an AgentBridge-created terminal tab when it is no longer needed. "
-            + "This closes the tab but does not stop a running command in it. "
-            + "Refuses to close user-created terminal tabs. Use list_terminals to find tab names.";
+        return "Close a terminal owned by this MCP session when it is no longer needed. "
+            + "Use terminal_id (preferred) or the owner-scoped tab_name fallback. "
+            + "Other agents' terminals and user-created terminal tabs cannot be closed.";
     }
 
     @Override
@@ -50,24 +50,32 @@ public final class CloseTerminalTool extends TerminalTool {
 
     @Override
     public @NotNull String permissionTemplate() {
-        return "Close terminal: {tab_name}";
+        return "Close owned terminal: {terminal_id} {tab_name}";
     }
 
     @Override
     public @NotNull JsonObject inputSchema() {
         return schema(
-            Param.required(JSON_TAB_NAME, TYPE_STRING,
-                "Name of the AgentBridge-created terminal tab to close")
+            Param.optional(JSON_TERMINAL_ID, TYPE_STRING,
+                "Stable ID returned by run_in_terminal (preferred)"),
+            Param.optional(JSON_TAB_NAME, TYPE_STRING,
+                "Owner-scoped terminal tab name (compatibility fallback)")
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
-        String tabName = args.get(JSON_TAB_NAME).getAsString();
+        String terminalId = optionalSelector(args, JSON_TERMINAL_ID);
+        String tabName = optionalSelector(args, JSON_TAB_NAME);
+        if (terminalId == null && tabName == null) {
+            return "Error: Provide terminal_id from run_in_terminal/list_terminals "
+                + "or an owner-scoped tab_name.";
+        }
+
+        String ownerId = currentOwnerId();
         CompletableFuture<String> resultFuture = new CompletableFuture<>();
-
-        EdtUtil.invokeLater(() -> closeTerminal(tabName, resultFuture));
-
+        EdtUtil.invokeLater(() ->
+            closeTerminal(ownerId, terminalId, tabName, resultFuture));
         return awaitCloseResult(resultFuture, 10, TimeUnit.SECONDS);
     }
 
@@ -95,41 +103,47 @@ public final class CloseTerminalTool extends TerminalTool {
 
     private static @NotNull String failureDetail(@NotNull Throwable failure) {
         String message = failure.getMessage();
-        return message == null || message.isBlank() ? failure.getClass().getSimpleName() : message;
+        return message == null || message.isBlank()
+            ? failure.getClass().getSimpleName()
+            : message;
     }
 
-    private void closeTerminal(String tabName, CompletableFuture<String> resultFuture) {
+    private void closeTerminal(
+        String ownerId,
+        String terminalId,
+        String tabName,
+        CompletableFuture<String> resultFuture
+    ) {
         try {
-            var content = resolveTerminalContent(tabName);
-            if (content == null) {
+            AgentTabTracker.AgentTerminal terminal =
+                resolveOwnedTerminal(ownerId, terminalId, tabName);
+            if (terminal == null) {
                 resultFuture.complete(
-                    "Error: No terminal tab found matching '" + tabName
-                        + "'. Use list_terminals to see available tabs.");
+                    "Error: No terminal owned by this MCP session matches "
+                        + selectorDescription(terminalId, tabName)
+                        + ". Use list_terminals to see this session's terminals.");
                 return;
             }
 
-            String displayName = content.getDisplayName();
-            AgentTabTracker tracker = AgentTabTracker.getInstance(project);
-            if (displayName == null || !tracker.isTrackedTerminalTab(displayName)) {
-                String rejectedName = displayName != null ? displayName : tabName;
+            var toolWindow = ToolWindowManager.getInstance(project)
+                .getToolWindow(TERMINAL_TOOL_WINDOW_ID);
+            if (toolWindow == null
+                || !toolWindow.getContentManager().removeContent(terminal.content(), true)) {
                 resultFuture.complete(
-                    "Error: Refusing to close terminal '" + rejectedName
-                        + "' because it was not created by AgentBridge.");
+                    "Error: Failed to close terminal '" + terminal.displayName()
+                        + "' [terminal_id=" + terminal.terminalId() + "].");
                 return;
             }
 
-            var toolWindow = ToolWindowManager.getInstance(project).getToolWindow(TERMINAL_TOOL_WINDOW_ID);
-            if (toolWindow == null || !toolWindow.getContentManager().removeContent(content, true)) {
-                resultFuture.complete("Error: Failed to close terminal '" + displayName + "'.");
-                return;
-            }
-
-            tracker.untrackTerminalTab(displayName);
-            resultFuture.complete("Closed AgentBridge terminal '" + displayName + "'.");
-        } catch (Exception e) {
-            LOG.warn("Failed to close terminal: " + tabName, e);
+            AgentTabTracker.getInstance(project)
+                .untrackTerminal(ownerId, terminal.terminalId());
             resultFuture.complete(
-                "Error: Failed to close terminal '" + tabName + "': " + failureDetail(e));
+                "Closed AgentBridge terminal '" + terminal.displayName()
+                    + "' [terminal_id=" + terminal.terminalId() + "].");
+        } catch (Exception e) {
+            LOG.warn("Failed to close terminal " + selectorDescription(terminalId, tabName), e);
+            resultFuture.complete(
+                "Error: Failed to close terminal: " + failureDetail(e));
         }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/ListTerminalsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/ListTerminalsTool.java
@@ -6,7 +6,7 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Lists active terminal tabs.
+ * Lists terminal resources owned by the current MCP session.
  */
 public final class ListTerminalsTool extends TerminalTool {
 
@@ -26,7 +26,8 @@ public final class ListTerminalsTool extends TerminalTool {
 
     @Override
     public @NotNull String description() {
-        return "List active terminal tabs with their names. Use tab names with read_terminal_output or write_terminal_input.";
+        return "List terminal resources owned by this MCP session, including stable terminal_id values. "
+            + "Other agents' terminals and user-created tabs are intentionally hidden.";
     }
 
     @Override
@@ -42,11 +43,11 @@ public final class ListTerminalsTool extends TerminalTool {
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         StringBuilder result = new StringBuilder();
-
-        appendOpenTerminalTabs(result);
+        appendOwnedTerminalTabs(result);
         appendDefaultShell(result);
-
-        result.append("\n\nTip: Reuse AgentBridge tabs with run_in_terminal, interact with read_terminal_output/write_terminal_input, and close unused tabs with close_terminal.");
+        result.append(
+            "\n\nTip: Reuse terminals with run_in_terminal. Use terminal_id with "
+                + "read_terminal_output, write_terminal_input, and close_terminal.");
         return result.toString();
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/ReadTerminalOutputTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/ReadTerminalOutputTool.java
@@ -1,17 +1,17 @@
 package com.github.catatafishen.agentbridge.psi.tools.terminal;
 
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.github.catatafishen.agentbridge.services.AgentTabTracker;
 import com.github.catatafishen.agentbridge.ui.renderers.TerminalOutputRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
-import com.intellij.ui.content.Content;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Reads output from an integrated terminal tab.
+ * Reads output from a terminal owned by the current MCP session.
  */
 public final class ReadTerminalOutputTool extends TerminalTool {
 
@@ -33,8 +33,9 @@ public final class ReadTerminalOutputTool extends TerminalTool {
 
     @Override
     public @NotNull String description() {
-        return "Read recent output from an integrated terminal tab. Returns the last N lines from the terminal buffer. " +
-            "Use list_terminals to see available tab names.";
+        return "Read recent output from a terminal owned by this MCP session. "
+            + "Use terminal_id from run_in_terminal or list_terminals; tab_name remains "
+            + "available as an owner-scoped compatibility selector.";
     }
 
     @Override
@@ -50,28 +51,36 @@ public final class ReadTerminalOutputTool extends TerminalTool {
     @Override
     public @NotNull JsonObject inputSchema() {
         return schema(
-            Param.optional("tab_name", TYPE_STRING, "Name of the terminal tab to read from. If omitted, reads from the currently selected terminal tab."),
-            Param.optional(PARAM_MAX_LINES, TYPE_INTEGER, "Maximum number of lines to return from the end of the terminal buffer (default: 50). Use 0 for the full buffer.")
+            Param.optional(JSON_TERMINAL_ID, TYPE_STRING,
+                "Stable ID returned by run_in_terminal (preferred)"),
+            Param.optional(JSON_TAB_NAME, TYPE_STRING,
+                "Owner-scoped terminal tab name. If both selectors are omitted, reads this session's most recent terminal"),
+            Param.optional(PARAM_MAX_LINES, TYPE_INTEGER,
+                "Maximum lines from the end of the buffer (default: 50). Use 0 for the full buffer")
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
-        String tabName = args.has(JSON_TAB_NAME) ? args.get(JSON_TAB_NAME).getAsString() : null;
-        int maxLines = args.has(PARAM_MAX_LINES) ? args.get(PARAM_MAX_LINES).getAsInt() : DEFAULT_MAX_LINES;
+        String terminalId = optionalSelector(args, JSON_TERMINAL_ID);
+        String tabName = optionalSelector(args, JSON_TAB_NAME);
+        String ownerId = currentOwnerId();
+        int maxLines =
+            args.has(PARAM_MAX_LINES) ? args.get(PARAM_MAX_LINES).getAsInt() : DEFAULT_MAX_LINES;
 
         CompletableFuture<String> resultFuture = new CompletableFuture<>();
-
         EdtUtil.invokeLater(() -> {
             try {
-                Content targetContent = resolveTerminalContent(tabName);
-                if (targetContent == null) {
-                    resultFuture.complete(tabName != null
-                        ? "No terminal tab found matching '" + tabName + "'. Use list_terminals to see available tabs."
-                        : "No terminal tab is open. Use run_in_terminal to start one.");
+                AgentTabTracker.AgentTerminal terminal =
+                    resolveOwnedTerminal(ownerId, terminalId, tabName);
+                if (terminal == null) {
+                    resultFuture.complete(
+                        "No terminal owned by this MCP session matches "
+                            + selectorDescription(terminalId, tabName)
+                            + ". Use run_in_terminal or list_terminals.");
                     return;
                 }
-                readTerminalText(resultFuture, targetContent, maxLines);
+                readTerminalText(resultFuture, terminal, maxLines);
             } catch (Exception e) {
                 LOG.warn("Failed to read terminal", e);
                 resultFuture.complete("Failed to read terminal: " + e.getMessage());

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/RunInTerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/RunInTerminalTool.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Runs a command in IntelliJ's integrated terminal.
+ * Runs a command in an integrated terminal owned by the current MCP session.
  */
 public final class RunInTerminalTool extends TerminalTool {
 
@@ -35,10 +35,10 @@ public final class RunInTerminalTool extends TerminalTool {
     @Override
     public @NotNull String description() {
         return """
-            Run a command in IntelliJ's integrated terminal. Returns terminal output. \
-            Use for interactive commands that need stdin (prompts, REPL). \
-            Reuses the most recent agent-created terminal by default. Set new_tab only for a truly parallel interactive process. \
-            Close an agent terminal with close_terminal when it is no longer needed. \
+            Run a command in an IntelliJ integrated terminal owned by this MCP session. \
+            Returns a stable terminal_id; pass it on later run, read, write, and close calls for deterministic reuse. \
+            With no terminal_id, reuses this session's most recent terminal. Set new_tab only for a truly parallel interactive process. \
+            Close the terminal with close_terminal when it is no longer needed. \
             For non-interactive commands with captured output, prefer run_command.
 
             When the terminal is waiting for input:
@@ -69,44 +69,61 @@ public final class RunInTerminalTool extends TerminalTool {
     public @NotNull JsonObject inputSchema() {
         return schema(
             Param.required(JSON_COMMAND, TYPE_STRING, "The command to run in the terminal"),
-            Param.optional(JSON_TAB_NAME, TYPE_STRING, "Name for the terminal tab. If omitted, reuses the most recent agent-created tab or creates a new one"),
-            Param.optional(JSON_NEW_TAB, TYPE_BOOLEAN, "If true, create a separate terminal tab. Use only for a parallel interactive process; AgentBridge allows at most 3 agent-created terminals"),
-            Param.optional(JSON_SHELL, TYPE_STRING, "Shell to use (e.g., 'bash', 'zsh'). If omitted, uses the default shell")
+            Param.optional(JSON_TERMINAL_ID, TYPE_STRING,
+                "Stable ID returned by an earlier run_in_terminal call (preferred for deterministic reuse)"),
+            Param.optional(JSON_TAB_NAME, TYPE_STRING,
+                "Name for this session's terminal tab. If no terminal_id is supplied, reuses a matching tab or creates one"),
+            Param.optional(JSON_NEW_TAB, TYPE_BOOLEAN,
+                "If true, create a separate terminal. Cannot be combined with terminal_id; the limit is 3 per MCP session"),
+            Param.optional(JSON_SHELL, TYPE_STRING,
+                "Shell to use (e.g., 'bash', 'zsh'). If omitted, uses the default shell")
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         String command = args.get(JSON_COMMAND).getAsString();
-        String tabName = args.has(JSON_TAB_NAME) ? args.get(JSON_TAB_NAME).getAsString() : null;
+        String terminalId = optionalSelector(args, JSON_TERMINAL_ID);
+        String tabName = optionalSelector(args, JSON_TAB_NAME);
         boolean newTab = args.has(JSON_NEW_TAB) && args.get(JSON_NEW_TAB).getAsBoolean();
-        String shell = args.has(JSON_SHELL) ? args.get(JSON_SHELL).getAsString() : null;
+        if (newTab && terminalId != null) {
+            return "Error: terminal_id cannot be combined with new_tab=true.";
+        }
+        String shell = optionalSelector(args, JSON_SHELL);
+        String ownerId = currentOwnerId();
 
-        // Flush all editor buffers to disk so terminal commands see current content
+        // Flush editor buffers so the command sees the latest content.
         EdtUtil.invokeAndWait(() ->
             com.intellij.openapi.fileEditor.FileDocumentManager.getInstance().saveAllDocuments());
 
         CompletableFuture<String> resultFuture = new CompletableFuture<>();
-
         EdtUtil.invokeLater(() -> {
             try {
                 var managerClass = Class.forName(TERMINAL_MANAGER_CLASS);
-                var manager = managerClass.getMethod(GET_INSTANCE_METHOD, Project.class).invoke(null, project);
+                var manager = managerClass.getMethod(GET_INSTANCE_METHOD, Project.class)
+                    .invoke(null, project);
 
-                var result = getOrCreateTerminalWidget(managerClass, manager, tabName, newTab, shell, command);
+                var result = getOrCreateTerminalWidget(
+                    ownerId, managerClass, manager, terminalId, tabName, newTab, shell, command);
                 sendTerminalCommand(result.widget(), command);
 
-                String terminalState = result.reused() ? "reused" : "new";
-                resultFuture.complete("Command sent to " + terminalState + " terminal '" + result.tabName() + "': " + command +
-                    "\n\nNote: Reuse is the default. Use read_terminal_output for content, close_terminal when done, or run_command for captured output.");
-
+                resultFuture.complete(
+                    "Command sent to " + (result.reused() ? "reused" : "new")
+                        + " terminal '" + result.tabName() + "'.\n"
+                        + "terminal_id: " + result.terminalId() + "\n"
+                        + "command: " + command
+                        + "\n\nReuse this terminal_id with run_in_terminal, read_terminal_output, "
+                        + "write_terminal_input, and close_terminal.");
             } catch (ClassNotFoundException e) {
-                resultFuture.complete("Error: Terminal plugin not available. Use run_command tool instead.");
+                resultFuture.complete(
+                    "Error: Terminal plugin not available. Use run_command tool instead.");
             } catch (IllegalStateException e) {
                 resultFuture.complete(formatCapacityError(e));
             } catch (Exception e) {
                 LOG.warn("Failed to open terminal", e);
-                resultFuture.complete("Error: Failed to open terminal: " + e.getMessage() + ". Use run_command tool instead.");
+                resultFuture.complete(
+                    "Error: Failed to open terminal: " + e.getMessage()
+                        + ". Use run_command tool instead.");
             }
         });
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalTool.java
@@ -121,7 +121,7 @@ public abstract class TerminalTool extends Tool {
             throw new IllegalStateException(
                 "Agent terminal limit reached ("
                     + AgentTabTracker.MAX_OPEN_AGENT_TERMINALS + " per MCP session, "
-                    + AgentTabTracker.MAX_OPEN_AGENT_TERMINALS_GLOBAL + " per project). "
+                    + tracker.getGlobalCap() + " per project). "
                     + "Reuse an existing terminal or close one with close_terminal.");
         }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalTool.java
@@ -1,36 +1,41 @@
 package com.github.catatafishen.agentbridge.psi.tools.terminal;
 
-import com.github.catatafishen.agentbridge.psi.EdtUtil;
 import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
 import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.psi.tools.Tool;
 import com.github.catatafishen.agentbridge.services.AgentTabTracker;
+import com.github.catatafishen.agentbridge.services.McpCallContext;
 import com.github.catatafishen.agentbridge.services.ToolRegistry;
+import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.content.Content;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Abstract base for terminal tools. Provides shared constants and utility
- * methods for terminal operations (formerly in {@code TerminalTools}).
+ * Abstract base for terminal tools. Integrated terminal resources are resolved by stable
+ * {@code terminal_id} inside the current MCP owner, never by the globally selected IDE tab.
  */
 // S112: These methods wrap reflection-based IntelliJ terminal API calls — generic exceptions are intentional
 @SuppressWarnings("java:S112")
 public abstract class TerminalTool extends Tool {
 
     protected static final Logger LOG = Logger.getInstance(TerminalTool.class);
+    protected static final String JSON_TERMINAL_ID = "terminal_id";
     protected static final String JSON_TAB_NAME = "tab_name";
     protected static final String TERMINAL_TOOL_WINDOW_ID = "Terminal";
     protected static final String GET_INSTANCE_METHOD = "getInstance";
-    protected static final String TERMINAL_MANAGER_CLASS = "org.jetbrains.plugins.terminal.TerminalToolWindowManager";
-    protected static final String TERMINAL_WIDGET_CLASS = "com.intellij.terminal.ui.TerminalWidget";
-    protected static final String FIND_WIDGET_BY_CONTENT_METHOD = "findWidgetByContent";
+    protected static final String TERMINAL_MANAGER_CLASS =
+        "org.jetbrains.plugins.terminal.TerminalToolWindowManager";
+    protected static final String TERMINAL_WIDGET_CLASS =
+        "com.intellij.terminal.ui.TerminalWidget";
     protected static final String TTY_CONNECTOR_CLASS = "com.jediterm.terminal.TtyConnector";
+    protected static final String FIND_WIDGET_BY_CONTENT_METHOD = "findWidgetByContent";
     protected static final int DEFAULT_MAX_LINES = 50;
 
     protected TerminalTool(Project project) {
@@ -42,30 +47,10 @@ public abstract class TerminalTool extends Tool {
         return ToolRegistry.Category.TERMINAL;
     }
 
-    protected Object findTerminalWidget(Class<?> managerClass, String tabName) {
-        if (tabName != null) {
-            return findTerminalWidgetByTabName(managerClass, tabName);
-        }
-        Object[] result = {null};
-        EdtUtil.invokeAndWait(() -> {
-            try {
-                var toolWindow = ToolWindowManager.getInstance(project)
-                    .getToolWindow(TERMINAL_TOOL_WINDOW_ID);
-                if (toolWindow == null) return;
-                var selected = toolWindow.getContentManager().getSelectedContent();
-                if (selected == null) return;
-                var findWidget = managerClass.getMethod(FIND_WIDGET_BY_CONTENT_METHOD, Content.class);
-                result[0] = findWidget.invoke(null, selected);
-            } catch (Exception e) {
-                LOG.warn("findTerminalWidget failed", e);
-            }
-        });
-        return result[0];
-    }
-
     /**
      * Resolve human-readable escape sequences to actual characters.
-     * Supports: {enter}, {tab}, {ctrl-c}, {ctrl-d}, {ctrl-z}, {escape}, {up}, {down}, {left}, {right}, \n, \t
+     * Supports: {enter}, {tab}, {ctrl-c}, {ctrl-d}, {ctrl-z}, {escape}, {up}, {down},
+     * {left}, {right}, \n, \t
      */
     protected static String resolveInputEscapes(String input) {
         return input
@@ -91,121 +76,170 @@ public abstract class TerminalTool extends Tool {
         return "'" + raw + "'";
     }
 
-    protected record TerminalWidgetResult(Object widget, String tabName, boolean reused) {
+    protected record TerminalWidgetResult(
+        Object widget,
+        String terminalId,
+        String tabName,
+        boolean reused
+    ) {
     }
 
-    protected TerminalWidgetResult getOrCreateTerminalWidget(Class<?> managerClass, Object manager,
-                                                             String tabName, boolean newTab,
-                                                             String shell, String command) throws Exception {
+    protected TerminalWidgetResult getOrCreateTerminalWidget(
+        @NotNull String ownerId,
+        Class<?> managerClass,
+        Object manager,
+        String terminalId,
+        String tabName,
+        boolean newTab,
+        String shell,
+        String command
+    ) throws Exception {
         AgentTabTracker tracker = AgentTabTracker.getInstance(project);
         if (!newTab) {
-            String reusableName = tabName != null ? tabName : tracker.findMostRecentOpenTerminalTabName();
-            if (reusableName != null) {
-                Object widget = findTerminalWidgetByTabName(managerClass, reusableName);
-                if (widget != null) {
-                    return new TerminalWidgetResult(widget, reusableName, true);
+            AgentTabTracker.AgentTerminal reusable =
+                tracker.findOwnedTerminal(ownerId, terminalId, tabName);
+            if (reusable != null) {
+                Object widget = findTerminalWidgetByContent(managerClass, reusable.content());
+                if (widget == null) {
+                    throw new IllegalStateException(
+                        "Owned terminal '" + reusable.terminalId()
+                            + "' has no terminal widget. Close it and create a new terminal.");
                 }
+                LOG.info("Reusing owned terminal " + reusable.terminalId()
+                    + " ('" + reusable.displayName() + "')");
+                return new TerminalWidgetResult(
+                    widget, reusable.terminalId(), reusable.displayName(), true);
+            }
+            if (terminalId != null) {
+                throw new IllegalStateException(
+                    "No terminal owned by this MCP session matches terminal_id '"
+                        + terminalId + "'. Use list_terminals to see this session's terminals.");
             }
         }
 
-        if (!tracker.hasOpenTerminalCapacity()) {
+        if (!tracker.hasOpenTerminalCapacity(ownerId)) {
             throw new IllegalStateException(
-                "Agent terminal limit reached (" + AgentTabTracker.MAX_OPEN_AGENT_TERMINALS
-                    + "). Reuse an existing tab or close one with close_terminal.");
+                "Agent terminal limit reached ("
+                    + AgentTabTracker.MAX_OPEN_AGENT_TERMINALS + " per MCP session, "
+                    + AgentTabTracker.MAX_OPEN_AGENT_TERMINALS_GLOBAL + " per project). "
+                    + "Reuse an existing terminal or close one with close_terminal.");
         }
 
         String title = tabName != null ? tabName : "Agent: " + truncateForTitle(command);
         List<String> shellCommand = shell != null ? List.of(shell) : null;
-        var createSession = managerClass.getMethod("createNewSession",
-            String.class, String.class, List.class, boolean.class, boolean.class);
-        // 4th param is `requestFocus`; flipping to false when the chat is active prevents
-        // the new terminal tab from yanking the keyboard caret out of the chat prompt.
+        var createSession = managerClass.getMethod(
+            "createNewSession",
+            String.class,
+            String.class,
+            List.class,
+            boolean.class,
+            boolean.class
+        );
+        // Avoid stealing the chat caret when the AgentBridge chat tool window is active.
         boolean requestFocus = !PsiBridgeService.isChatToolWindowActive(project);
-        Object widget = createSession.invoke(manager, project.getBasePath(), title, shellCommand, requestFocus, true);
-        tracker.trackTab(TERMINAL_TOOL_WINDOW_ID, title);
-        return new TerminalWidgetResult(widget, title, false);
+        Object widget = createSession.invoke(
+            manager, project.getBasePath(), title, shellCommand, requestFocus, true);
+
+        Content content = findTerminalContentForWidget(managerClass, widget);
+        if (content == null) {
+            throw new IllegalStateException(
+                "Terminal session was created, but its IDE content could not be resolved");
+        }
+
+        String createdTerminalId = tracker.trackTerminal(ownerId, content);
+        String displayName = content.getDisplayName() != null ? content.getDisplayName() : title;
+        return new TerminalWidgetResult(widget, createdTerminalId, displayName, false);
     }
 
     /**
-     * Send a command to a TerminalWidget, using the interface method to avoid IllegalAccessException.
+     * Send a command to a TerminalWidget, using the interface method to avoid
+     * {@link IllegalAccessException}.
      */
     protected void sendTerminalCommand(Object widget, String command) throws Exception {
         var widgetInterface = Class.forName(TERMINAL_WIDGET_CLASS);
         try {
-            widgetInterface.getMethod("sendCommandToExecute", String.class).invoke(widget, command);
+            widgetInterface.getMethod("sendCommandToExecute", String.class)
+                .invoke(widget, command);
         } catch (NoSuchMethodException e) {
-            widget.getClass().getMethod("executeCommand", String.class).invoke(widget, command);
+            widget.getClass().getMethod("executeCommand", String.class)
+                .invoke(widget, command);
         }
     }
 
-    protected Object findTerminalWidgetByTabName(Class<?> managerClass, String tabName) {
-        Object[] result = {null};
+    protected @Nullable Object findTerminalWidgetByContent(
+        @NotNull Class<?> managerClass,
+        @NotNull Content content
+    ) {
         try {
-            EdtUtil.invokeAndWait(() -> {
-                try {
-                    var toolWindow = ToolWindowManager.getInstance(project).getToolWindow(TERMINAL_TOOL_WINDOW_ID);
-                    if (toolWindow == null) return;
-
-                    var findWidgetByContent = managerClass.getMethod(FIND_WIDGET_BY_CONTENT_METHOD, Content.class);
-
-                    for (var content : toolWindow.getContentManager().getContents()) {
-                        String displayName = content.getDisplayName();
-                        if (AgentTabTracker.terminalTabNameMatches(tabName, displayName)) {
-                            Object widget = findWidgetByContent.invoke(null, content);
-                            if (widget != null) {
-                                LOG.info("Reusing terminal tab '" + displayName + "'");
-                                result[0] = widget;
-                                return;
-                            }
-                        }
-                    }
-                } catch (Exception e) {
-                    LOG.warn("Could not find terminal tab: " + tabName, e);
-                }
-            });
+            var findWidget = managerClass.getMethod(FIND_WIDGET_BY_CONTENT_METHOD, Content.class);
+            return findWidget.invoke(null, content);
         } catch (Exception e) {
-            LOG.warn("findTerminalWidgetByTabName EDT dispatch failed: " + tabName, e);
+            LOG.warn("Could not resolve terminal widget for " + content.getDisplayName(), e);
+            return null;
         }
-        return result[0];
     }
 
-    protected Content resolveTerminalContent(String tabName) {
-        Content[] result = {null};
-        try {
-            EdtUtil.invokeAndWait(() -> {
-                var toolWindow = ToolWindowManager.getInstance(project)
-                    .getToolWindow(TERMINAL_TOOL_WINDOW_ID);
-                if (toolWindow == null) return;
+    protected @Nullable Content findTerminalContentForWidget(
+        @NotNull Class<?> managerClass,
+        @NotNull Object widget
+    ) {
+        var toolWindow = ToolWindowManager.getInstance(project)
+            .getToolWindow(TERMINAL_TOOL_WINDOW_ID);
+        if (toolWindow == null) return null;
 
-                var contentManager = toolWindow.getContentManager();
-                if (tabName == null) {
-                    result[0] = contentManager.getSelectedContent();
-                    return;
-                }
-
-                for (var content : contentManager.getContents()) {
-                    String name = content.getDisplayName();
-                    if (AgentTabTracker.terminalTabNameMatches(tabName, name)) {
-                        result[0] = content;
-                        return;
-                    }
-                }
-            });
-        } catch (Exception e) {
-            LOG.warn("resolveTerminalContent failed", e);
+        for (Content content : toolWindow.getContentManager().getContents()) {
+            Object candidate = findTerminalWidgetByContent(managerClass, content);
+            if (candidate == widget) {
+                return content;
+            }
         }
-        return result[0];
+        return null;
     }
 
-    protected void readTerminalText(CompletableFuture<String> resultFuture,
-                                    Content targetContent,
-                                    int maxLines) throws Exception {
+    protected @Nullable AgentTabTracker.AgentTerminal resolveOwnedTerminal(
+        @NotNull String ownerId,
+        @Nullable String terminalId,
+        @Nullable String tabName
+    ) {
+        return AgentTabTracker.getInstance(project)
+            .findOwnedTerminal(ownerId, terminalId, tabName);
+    }
+
+    protected static @Nullable String optionalSelector(
+        @NotNull JsonObject args,
+        @NotNull String key
+    ) {
+        if (!args.has(key) || args.get(key).isJsonNull()) return null;
+        String value = args.get(key).getAsString();
+        return value.isBlank() ? null : value;
+    }
+
+    protected static @NotNull String selectorDescription(
+        @Nullable String terminalId,
+        @Nullable String tabName
+    ) {
+        if (terminalId != null) return "terminal_id '" + terminalId + "'";
+        if (tabName != null) return "tab_name '" + tabName + "'";
+        return "the caller's most recent terminal";
+    }
+
+    protected static @NotNull String currentOwnerId() {
+        return McpCallContext.currentOrFallback();
+    }
+
+    protected void readTerminalText(
+        CompletableFuture<String> resultFuture,
+        AgentTabTracker.AgentTerminal terminal,
+        int maxLines
+    ) throws Exception {
+        Content targetContent = terminal.content();
         var managerClass = Class.forName(TERMINAL_MANAGER_CLASS);
-        var findWidgetByContent = managerClass.getMethod(FIND_WIDGET_BY_CONTENT_METHOD, Content.class);
+        var findWidgetByContent =
+            managerClass.getMethod(FIND_WIDGET_BY_CONTENT_METHOD, Content.class);
         Object widget = findWidgetByContent.invoke(null, targetContent);
         if (widget == null) {
-            resultFuture.complete("No terminal widget found for tab '" + targetContent.getDisplayName() +
-                "'. The auto-created default tab may not be readable — use agent-created tabs instead.");
+            resultFuture.complete(
+                "No terminal widget found for terminal_id '" + terminal.terminalId() + "'.");
             return;
         }
 
@@ -215,22 +249,27 @@ public abstract class TerminalTool extends Tool {
             CharSequence text = (CharSequence) getText.invoke(widget);
             String fullOutput = text != null ? text.toString().strip() : "";
             if (fullOutput.isEmpty()) {
-                resultFuture.complete("Terminal '" + targetContent.getDisplayName() + "' has no output.");
+                resultFuture.complete(
+                    "Terminal '" + terminal.displayName() + "' [terminal_id="
+                        + terminal.terminalId() + "] has no output.");
                 return;
             }
 
             String output = tailLines(fullOutput, maxLines);
-            String tabDisplayName = targetContent.getDisplayName();
-            resultFuture.complete("Terminal '" + tabDisplayName + "' output:\n" + output);
+            resultFuture.complete(
+                "Terminal '" + terminal.displayName() + "' [terminal_id="
+                    + terminal.terminalId() + "] output:\n" + output);
         } catch (NoSuchMethodException e) {
-            resultFuture.complete("getText() not available on this terminal type (" +
-                widget.getClass().getSimpleName() + "). Terminal output reading not supported.");
+            resultFuture.complete(
+                "getText() not available on this terminal type ("
+                    + widget.getClass().getSimpleName()
+                    + "). Terminal output reading not supported.");
         }
     }
 
     /**
-     * Return the last {@code maxLines} lines of the text. If maxLines &le; 0, return the full text
-     * (subject to character truncation via {@link ToolUtils#truncateOutput}).
+     * Return the last {@code maxLines} lines of the text. If maxLines &le; 0, return the
+     * full text (subject to character truncation via {@link ToolUtils#truncateOutput}).
      */
     protected static String tailLines(String text, int maxLines) {
         if (maxLines <= 0) {
@@ -249,40 +288,30 @@ public abstract class TerminalTool extends Tool {
         return sb.toString();
     }
 
-    protected void appendOpenTerminalTabs(StringBuilder result) {
-        result.append("Open terminal tabs:\n");
-        try {
-            EdtUtil.invokeAndWait(() -> {
-                try {
-                    var toolWindowManager = ToolWindowManager.getInstance(project);
-                    var toolWindow = toolWindowManager.getToolWindow(TERMINAL_TOOL_WINDOW_ID);
-                    if (toolWindow != null) {
-                        var contentManager = toolWindow.getContentManager();
-                        var contents = contentManager.getContents();
-                        if (contents.length == 0) {
-                            result.append("  (none)\n");
-                        } else {
-                            for (var content : contents) {
-                                String name = content.getDisplayName();
-                                boolean selected = content == contentManager.getSelectedContent();
-                                result.append(selected ? "  ▸ " : "  • ").append(name).append("\n");
-                            }
-                        }
-                    } else {
-                        result.append("  (Terminal tool window not available)\n");
-                    }
-                } catch (Exception e) {
-                    result.append("  (Could not list open terminals)\n");
-                }
-            });
-        } catch (Exception e) {
-            result.append("  (Could not list open terminals)\n");
+    protected void appendOwnedTerminalTabs(StringBuilder result) {
+        List<AgentTabTracker.AgentTerminal> terminals =
+            AgentTabTracker.getInstance(project).listOpenTerminals(currentOwnerId());
+        result.append("AgentBridge terminals owned by this MCP session:\n");
+        if (terminals.isEmpty()) {
+            result.append("  (none)\n");
+            return;
+        }
+
+        for (int i = 0; i < terminals.size(); i++) {
+            AgentTabTracker.AgentTerminal terminal = terminals.get(i);
+            boolean mostRecent = i == terminals.size() - 1;
+            result.append(mostRecent ? "  ▸ " : "  • ")
+                .append(terminal.displayName())
+                .append(" [terminal_id=")
+                .append(terminal.terminalId())
+                .append("]\n");
         }
     }
 
     protected void appendDefaultShell(StringBuilder result) {
         try {
-            var settingsClass = Class.forName("org.jetbrains.plugins.terminal.TerminalProjectOptionsProvider");
+            var settingsClass =
+                Class.forName("org.jetbrains.plugins.terminal.TerminalProjectOptionsProvider");
             var getInstance = settingsClass.getMethod(GET_INSTANCE_METHOD, Project.class);
             var settings = getInstance.invoke(null, project);
             var getShellPath = settings.getClass().getMethod("getShellPath");

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/WriteTerminalInputTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/WriteTerminalInputTool.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.psi.tools.terminal;
 
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.github.catatafishen.agentbridge.services.AgentTabTracker;
 import com.github.catatafishen.agentbridge.ui.renderers.TerminalOutputRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
@@ -9,6 +10,9 @@ import org.jetbrains.annotations.NotNull;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Writes input to a terminal owned by the current MCP session.
+ */
 public final class WriteTerminalInputTool extends TerminalTool {
 
     private static final String PARAM_INPUT = "input";
@@ -29,7 +33,8 @@ public final class WriteTerminalInputTool extends TerminalTool {
 
     @Override
     public @NotNull String description() {
-        return "Send raw text or keystrokes to a running terminal (e.g. answer prompts, send Ctrl-C)";
+        return "Send raw text or keystrokes to a terminal owned by this MCP session. "
+            + "Use terminal_id from run_in_terminal or list_terminals.";
     }
 
     @Override
@@ -45,28 +50,42 @@ public final class WriteTerminalInputTool extends TerminalTool {
     @Override
     public @NotNull JsonObject inputSchema() {
         return schema(
-            Param.required(PARAM_INPUT, TYPE_STRING, "Text or keystrokes to send. Supports escape sequences: {enter}, {tab}, {ctrl-c}, {ctrl-d}, {ctrl-z}, {escape}, {up}, {down}, {left}, {right}, {backspace}, \\n, \\t"),
-            Param.optional("tab_name", TYPE_STRING, "Name of the terminal tab to write to. If omitted, writes to the currently selected tab")
+            Param.required(PARAM_INPUT, TYPE_STRING,
+                "Text or keystrokes to send. Supports: {enter}, {tab}, {ctrl-c}, {ctrl-d}, {ctrl-z}, {escape}, {up}, {down}, {left}, {right}, {backspace}, \\n, \\t"),
+            Param.optional(JSON_TERMINAL_ID, TYPE_STRING,
+                "Stable ID returned by run_in_terminal (preferred)"),
+            Param.optional(JSON_TAB_NAME, TYPE_STRING,
+                "Owner-scoped tab name. If both selectors are omitted, writes to this session's most recent terminal")
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         String input = args.get(PARAM_INPUT).getAsString();
-        String tabName = args.has(JSON_TAB_NAME) ? args.get(JSON_TAB_NAME).getAsString() : null;
-
+        String terminalId = optionalSelector(args, JSON_TERMINAL_ID);
+        String tabName = optionalSelector(args, JSON_TAB_NAME);
+        String ownerId = currentOwnerId();
         String resolved = resolveInputEscapes(input);
 
         CompletableFuture<String> resultFuture = new CompletableFuture<>();
-
         EdtUtil.invokeLater(() -> {
             try {
+                AgentTabTracker.AgentTerminal terminal =
+                    resolveOwnedTerminal(ownerId, terminalId, tabName);
+                if (terminal == null) {
+                    resultFuture.complete(
+                        "No terminal owned by this MCP session matches "
+                            + selectorDescription(terminalId, tabName)
+                            + ". Use run_in_terminal to create one first.");
+                    return;
+                }
+
                 var managerClass = Class.forName(TERMINAL_MANAGER_CLASS);
-                Object widget = findTerminalWidget(managerClass, tabName);
+                Object widget = findTerminalWidgetByContent(managerClass, terminal.content());
                 if (widget == null) {
-                    resultFuture.complete("No terminal found" +
-                        (tabName != null ? " matching '" + tabName + "'" : "") +
-                        ". Use run_in_terminal to create one first.");
+                    resultFuture.complete(
+                        "No terminal widget found for terminal_id '"
+                            + terminal.terminalId() + "'.");
                     return;
                 }
 
@@ -77,17 +96,20 @@ public final class WriteTerminalInputTool extends TerminalTool {
                 var tty = getTty.invoke(accessor);
 
                 if (tty == null) {
-                    resultFuture.complete("Terminal has no active process. The command may have finished.");
+                    resultFuture.complete(
+                        "Terminal [terminal_id=" + terminal.terminalId()
+                            + "] has no active process. The command may have finished.");
                     return;
                 }
 
                 var ttyInterface = Class.forName(TTY_CONNECTOR_CLASS);
                 ttyInterface.getMethod("write", String.class).invoke(tty, resolved);
 
-                String description = describeInput(input, resolved);
-                resultFuture.complete("Sent " + description + " to terminal." +
-                    "\n\nTip: Use read_terminal_output to see the result.");
-
+                resultFuture.complete(
+                    "Sent " + describeInput(input, resolved)
+                        + " to terminal '" + terminal.displayName() + "'.\n"
+                        + "terminal_id: " + terminal.terminalId()
+                        + "\n\nUse read_terminal_output with this terminal_id to see the result.");
             } catch (Exception e) {
                 LOG.warn("Failed to write terminal input", e);
                 resultFuture.complete("Failed to write to terminal: " + e.getMessage());

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentTabTracker.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentTabTracker.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.services;
 
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.github.catatafishen.agentbridge.settings.McpServerSettings;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.ui.RunContentDescriptor;
 import com.intellij.execution.ui.RunContentManager;
@@ -199,8 +200,32 @@ public final class AgentTabTracker implements Disposable {
                 if (ref.ownerId().equals(ownerId)) ownerCount++;
             }
             return ownerCount < MAX_OPEN_AGENT_TERMINALS
-                && trackedTerminals.size() < MAX_OPEN_AGENT_TERMINALS_GLOBAL;
+                && trackedTerminals.size() < resolveGlobalCap();
         }
+    }
+
+    /**
+     * @return the currently effective project-wide terminal cap, sourced from settings when
+     * available and falling back to {@link #MAX_OPEN_AGENT_TERMINALS_GLOBAL}. Exposed so
+     * user-facing error messages can report the actual limit the user has configured.
+     */
+    public int getGlobalCap() {
+        return resolveGlobalCap();
+    }
+
+    /**
+     * Reads the current project-wide terminal cap. Falls back to the shipped default when the
+     * settings service is unavailable (e.g. tests using a mock Project) so unit tests that
+     * exercise this method continue to work without wiring a real service.
+     */
+    private int resolveGlobalCap() {
+        try {
+            McpServerSettings settings = McpServerSettings.getInstance(project);
+            if (settings != null) return settings.getMaxAgentTerminalsGlobal();
+        } catch (RuntimeException ignored) {
+            // fall through to default
+        }
+        return MAX_OPEN_AGENT_TERMINALS_GLOBAL;
     }
 
     public synchronized void untrackTerminal(

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentTabTracker.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentTabTracker.java
@@ -47,7 +47,18 @@ public final class AgentTabTracker implements Disposable {
     private record TabRef(String toolWindowId, String tabName) {
     }
 
-    private record TerminalRef(String ownerId, String terminalId, Content content) {
+    private record TerminalRef(
+        String ownerId,
+        String terminalId,
+        Content content,
+        long trackedSequence
+    ) {
+    }
+
+    private record OpenTerminalSnapshot(
+        List<Content> contents,
+        long pruneThroughSequence
+    ) {
     }
 
     /**
@@ -65,6 +76,7 @@ public final class AgentTabTracker implements Disposable {
     private final Supplier<List<Content>> openTerminalContents;
     private final List<TabRef> trackedTabs = new ArrayList<>();
     private final List<TerminalRef> trackedTerminals = new ArrayList<>();
+    private long terminalSequence;
 
     public AgentTabTracker(@NotNull Project project) {
         this(project, () -> readOpenTerminalContents(project));
@@ -106,7 +118,8 @@ public final class AgentTabTracker implements Disposable {
                 "Terminal content is already owned by another MCP session");
         }
         String terminalId = UUID.randomUUID().toString();
-        trackedTerminals.add(new TerminalRef(ownerId, terminalId, content));
+        trackedTerminals.add(new TerminalRef(
+            ownerId, terminalId, content, ++terminalSequence));
         return terminalId;
     }
 
@@ -120,9 +133,9 @@ public final class AgentTabTracker implements Disposable {
         @Nullable String terminalId,
         @Nullable String tabName
     ) {
-        List<Content> open = openTerminalContents.get();
+        OpenTerminalSnapshot snapshot = snapshotOpenTerminals();
         synchronized (this) {
-            pruneClosedTerminals(open);
+            pruneClosedTerminals(snapshot);
             if (terminalId != null) {
                 for (TerminalRef ref : trackedTerminals) {
                     if (ref.ownerId().equals(ownerId) && ref.terminalId().equals(terminalId)) {
@@ -149,9 +162,9 @@ public final class AgentTabTracker implements Disposable {
     }
 
     public @NotNull List<AgentTerminal> listOpenTerminals(@NotNull String ownerId) {
-        List<Content> open = openTerminalContents.get();
+        OpenTerminalSnapshot snapshot = snapshotOpenTerminals();
         synchronized (this) {
-            pruneClosedTerminals(open);
+            pruneClosedTerminals(snapshot);
             List<AgentTerminal> result = new ArrayList<>();
             for (TerminalRef ref : trackedTerminals) {
                 if (ref.ownerId().equals(ownerId)) {
@@ -167,9 +180,9 @@ public final class AgentTabTracker implements Disposable {
     }
 
     public int countOpenTerminalTabs() {
-        List<Content> open = openTerminalContents.get();
+        OpenTerminalSnapshot snapshot = snapshotOpenTerminals();
         synchronized (this) {
-            pruneClosedTerminals(open);
+            pruneClosedTerminals(snapshot);
             return trackedTerminals.size();
         }
     }
@@ -178,9 +191,9 @@ public final class AgentTabTracker implements Disposable {
      * Enforces both the per-owner reuse policy and a project-wide resource safety cap.
      */
     public boolean hasOpenTerminalCapacity(@NotNull String ownerId) {
-        List<Content> open = openTerminalContents.get();
+        OpenTerminalSnapshot snapshot = snapshotOpenTerminals();
         synchronized (this) {
-            pruneClosedTerminals(open);
+            pruneClosedTerminals(snapshot);
             int ownerCount = 0;
             for (TerminalRef ref : trackedTerminals) {
                 if (ref.ownerId().equals(ownerId)) ownerCount++;
@@ -248,8 +261,22 @@ public final class AgentTabTracker implements Disposable {
         return new AgentTerminal(ref.terminalId(), ref.content());
     }
 
-    private synchronized void pruneClosedTerminals(@NotNull List<Content> open) {
-        trackedTerminals.removeIf(ref -> !containsIdentity(open, ref.content()));
+    /**
+     * Captures the tracker generation before the potentially blocking EDT snapshot. Terminals
+     * registered while that snapshot is in flight must not be pruned against stale contents.
+     */
+    private @NotNull OpenTerminalSnapshot snapshotOpenTerminals() {
+        long pruneThroughSequence;
+        synchronized (this) {
+            pruneThroughSequence = terminalSequence;
+        }
+        return new OpenTerminalSnapshot(openTerminalContents.get(), pruneThroughSequence);
+    }
+
+    private synchronized void pruneClosedTerminals(@NotNull OpenTerminalSnapshot snapshot) {
+        trackedTerminals.removeIf(ref ->
+            ref.trackedSequence() <= snapshot.pruneThroughSequence()
+                && !containsIdentity(snapshot.contents(), ref.content()));
     }
 
     private static boolean containsIdentity(@NotNull Content[] contents, @NotNull Content target) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentTabTracker.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentTabTracker.java
@@ -17,17 +17,28 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
 
 /**
- * Tracks tool window tabs created by the agent and closes them at turn boundaries.
+ * Tracks IDE tabs created by agents.
  *
- * <p>Tools call {@link #trackTab(String, String)} when they create a tab.
- * At the start of a new turn, {@link #closeTrackedTabs()} closes tracked tabs
- * that are safe to close and keeps skipped tabs tracked for later cleanup.</p>
+ * <p>Ordinary tool-window tabs are cleaned at turn boundaries. Integrated terminal tabs are
+ * different: they are long-lived resources owned by one MCP transport session. They use stable
+ * terminal IDs and are released only by their owner or when that transport session ends. This
+ * prevents one concurrent agent from reusing, writing to, or closing another agent's terminal.</p>
  */
 public final class AgentTabTracker implements Disposable {
 
+    /**
+     * Maximum open terminal resources owned by one MCP session.
+     */
     public static final int MAX_OPEN_AGENT_TERMINALS = 3;
+
+    /**
+     * Project-wide safety cap across all MCP sessions.
+     */
+    public static final int MAX_OPEN_AGENT_TERMINALS_GLOBAL = 12;
 
     private static final Logger LOG = Logger.getInstance(AgentTabTracker.class);
     private static final String TERMINAL_TOOL_WINDOW_ID = "Terminal";
@@ -36,11 +47,32 @@ public final class AgentTabTracker implements Disposable {
     private record TabRef(String toolWindowId, String tabName) {
     }
 
+    private record TerminalRef(String ownerId, String terminalId, Content content) {
+    }
+
+    /**
+     * Public immutable view returned to terminal tools. The {@link Content} reference is the stable
+     * IDE identity; display names are deliberately not used as resource identities.
+     */
+    public record AgentTerminal(@NotNull String terminalId, @NotNull Content content) {
+        public @NotNull String displayName() {
+            String name = content.getDisplayName();
+            return name != null ? name : "(unnamed)";
+        }
+    }
+
     private final Project project;
+    private final Supplier<List<Content>> openTerminalContents;
     private final List<TabRef> trackedTabs = new ArrayList<>();
+    private final List<TerminalRef> trackedTerminals = new ArrayList<>();
 
     public AgentTabTracker(@NotNull Project project) {
+        this(project, () -> readOpenTerminalContents(project));
+    }
+
+    AgentTabTracker(@NotNull Project project, @NotNull Supplier<List<Content>> openTerminalContents) {
         this.project = project;
+        this.openTerminalContents = openTerminalContents;
     }
 
     public static @NotNull AgentTabTracker getInstance(@NotNull Project project) {
@@ -48,101 +80,212 @@ public final class AgentTabTracker implements Disposable {
     }
 
     /**
-     * Registers a tab as agent-created. Call this after the tool creates the tab.
+     * Registers a non-terminal tool-window tab as agent-created.
      */
     public synchronized void trackTab(@NotNull String toolWindowId, @NotNull String tabName) {
+        if (TERMINAL_TOOL_WINDOW_ID.equals(toolWindowId)) {
+            throw new IllegalArgumentException(
+                "Terminal tabs require trackTerminal(ownerId, content) so ownership is preserved");
+        }
         trackedTabs.add(new TabRef(toolWindowId, tabName));
     }
 
-    public int countOpenTerminalTabs() {
-        return countMatchingTerminalTabs(trackedTerminalTabNames(), openTerminalDisplayNames());
-    }
-
-    public boolean hasOpenTerminalCapacity() {
-        return hasTerminalCapacity(countOpenTerminalTabs());
-    }
-
-    public @Nullable String findMostRecentOpenTerminalTabName() {
-        return mostRecentOpenTerminalTabName(trackedTerminalTabNames(), openTerminalDisplayNames());
-    }
-
-    public synchronized boolean isTrackedTerminalTab(@NotNull String displayName) {
-        for (TabRef ref : trackedTabs) {
-            if (TERMINAL_TOOL_WINDOW_ID.equals(ref.toolWindowId())
-                && terminalTabNameMatches(ref.tabName(), displayName)) {
-                return true;
+    /**
+     * Registers an exact terminal content object for one MCP owner and returns its stable handle.
+     */
+    public synchronized @NotNull String trackTerminal(
+        @NotNull String ownerId,
+        @NotNull Content content
+    ) {
+        for (TerminalRef ref : trackedTerminals) {
+            if (ref.content() != content) continue;
+            if (ref.ownerId().equals(ownerId)) {
+                return ref.terminalId();
             }
+            throw new IllegalStateException(
+                "Terminal content is already owned by another MCP session");
+        }
+        String terminalId = UUID.randomUUID().toString();
+        trackedTerminals.add(new TerminalRef(ownerId, terminalId, content));
+        return terminalId;
+    }
+
+    /**
+     * Resolves a terminal only within {@code ownerId}. Stable ID takes precedence; a supplied
+     * display name is additionally checked when both selectors are present. With neither selector,
+     * the most recently created open terminal owned by the caller is returned.
+     */
+    public @Nullable AgentTerminal findOwnedTerminal(
+        @NotNull String ownerId,
+        @Nullable String terminalId,
+        @Nullable String tabName
+    ) {
+        List<Content> open = openTerminalContents.get();
+        synchronized (this) {
+            pruneClosedTerminals(open);
+            if (terminalId != null) {
+                for (TerminalRef ref : trackedTerminals) {
+                    if (ref.ownerId().equals(ownerId) && ref.terminalId().equals(terminalId)) {
+                        if (tabName != null
+                            && !terminalTabNameMatches(tabName, ref.content().getDisplayName())) {
+                            return null;
+                        }
+                        return view(ref);
+                    }
+                }
+                return null;
+            }
+
+            for (int i = trackedTerminals.size() - 1; i >= 0; i--) {
+                TerminalRef ref = trackedTerminals.get(i);
+                if (!ref.ownerId().equals(ownerId)) continue;
+                if (tabName == null
+                    || terminalTabNameMatches(tabName, ref.content().getDisplayName())) {
+                    return view(ref);
+                }
+            }
+            return null;
+        }
+    }
+
+    public @NotNull List<AgentTerminal> listOpenTerminals(@NotNull String ownerId) {
+        List<Content> open = openTerminalContents.get();
+        synchronized (this) {
+            pruneClosedTerminals(open);
+            List<AgentTerminal> result = new ArrayList<>();
+            for (TerminalRef ref : trackedTerminals) {
+                if (ref.ownerId().equals(ownerId)) {
+                    result.add(view(ref));
+                }
+            }
+            return List.copyOf(result);
+        }
+    }
+
+    public int countOpenTerminalTabs(@NotNull String ownerId) {
+        return listOpenTerminals(ownerId).size();
+    }
+
+    public int countOpenTerminalTabs() {
+        List<Content> open = openTerminalContents.get();
+        synchronized (this) {
+            pruneClosedTerminals(open);
+            return trackedTerminals.size();
+        }
+    }
+
+    /**
+     * Enforces both the per-owner reuse policy and a project-wide resource safety cap.
+     */
+    public boolean hasOpenTerminalCapacity(@NotNull String ownerId) {
+        List<Content> open = openTerminalContents.get();
+        synchronized (this) {
+            pruneClosedTerminals(open);
+            int ownerCount = 0;
+            for (TerminalRef ref : trackedTerminals) {
+                if (ref.ownerId().equals(ownerId)) ownerCount++;
+            }
+            return ownerCount < MAX_OPEN_AGENT_TERMINALS
+                && trackedTerminals.size() < MAX_OPEN_AGENT_TERMINALS_GLOBAL;
+        }
+    }
+
+    public synchronized void untrackTerminal(
+        @NotNull String ownerId,
+        @NotNull String terminalId
+    ) {
+        trackedTerminals.removeIf(ref ->
+            ref.ownerId().equals(ownerId) && ref.terminalId().equals(terminalId));
+    }
+
+    /**
+     * Releases the exact terminal contents belonging to one ended transport session.
+     */
+    public void closeOwnedTerminalTabs(@NotNull String ownerId) {
+        List<TerminalRef> candidates;
+        synchronized (this) {
+            candidates = trackedTerminals.stream()
+                .filter(ref -> ref.ownerId().equals(ownerId))
+                .toList();
+        }
+        closeTerminalRefs(candidates);
+    }
+
+    /**
+     * Releases all agent-owned terminal resources, used when the MCP server itself stops.
+     */
+    public void closeAllOwnedTerminalTabs() {
+        List<TerminalRef> candidates;
+        synchronized (this) {
+            candidates = List.copyOf(trackedTerminals);
+        }
+        closeTerminalRefs(candidates);
+    }
+
+    private void closeTerminalRefs(@NotNull List<TerminalRef> candidates) {
+        if (candidates.isEmpty()) return;
+        ApplicationManager.getApplication().invokeLater(() -> {
+            ToolWindow toolWindow = ToolWindowManager.getInstance(project)
+                .getToolWindow(TERMINAL_TOOL_WINDOW_ID);
+            ContentManager manager = toolWindow != null ? toolWindow.getContentManager() : null;
+
+            for (TerminalRef ref : candidates) {
+                try {
+                    boolean open = manager != null && containsIdentity(manager.getContents(), ref.content());
+                    if (!open || manager.removeContent(ref.content(), true)) {
+                        removeTerminalRef(ref);
+                        LOG.debug("Released agent terminal " + ref.terminalId()
+                            + " for owner " + ref.ownerId());
+                    }
+                } catch (Exception e) {
+                    LOG.debug("Failed to release agent terminal " + ref.terminalId(), e);
+                }
+            }
+        });
+    }
+
+    private static @NotNull AgentTerminal view(@NotNull TerminalRef ref) {
+        return new AgentTerminal(ref.terminalId(), ref.content());
+    }
+
+    private synchronized void pruneClosedTerminals(@NotNull List<Content> open) {
+        trackedTerminals.removeIf(ref -> !containsIdentity(open, ref.content()));
+    }
+
+    private static boolean containsIdentity(@NotNull Content[] contents, @NotNull Content target) {
+        for (Content content : contents) {
+            if (content == target) return true;
         }
         return false;
     }
 
-    public synchronized void untrackTerminalTab(@NotNull String displayName) {
-        trackedTabs.removeIf(ref -> TERMINAL_TOOL_WINDOW_ID.equals(ref.toolWindowId())
-            && terminalTabNameMatches(ref.tabName(), displayName));
-    }
-
-    private synchronized List<String> trackedTerminalTabNames() {
-        List<String> names = new ArrayList<>();
-        for (TabRef ref : trackedTabs) {
-            if (TERMINAL_TOOL_WINDOW_ID.equals(ref.toolWindowId())) {
-                names.add(ref.tabName());
-            }
+    private static boolean containsIdentity(@NotNull List<Content> contents, @NotNull Content target) {
+        for (Content content : contents) {
+            if (content == target) return true;
         }
-        return names;
+        return false;
     }
 
-    private List<String> openTerminalDisplayNames() {
-        List<String> names = new ArrayList<>();
+    private static @NotNull List<Content> readOpenTerminalContents(@NotNull Project project) {
+        List<Content> contents = new ArrayList<>();
         EdtUtil.invokeAndWait(() -> {
-            ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(TERMINAL_TOOL_WINDOW_ID);
-            if (toolWindow == null) return;
-            for (Content content : toolWindow.getContentManager().getContents()) {
-                names.add(content.getDisplayName());
+            ToolWindow toolWindow = ToolWindowManager.getInstance(project)
+                .getToolWindow(TERMINAL_TOOL_WINDOW_ID);
+            if (toolWindow != null) {
+                contents.addAll(List.of(toolWindow.getContentManager().getContents()));
             }
         });
-        return names;
+        return contents;
     }
 
-    static boolean hasTerminalCapacity(int openAgentTerminalCount) {
-        return openAgentTerminalCount < MAX_OPEN_AGENT_TERMINALS;
-    }
-
-    static @Nullable String mostRecentOpenTerminalTabName(
-        List<String> trackedTerminalTabNames,
-        List<String> openDisplayNames
+    /**
+     * Matches an agent-provided base name against the IDE display name, which may include a
+     * numeric {@code (N)} suffix.
+     */
+    public static boolean terminalTabNameMatches(
+        @Nullable String trackedName,
+        @Nullable String displayName
     ) {
-        for (int trackedIndex = trackedTerminalTabNames.size() - 1; trackedIndex >= 0; trackedIndex--) {
-            String trackedName = trackedTerminalTabNames.get(trackedIndex);
-            for (String displayName : openDisplayNames) {
-                if (terminalTabNameMatches(trackedName, displayName)) {
-                    return displayName;
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Counts currently open terminal tabs that correspond to tracked agent tabs.
-     */
-    static int countMatchingTerminalTabs(List<String> trackedTerminalTabNames, List<String> openDisplayNames) {
-        int count = 0;
-        for (String displayName : openDisplayNames) {
-            if (displayName == null) continue;
-            for (String tabName : trackedTerminalTabNames) {
-                if (terminalTabNameMatches(tabName, displayName)) {
-                    count++;
-                    break;
-                }
-            }
-        }
-        return count;
-    }
-
-    /**
-     * Matches an agent-tracked base name against the IDE display name, which may include a numeric {@code (N)} suffix.
-     */
-    public static boolean terminalTabNameMatches(@Nullable String trackedName, @Nullable String displayName) {
         if (trackedName == null || displayName == null) return false;
         return displayName.equals(trackedName) || displayName.matches(
             java.util.regex.Pattern.quote(trackedName) + " \\(\\d+\\)"
@@ -150,7 +293,8 @@ public final class AgentTabTracker implements Disposable {
     }
 
     /**
-     * Closes tracked tabs from previous turns and retains tabs skipped by cleanup policy.
+     * Closes non-terminal tabs from previous turns. Terminals are session resources and must never
+     * be closed by another prompt's global turn-boundary cleanup.
      */
     public void closeTrackedTabs() {
         CleanupSettings settings = CleanupSettings.getInstance(project);
@@ -162,11 +306,10 @@ public final class AgentTabTracker implements Disposable {
         }
         if (candidates.isEmpty()) return;
 
-        boolean closeRunningTerminals = settings.isAutoCloseRunningTerminals();
         ApplicationManager.getApplication().invokeLater(() -> {
             for (TabRef ref : candidates) {
                 try {
-                    if (closeTab(ref, closeRunningTerminals)) {
+                    if (closeTab(ref)) {
                         removeTrackedRef(ref);
                     }
                 } catch (Exception e) {
@@ -177,54 +320,54 @@ public final class AgentTabTracker implements Disposable {
     }
 
     /**
-     * Determines whether a tab should be skipped during cleanup.
+     * Determines whether a non-terminal tab should be skipped during turn cleanup.
+     * The terminal branch is retained for compatibility with existing settings tests; session-owned
+     * terminals do not enter this cleanup path.
      */
-    static boolean shouldSkipClose(String toolWindowId, boolean closeRunningTerminals,
-                                   boolean isProcessActive) {
+    static boolean shouldSkipClose(
+        String toolWindowId,
+        boolean closeRunningTerminals,
+        boolean isProcessActive
+    ) {
         if (TERMINAL_TOOL_WINDOW_ID.equals(toolWindowId) && !closeRunningTerminals) {
             return true;
         }
         return RUN_TOOL_WINDOW_ID.equals(toolWindowId) && isProcessActive;
     }
 
-    /**
-     * @return true when the reference can be forgotten; false when it must be retried later.
-     */
-    private boolean closeTab(TabRef ref, boolean closeRunningTerminals) {
+    private boolean closeTab(TabRef ref) {
         boolean processActive = RUN_TOOL_WINDOW_ID.equals(ref.toolWindowId())
             && isRunProcessStillActive(ref.tabName());
-        if (shouldSkipClose(ref.toolWindowId(), closeRunningTerminals, processActive)) {
+        if (shouldSkipClose(ref.toolWindowId(), false, processActive)) {
             return false;
         }
 
-        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(ref.toolWindowId());
+        ToolWindow toolWindow = ToolWindowManager.getInstance(project)
+            .getToolWindow(ref.toolWindowId());
         if (toolWindow == null) return true;
 
         ContentManager contentManager = toolWindow.getContentManager();
         for (Content content : contentManager.getContents()) {
-            String displayName = content.getDisplayName();
-            if (tabDisplayNameMatches(ref, displayName)) {
+            if (ref.tabName().equals(content.getDisplayName())) {
                 contentManager.removeContent(content, true);
-                LOG.debug("Closed agent tab: " + ref.toolWindowId() + "/" + displayName);
+                LOG.debug("Closed agent tab: " + ref.toolWindowId() + "/" + ref.tabName());
                 return true;
             }
         }
         return true;
     }
 
-    private static boolean tabDisplayNameMatches(TabRef ref, @Nullable String displayName) {
-        if (TERMINAL_TOOL_WINDOW_ID.equals(ref.toolWindowId())) {
-            return terminalTabNameMatches(ref.tabName(), displayName);
-        }
-        return ref.tabName().equals(displayName);
-    }
-
     private synchronized void removeTrackedRef(TabRef ref) {
         trackedTabs.remove(ref);
     }
 
+    private synchronized void removeTerminalRef(TerminalRef ref) {
+        trackedTerminals.remove(ref);
+    }
+
     private boolean isRunProcessStillActive(String tabName) {
-        for (RunContentDescriptor descriptor : RunContentManager.getInstance(project).getAllDescriptors()) {
+        for (RunContentDescriptor descriptor :
+            RunContentManager.getInstance(project).getAllDescriptors()) {
             if (tabName.equals(descriptor.getDisplayName())) {
                 ProcessHandler handler = descriptor.getProcessHandler();
                 return handler != null && !handler.isProcessTerminated();
@@ -236,5 +379,6 @@ public final class AgentTabTracker implements Disposable {
     @Override
     public synchronized void dispose() {
         trackedTabs.clear();
+        trackedTerminals.clear();
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpCallContext.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpCallContext.java
@@ -4,8 +4,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Thread-local that lets quality tools (especially the popup-handling ones) discover the
- * MCP session key of the caller without plumbing it through every tool's signature.
+ * Thread-local that lets tools discover the MCP transport-session owner without plumbing it
+ * through every tool signature. Popup gates use it for per-session counters; stateful resources
+ * such as integrated terminals use it as an isolation boundary.
  *
  * <p><b>Why this exists — DO NOT REMOVE without reading
  * {@code .agent-work/popup-interaction-design-2026-04-30.md}.</b>

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpHttpServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpHttpServer.java
@@ -36,8 +36,6 @@ public final class McpHttpServer implements Disposable, McpServerControl {
     private static final String APPLICATION_JSON = "application/json";
     static final String MCP_SESSION_ID_HEADER = "Mcp-Session-Id";
     private static final String MCP_PROTOCOL_VERSION_HEADER = "MCP-Protocol-Version";
-    static final long HTTP_SESSION_IDLE_TIMEOUT_NANOS =
-        java.util.concurrent.TimeUnit.HOURS.toNanos(2);
     private static final long HTTP_SESSION_SWEEP_INTERVAL_MINUTES = 5;
     private static final String HTTP_OWNER_PREFIX = "http:";
     private static final String ALLOWED_REQUEST_HEADERS =
@@ -370,7 +368,15 @@ public final class McpHttpServer implements Disposable, McpServerControl {
         }
 
         if (kind == McpSessionRegistry.RequestKind.INITIALIZE) {
-            String sessionId = httpSessions.openSession();
+            int cap = getMaxOpenHttpSessions();
+            String sessionId = httpSessions.openSession(cap);
+            if (sessionId == null) {
+                sendJsonRpcError(exchange, 503, -32000,
+                    "MCP session limit reached (" + cap + " concurrent sessions)."
+                        + " Close an existing session or raise the limit in"
+                        + " Settings → AgentBridge → MCP Server.");
+                return null;
+            }
             return HttpOwnerResolution.initialize(sessionId);
         }
 
@@ -471,7 +477,7 @@ public final class McpHttpServer implements Disposable, McpServerControl {
 
     private void closeExpiredHttpSessions() {
         try {
-            var expired = httpSessions.expireIdleSessions(HTTP_SESSION_IDLE_TIMEOUT_NANOS);
+            var expired = httpSessions.expireIdleSessions(getHttpSessionIdleTimeoutNanos());
             if (expired.isEmpty() || project.isDisposed()) return;
 
             AgentTabTracker tracker = AgentTabTracker.getInstance(project);
@@ -482,6 +488,34 @@ public final class McpHttpServer implements Disposable, McpServerControl {
             LOG.info("Expired " + expired.size() + " idle MCP HTTP session(s)");
         } catch (RuntimeException e) {
             LOG.warn("Failed to expire idle MCP HTTP sessions", e);
+        }
+    }
+
+    private int getMaxOpenHttpSessions() {
+        McpServerSettings settings = tryGetSettings();
+        return settings != null
+            ? settings.getMaxOpenHttpSessions()
+            : McpServerSettings.DEFAULT_MAX_OPEN_HTTP_SESSIONS;
+    }
+
+    private long getHttpSessionIdleTimeoutNanos() {
+        McpServerSettings settings = tryGetSettings();
+        int minutes = settings != null
+            ? settings.getHttpSessionIdleTimeoutMinutes()
+            : McpServerSettings.DEFAULT_HTTP_SESSION_IDLE_TIMEOUT_MINUTES;
+        return java.util.concurrent.TimeUnit.MINUTES.toNanos(minutes);
+    }
+
+    /**
+     * Reads the persistent settings service for this project. Returns {@code null} when the
+     * service cannot be resolved (e.g. mock projects in unit tests) so callers can fall back
+     * to the shipping defaults without letting a test-only wiring quirk break production paths.
+     */
+    private @Nullable McpServerSettings tryGetSettings() {
+        try {
+            return McpServerSettings.getInstance(project);
+        } catch (RuntimeException e) {
+            return null;
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpHttpServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpHttpServer.java
@@ -4,6 +4,8 @@ import com.github.catatafishen.agentbridge.services.hooks.HookQueryHandler;
 import com.github.catatafishen.agentbridge.services.hooks.HookToolHandler;
 import com.github.catatafishen.agentbridge.settings.McpServerSettings;
 import com.github.catatafishen.agentbridge.settings.TransportMode;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -32,6 +34,14 @@ public final class McpHttpServer implements Disposable, McpServerControl {
     private static final Logger LOG = Logger.getInstance(McpHttpServer.class);
     private static final String CONTENT_TYPE = "Content-Type";
     private static final String APPLICATION_JSON = "application/json";
+    static final String MCP_SESSION_ID_HEADER = "Mcp-Session-Id";
+    private static final String MCP_PROTOCOL_VERSION_HEADER = "MCP-Protocol-Version";
+    static final long HTTP_SESSION_IDLE_TIMEOUT_NANOS =
+        java.util.concurrent.TimeUnit.HOURS.toNanos(2);
+    private static final long HTTP_SESSION_SWEEP_INTERVAL_MINUTES = 5;
+    private static final String HTTP_OWNER_PREFIX = "http:";
+    private static final String ALLOWED_REQUEST_HEADERS =
+        CONTENT_TYPE + ", " + MCP_SESSION_ID_HEADER + ", " + MCP_PROTOCOL_VERSION_HEADER;
 
     /**
      * Fired on the project message bus when the MCP server starts or stops.
@@ -52,7 +62,9 @@ public final class McpHttpServer implements Disposable, McpServerControl {
     private McpSseTransport sseTransport;
     private TransportMode activeTransportMode;
     private java.util.concurrent.ExecutorService requestExecutor;
+    private java.util.concurrent.ScheduledExecutorService sessionCleanupExecutor;
     private final AtomicInteger activeConnections = new AtomicInteger(0);
+    private final McpSessionRegistry httpSessions = new McpSessionRegistry();
     private volatile boolean running;
 
     public McpHttpServer(@NotNull Project project) {
@@ -84,7 +96,7 @@ public final class McpHttpServer implements Disposable, McpServerControl {
             httpServer.createContext("/hooks/tool", new HookToolHandler(project)::handle);
 
             if (activeTransportMode == TransportMode.SSE) {
-                sseTransport = new McpSseTransport(protocolHandler);
+                sseTransport = new McpSseTransport(project, protocolHandler);
                 httpServer.createContext("/sse", sseTransport::handleSseConnect);
                 httpServer.createContext("/message", sseTransport::handleMessage);
                 sseTransport.start();
@@ -107,6 +119,9 @@ public final class McpHttpServer implements Disposable, McpServerControl {
             );
             httpServer.setExecutor(requestExecutor);
             httpServer.start();
+            if (activeTransportMode == TransportMode.STREAMABLE_HTTP) {
+                startHttpSessionCleanup();
+            }
             running = true;
             LOG.info("[MCP] server started on port " + actualPort + " (" + activeTransportMode.getDisplayName()
                 + ") for project: " + project.getBasePath());
@@ -164,6 +179,8 @@ public final class McpHttpServer implements Disposable, McpServerControl {
                 sseTransport.stop();
                 sseTransport = null;
             }
+            stopHttpSessionCleanup();
+            closeAllHttpSessions();
             httpServer.stop(1);
             httpServer = null;
             if (requestExecutor != null) {
@@ -223,33 +240,31 @@ public final class McpHttpServer implements Disposable, McpServerControl {
     private static final int MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024; // 10 MB
 
     private void handleMcp(HttpExchange exchange) throws IOException {
-        // CORS headers for browser-based agents
+        // CORS headers for browser-based agents and MCP transport session propagation.
         exchange.getResponseHeaders().set("Access-Control-Allow-Origin", "*");
-        exchange.getResponseHeaders().set("Access-Control-Allow-Methods", "POST, OPTIONS");
-        exchange.getResponseHeaders().set("Access-Control-Allow-Headers", CONTENT_TYPE);
+        exchange.getResponseHeaders().set(
+            "Access-Control-Allow-Methods", "POST, DELETE, OPTIONS");
+        exchange.getResponseHeaders().set(
+            "Access-Control-Allow-Headers", ALLOWED_REQUEST_HEADERS);
+        exchange.getResponseHeaders().set(
+            "Access-Control-Expose-Headers", MCP_SESSION_ID_HEADER);
 
-        // Close the TCP connection after every Streamable-HTTP response instead of keeping it
-        // alive for reuse. Each MCP request/response is self-contained (we never hold a server→client
-        // SSE stream open on this endpoint — GET /mcp returns 405), so there is no benefit to pooling.
-        //
-        // Why this matters: the JDK HttpServer idle-closes pooled keep-alive sockets after ~60s
-        // (sun.net.httpserver.idleInterval). On a long model "think" gap between tool calls, the
-        // client's pooled connection goes stale; its next tool-call POST reuses the dead socket and
-        // gets ECONNRESET. Because POST is not idempotent, HTTP clients (e.g., Claude Code's undici)
-        // do NOT auto-retry it, so the call fails, and the harness reports the MCP server as
-        // "disconnected" — even though the server is healthy. That spurious notice then gets baked
-        // into the resumed transcript and keeps reappearing on later turns. Sending Connection: close
-        // makes the client open a fresh connection per request, so there is never a stale socket to
-        // reset. The localhost reconnect cost is negligible. See issue #841.
+        // Force a fresh localhost connection for each request to avoid stale pooled sockets after
+        // long model think gaps. MCP ownership is carried by Mcp-Session-Id, not by the TCP socket.
+        // See issue #841.
         exchange.getResponseHeaders().set("Connection", "close");
 
-        if ("OPTIONS".equals(exchange.getRequestMethod())) {
+        String requestMethod = exchange.getRequestMethod();
+        if ("OPTIONS".equals(requestMethod)) {
             exchange.sendResponseHeaders(204, -1);
             exchange.close();
             return;
         }
-
-        if (!"POST".equals(exchange.getRequestMethod())) {
+        if ("DELETE".equals(requestMethod)) {
+            handleSessionDelete(exchange);
+            return;
+        }
+        if (!"POST".equals(requestMethod)) {
             exchange.sendResponseHeaders(405, -1);
             exchange.close();
             return;
@@ -257,6 +272,8 @@ public final class McpHttpServer implements Disposable, McpServerControl {
 
         activeConnections.incrementAndGet();
         McpServerSettings settings = McpServerSettings.getInstance(project);
+        HttpOwnerResolution owner = null;
+        boolean retainNewSession = false;
         try {
             byte[] bodyBytes = exchange.getRequestBody().readNBytes(MAX_REQUEST_BODY_BYTES + 1);
             if (bodyBytes.length > MAX_REQUEST_BODY_BYTES) {
@@ -268,10 +285,20 @@ public final class McpHttpServer implements Disposable, McpServerControl {
             if (settings.isDebugLoggingEnabled()) {
                 LOG.info("[MCP] <<< " + truncateForLog(body));
             }
-            String response = protocolHandler.handleMessage(body);
+
+            owner = resolveHttpOwner(exchange, body);
+            if (owner == null) return;
+            String response;
+            try {
+                response = protocolHandler.handleMessage(body, owner.ownerKey());
+            } finally {
+                finishHttpRequest(owner.ownerKey());
+            }
+
+            boolean initialized = completeInitialization(exchange, owner, response);
 
             if (response == null) {
-                // Notification — no response needed
+                // Notification — no response needed.
                 exchange.sendResponseHeaders(202, -1);
             } else {
                 if (settings.isDebugLoggingEnabled()) {
@@ -282,13 +309,171 @@ public final class McpHttpServer implements Disposable, McpServerControl {
                 exchange.sendResponseHeaders(200, bytes.length);
                 exchange.getResponseBody().write(bytes);
             }
+
+            retainNewSession = initialized;
         } catch (Exception e) {
             LOG.warn("MCP request error", e);
             String msg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
             sendJsonRpcError(exchange, 500, -32603, "Internal error: " + msg);
         } finally {
+            if (owner != null && owner.newSessionId() != null && !retainNewSession) {
+                httpSessions.closeSession(owner.newSessionId());
+            }
             exchange.close();
             activeConnections.decrementAndGet();
+        }
+    }
+
+    record HttpOwnerResolution(
+        @NotNull String ownerKey,
+        @Nullable String newSessionId
+    ) {
+    }
+
+    @Nullable HttpOwnerResolution resolveHttpOwner(
+        @NotNull HttpExchange exchange,
+        @NotNull String body
+    ) throws IOException {
+        McpSessionRegistry.RequestKind kind = McpSessionRegistry.classifyRequest(body);
+        if (kind == McpSessionRegistry.RequestKind.INVALID) {
+            // Let the protocol handler return the precise JSON-RPC parse/validation error.
+            return new HttpOwnerResolution(
+                McpSessionRegistry.ownerKey("http", "invalid-request"), null);
+        }
+
+        if (kind == McpSessionRegistry.RequestKind.INITIALIZE) {
+            String sessionId = httpSessions.openSession();
+            return new HttpOwnerResolution(
+                McpSessionRegistry.ownerKey("http", sessionId), sessionId);
+        }
+
+        String sessionId = exchange.getRequestHeaders().getFirst(MCP_SESSION_ID_HEADER);
+        if (sessionId == null || sessionId.isBlank()) {
+            sendJsonRpcError(exchange, 400, -32600,
+                "Missing " + MCP_SESSION_ID_HEADER
+                    + ". Initialize the MCP transport session first.");
+            return null;
+        }
+        if (!httpSessions.touch(sessionId)) {
+            sendJsonRpcError(exchange, 404, -32600,
+                "Unknown or expired MCP session: " + sessionId);
+            return null;
+        }
+
+        exchange.getResponseHeaders().set(MCP_SESSION_ID_HEADER, sessionId);
+        return new HttpOwnerResolution(
+            McpSessionRegistry.ownerKey("http", sessionId), null);
+    }
+
+    /**
+     * Publishes a newly allocated session only on the HTTP response containing an
+     * InitializeResult, as required by the Streamable HTTP transport specification.
+     */
+    boolean completeInitialization(
+        @NotNull HttpExchange exchange,
+        @NotNull HttpOwnerResolution owner,
+        @Nullable String response
+    ) {
+        String sessionId = owner.newSessionId();
+        if (sessionId == null) return true;
+        if (!containsInitializeResult(response)) {
+            httpSessions.closeSession(sessionId);
+            return false;
+        }
+        exchange.getResponseHeaders().set(MCP_SESSION_ID_HEADER, sessionId);
+        return true;
+    }
+
+    static boolean containsInitializeResult(@Nullable String response) {
+        if (response == null) return false;
+        try {
+            JsonObject parsed = JsonParser.parseString(response).getAsJsonObject();
+            return !parsed.has("error")
+                && parsed.has("result")
+                && parsed.get("result").isJsonObject();
+        } catch (RuntimeException ignored) {
+            return false;
+        }
+    }
+
+    private void handleSessionDelete(@NotNull HttpExchange exchange) throws IOException {
+        String sessionId = exchange.getRequestHeaders().getFirst(MCP_SESSION_ID_HEADER);
+        if (sessionId == null || sessionId.isBlank()) {
+            sendJsonRpcError(exchange, 400, -32600,
+                "Missing " + MCP_SESSION_ID_HEADER);
+            exchange.close();
+            return;
+        }
+        if (!httpSessions.closeSession(sessionId)) {
+            sendJsonRpcError(exchange, 404, -32600,
+                "Unknown or expired MCP session: " + sessionId);
+            exchange.close();
+            return;
+        }
+
+        AgentTabTracker.getInstance(project).closeOwnedTerminalTabs(
+            McpSessionRegistry.ownerKey("http", sessionId));
+        exchange.sendResponseHeaders(204, -1);
+        exchange.close();
+    }
+
+    private void startHttpSessionCleanup() {
+        sessionCleanupExecutor = java.util.concurrent.Executors
+            .newSingleThreadScheduledExecutor(r -> {
+                Thread thread = new Thread(r, "mcp-http-session-cleanup");
+                thread.setDaemon(true);
+                return thread;
+            });
+        sessionCleanupExecutor.scheduleAtFixedRate(
+            this::closeExpiredHttpSessions,
+            HTTP_SESSION_SWEEP_INTERVAL_MINUTES,
+            HTTP_SESSION_SWEEP_INTERVAL_MINUTES,
+            java.util.concurrent.TimeUnit.MINUTES
+        );
+    }
+
+    private void stopHttpSessionCleanup() {
+        if (sessionCleanupExecutor == null) return;
+        sessionCleanupExecutor.shutdownNow();
+        sessionCleanupExecutor = null;
+    }
+
+    private void closeExpiredHttpSessions() {
+        try {
+            var expired = httpSessions.expireIdleSessions(HTTP_SESSION_IDLE_TIMEOUT_NANOS);
+            if (expired.isEmpty() || project.isDisposed()) return;
+
+            AgentTabTracker tracker = AgentTabTracker.getInstance(project);
+            for (String sessionId : expired) {
+                tracker.closeOwnedTerminalTabs(
+                    McpSessionRegistry.ownerKey("http", sessionId));
+            }
+            LOG.info("Expired " + expired.size() + " idle MCP HTTP session(s)");
+        } catch (RuntimeException e) {
+            LOG.warn("Failed to expire idle MCP HTTP sessions", e);
+        }
+    }
+
+    /**
+     * Refreshes activity after a request completes. If DELETE or idle expiry won a race with an
+     * in-flight tool call, close any terminal that the call created after session termination.
+     */
+    private void finishHttpRequest(@NotNull String ownerKey) {
+        if (!ownerKey.startsWith(HTTP_OWNER_PREFIX)
+            || ownerKey.equals(HTTP_OWNER_PREFIX + "invalid-request")) {
+            return;
+        }
+        String sessionId = ownerKey.substring(HTTP_OWNER_PREFIX.length());
+        if (!httpSessions.touch(sessionId) && !project.isDisposed()) {
+            AgentTabTracker.getInstance(project).closeOwnedTerminalTabs(ownerKey);
+        }
+    }
+
+    private void closeAllHttpSessions() {
+        AgentTabTracker tracker = AgentTabTracker.getInstance(project);
+        for (String sessionId : httpSessions.drainSessions()) {
+            tracker.closeOwnedTerminalTabs(
+                McpSessionRegistry.ownerKey("http", sessionId));
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpHttpServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpHttpServer.java
@@ -289,10 +289,15 @@ public final class McpHttpServer implements Disposable, McpServerControl {
             owner = resolveHttpOwner(exchange, body);
             if (owner == null) return;
             String response;
+            String ownerKey = owner.ownerKey();
             try {
-                response = protocolHandler.handleMessage(body, owner.ownerKey());
+                response = ownerKey != null
+                    ? protocolHandler.handleMessage(body, ownerKey)
+                    : protocolHandler.handleMessage(body);
             } finally {
-                finishHttpRequest(owner.ownerKey());
+                if (ownerKey != null) {
+                    finishHttpRequest(ownerKey);
+                }
             }
 
             boolean initialized = completeInitialization(exchange, owner, response);
@@ -317,17 +322,41 @@ public final class McpHttpServer implements Disposable, McpServerControl {
             sendJsonRpcError(exchange, 500, -32603, "Internal error: " + msg);
         } finally {
             if (owner != null && owner.newSessionId() != null && !retainNewSession) {
-                httpSessions.closeSession(owner.newSessionId());
+                closeHttpSession(owner.newSessionId());
             }
             exchange.close();
             activeConnections.decrementAndGet();
         }
     }
 
+    enum HttpOwnerKind {
+        INVALID,
+        INITIALIZE,
+        ESTABLISHED
+    }
+
     record HttpOwnerResolution(
-        @NotNull String ownerKey,
+        @NotNull HttpOwnerKind kind,
+        @Nullable String ownerKey,
         @Nullable String newSessionId
     ) {
+        static @NotNull HttpOwnerResolution invalid() {
+            return new HttpOwnerResolution(HttpOwnerKind.INVALID, null, null);
+        }
+
+        static @NotNull HttpOwnerResolution initialize(@NotNull String sessionId) {
+            return new HttpOwnerResolution(
+                HttpOwnerKind.INITIALIZE,
+                McpSessionRegistry.ownerKey("http", sessionId),
+                sessionId);
+        }
+
+        static @NotNull HttpOwnerResolution established(@NotNull String sessionId) {
+            return new HttpOwnerResolution(
+                HttpOwnerKind.ESTABLISHED,
+                McpSessionRegistry.ownerKey("http", sessionId),
+                null);
+        }
     }
 
     @Nullable HttpOwnerResolution resolveHttpOwner(
@@ -337,14 +366,12 @@ public final class McpHttpServer implements Disposable, McpServerControl {
         McpSessionRegistry.RequestKind kind = McpSessionRegistry.classifyRequest(body);
         if (kind == McpSessionRegistry.RequestKind.INVALID) {
             // Let the protocol handler return the precise JSON-RPC parse/validation error.
-            return new HttpOwnerResolution(
-                McpSessionRegistry.ownerKey("http", "invalid-request"), null);
+            return HttpOwnerResolution.invalid();
         }
 
         if (kind == McpSessionRegistry.RequestKind.INITIALIZE) {
             String sessionId = httpSessions.openSession();
-            return new HttpOwnerResolution(
-                McpSessionRegistry.ownerKey("http", sessionId), sessionId);
+            return HttpOwnerResolution.initialize(sessionId);
         }
 
         String sessionId = exchange.getRequestHeaders().getFirst(MCP_SESSION_ID_HEADER);
@@ -361,8 +388,7 @@ public final class McpHttpServer implements Disposable, McpServerControl {
         }
 
         exchange.getResponseHeaders().set(MCP_SESSION_ID_HEADER, sessionId);
-        return new HttpOwnerResolution(
-            McpSessionRegistry.ownerKey("http", sessionId), null);
+        return HttpOwnerResolution.established(sessionId);
     }
 
     /**
@@ -377,7 +403,7 @@ public final class McpHttpServer implements Disposable, McpServerControl {
         String sessionId = owner.newSessionId();
         if (sessionId == null) return true;
         if (!containsInitializeResult(response)) {
-            httpSessions.closeSession(sessionId);
+            closeHttpSession(sessionId);
             return false;
         }
         exchange.getResponseHeaders().set(MCP_SESSION_ID_HEADER, sessionId);
@@ -404,17 +430,22 @@ public final class McpHttpServer implements Disposable, McpServerControl {
             exchange.close();
             return;
         }
-        if (!httpSessions.closeSession(sessionId)) {
+        if (!closeHttpSession(sessionId)) {
             sendJsonRpcError(exchange, 404, -32600,
                 "Unknown or expired MCP session: " + sessionId);
             exchange.close();
             return;
         }
 
-        AgentTabTracker.getInstance(project).closeOwnedTerminalTabs(
-            McpSessionRegistry.ownerKey("http", sessionId));
         exchange.sendResponseHeaders(204, -1);
         exchange.close();
+    }
+
+    private boolean closeHttpSession(@NotNull String sessionId) {
+        if (!httpSessions.closeSession(sessionId)) return false;
+        AgentTabTracker.getInstance(project).closeOwnedTerminalTabs(
+            McpSessionRegistry.ownerKey("http", sessionId));
+        return true;
     }
 
     private void startHttpSessionCleanup() {
@@ -459,10 +490,7 @@ public final class McpHttpServer implements Disposable, McpServerControl {
      * in-flight tool call, close any terminal that the call created after session termination.
      */
     private void finishHttpRequest(@NotNull String ownerKey) {
-        if (!ownerKey.startsWith(HTTP_OWNER_PREFIX)
-            || ownerKey.equals(HTTP_OWNER_PREFIX + "invalid-request")) {
-            return;
-        }
+        if (!ownerKey.startsWith(HTTP_OWNER_PREFIX)) return;
         String sessionId = ownerKey.substring(HTTP_OWNER_PREFIX.length());
         if (!httpSessions.touch(sessionId) && !project.isDisposed()) {
             AgentTabTracker.getInstance(project).closeOwnedTerminalTabs(ownerKey);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpProtocolHandler.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpProtocolHandler.java
@@ -132,6 +132,16 @@ public final class McpProtocolHandler {
      * Returns null for notifications (no id field).
      */
     public String handleMessage(String messageJson) {
+        return handleMessage(messageJson, legacySessionKey());
+    }
+
+    /**
+     * Handles a request inside an explicit transport-session ownership boundary.
+     */
+    public String handleMessage(
+        @NotNull String messageJson,
+        @NotNull String sessionKey
+    ) {
         try {
             JsonObject msg = JsonParser.parseString(messageJson).getAsJsonObject();
             String method = msg.has("method") ? msg.get("method").getAsString() : null;
@@ -140,7 +150,7 @@ public final class McpProtocolHandler {
             JsonObject result = switch (method) {
                 case "initialize" -> handleInitialize(msg);
                 case "tools/list" -> handleToolsList(msg);
-                case "tools/call" -> handleToolsCall(msg);
+                case "tools/call" -> handleToolsCall(msg, sessionKey);
                 case "resources/list" -> handleResourcesList(msg);
                 case "resources/templates/list" -> handleResourceTemplatesList(msg);
                 case "resources/read" -> handleResourcesRead(msg);
@@ -517,7 +527,10 @@ public final class McpProtocolHandler {
         return respondResult(msg, result);
     }
 
-    private JsonObject handleToolsCall(JsonObject msg) {
+    private JsonObject handleToolsCall(
+        JsonObject msg,
+        @NotNull String sessionKey
+    ) {
         JsonObject params = msg.has(KEY_PARAMS) ? msg.getAsJsonObject(KEY_PARAMS) : new JsonObject();
         String toolName = params.has("name") ? params.get("name").getAsString() : null;
         if (toolName == null) {
@@ -535,7 +548,6 @@ public final class McpProtocolHandler {
         ToolCallMeta meta = extractMeta(params);
         logToolCall(toolName, meta.progressToken(), settings);
 
-        String sessionKey = sessionKey(project);
         PopupGateResult gateResult = evaluatePopupGate(toolName, sessionKey, msg);
         if (gateResult.blocked != null) return gateResult.blocked;
 
@@ -559,8 +571,13 @@ public final class McpProtocolHandler {
         if (preHookResult.blockedMessage != null) return buildToolResult(msg, preHookResult.blockedMessage, true);
         arguments = preHookResult.arguments;
 
-        return executeToolCall(msg, toolName, arguments, preHookResult, hookStages,
-            meta.toolUseId(), originalArguments, gateResult.prefix);
+        McpCallContext.setCurrent(sessionKey);
+        try {
+            return executeToolCall(msg, toolName, arguments, preHookResult, hookStages,
+                meta.toolUseId(), originalArguments, gateResult.prefix);
+        } finally {
+            McpCallContext.clear();
+        }
     }
 
     private JsonObject executeToolCall(JsonObject msg, String toolName, JsonObject arguments,
@@ -633,8 +650,6 @@ public final class McpProtocolHandler {
                 e.getMessage(), kind, hookStages));
 
             return buildToolResult(msg, finalOutput, isError);
-        } finally {
-            McpCallContext.clear();
         }
     }
 
@@ -651,7 +666,7 @@ public final class McpProtocolHandler {
     private ToolResult callToolWithTimeout(String toolName, JsonObject arguments,
                                            @Nullable String toolUseId, JsonObject originalArguments,
                                            @Nullable String displayName) {
-        String sessionKey = sessionKey(project);
+        String sessionKey = McpCallContext.currentOrFallback();
         PsiBridgeService bridge = PsiBridgeService.getInstance(project);
         AtomicReference<Thread> workerThread = new AtomicReference<>();
         long startMs = System.currentTimeMillis();
@@ -882,8 +897,8 @@ public final class McpProtocolHandler {
         return normalized;
     }
 
-    private String sessionKey(com.intellij.openapi.project.Project proj) {
-        return proj.getLocationHash() + ":" + System.identityHashCode(this);
+    private @NotNull String legacySessionKey() {
+        return "legacy:" + project.getLocationHash() + ":" + System.identityHashCode(this);
     }
 
     private @Nullable String evaluatePermissionHook(@NotNull String toolName,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpSessionRegistry.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpSessionRegistry.java
@@ -1,0 +1,97 @@
+package com.github.catatafishen.agentbridge.services;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.LongSupplier;
+
+/**
+ * Tracks Streamable HTTP sessions minted by AgentBridge.
+ *
+ * <p>The current MCP transport specification allows the server to return an
+ * {@code Mcp-Session-Id} during initialization. The client then echoes that ID on every
+ * subsequent request. AgentBridge also uses the ID as the ownership boundary for stateful
+ * resources such as integrated terminals.</p>
+ */
+final class McpSessionRegistry {
+
+    enum RequestKind {
+        INITIALIZE,
+        ESTABLISHED,
+        INVALID
+    }
+
+    private final Map<String, Long> lastActivityNanos = new HashMap<>();
+    private final LongSupplier nanoTime;
+
+    McpSessionRegistry() {
+        this(System::nanoTime);
+    }
+
+    McpSessionRegistry(@NotNull LongSupplier nanoTime) {
+        this.nanoTime = nanoTime;
+    }
+
+    synchronized @NotNull String openSession() {
+        String sessionId;
+        do {
+            sessionId = UUID.randomUUID().toString();
+        } while (lastActivityNanos.putIfAbsent(sessionId, nanoTime.getAsLong()) != null);
+        return sessionId;
+    }
+
+    synchronized boolean touch(@NotNull String sessionId) {
+        if (!lastActivityNanos.containsKey(sessionId)) return false;
+        lastActivityNanos.put(sessionId, nanoTime.getAsLong());
+        return true;
+    }
+
+    synchronized boolean closeSession(@NotNull String sessionId) {
+        return lastActivityNanos.remove(sessionId) != null;
+    }
+
+    synchronized @NotNull Set<String> expireIdleSessions(long maxIdleNanos) {
+        if (maxIdleNanos < 0) {
+            throw new IllegalArgumentException("maxIdleNanos must not be negative");
+        }
+        long now = nanoTime.getAsLong();
+        Set<String> expired = new HashSet<>();
+        lastActivityNanos.entrySet().removeIf(entry -> {
+            boolean idle = now - entry.getValue() >= maxIdleNanos;
+            if (idle) expired.add(entry.getKey());
+            return idle;
+        });
+        return Set.copyOf(expired);
+    }
+
+    synchronized @NotNull Set<String> drainSessions() {
+        Set<String> drained = Set.copyOf(lastActivityNanos.keySet());
+        lastActivityNanos.clear();
+        return drained;
+    }
+
+    static @NotNull RequestKind classifyRequest(@NotNull String body) {
+        try {
+            var parsed = JsonParser.parseString(body);
+            if (!parsed.isJsonObject()) return RequestKind.INVALID;
+            JsonObject request = parsed.getAsJsonObject();
+            if (!request.has("method") || !request.get("method").isJsonPrimitive()) {
+                return RequestKind.INVALID;
+            }
+            String method = request.get("method").getAsString();
+            return "initialize".equals(method) ? RequestKind.INITIALIZE : RequestKind.ESTABLISHED;
+        } catch (RuntimeException ignored) {
+            return RequestKind.INVALID;
+        }
+    }
+
+    static @NotNull String ownerKey(@NotNull String transport, @NotNull String sessionId) {
+        return transport + ":" + sessionId;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpSessionRegistry.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpSessionRegistry.java
@@ -3,6 +3,7 @@ package com.github.catatafishen.agentbridge.services;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -38,12 +39,29 @@ final class McpSessionRegistry {
         this.nanoTime = nanoTime;
     }
 
-    synchronized @NotNull String openSession() {
+    /**
+     * Allocates a new session ID when the registry has room for it.
+     *
+     * @param maxOpenSessions upper bound on concurrent sessions. Values below 1 are treated as
+     *                        "no cap" so that a mis-configured setting cannot make the server
+     *                        refuse every {@code initialize}.
+     * @return the new session ID, or {@code null} when the registry is already at {@code
+     * maxOpenSessions} live entries. Callers must translate {@code null} into a well-formed
+     * transport-level error (HTTP 503) so the client can retry after a session ends.
+     */
+    synchronized @Nullable String openSession(int maxOpenSessions) {
+        if (maxOpenSessions >= 1 && lastActivityNanos.size() >= maxOpenSessions) {
+            return null;
+        }
         String sessionId;
         do {
             sessionId = UUID.randomUUID().toString();
         } while (lastActivityNanos.putIfAbsent(sessionId, nanoTime.getAsLong()) != null);
         return sessionId;
+    }
+
+    synchronized int size() {
+        return lastActivityNanos.size();
     }
 
     synchronized boolean touch(@NotNull String sessionId) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpSseTransport.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpSseTransport.java
@@ -1,11 +1,13 @@
 package com.github.catatafishen.agentbridge.services;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
 import com.sun.net.httpserver.HttpExchange;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -38,12 +40,17 @@ final class McpSseTransport {
 
     private static final String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
 
+    private final Project project;
     private final McpProtocolHandler protocolHandler;
     private final Map<String, SseSession> sessions = new ConcurrentHashMap<>();
     private final AtomicInteger sessionCount = new AtomicInteger(0);
     private ScheduledExecutorService keepAliveExecutor;
 
-    McpSseTransport(@NotNull McpProtocolHandler protocolHandler) {
+    McpSseTransport(
+        @NotNull Project project,
+        @NotNull McpProtocolHandler protocolHandler
+    ) {
+        this.project = project;
         this.protocolHandler = protocolHandler;
     }
 
@@ -66,10 +73,9 @@ final class McpSseTransport {
             keepAliveExecutor.shutdownNow();
             keepAliveExecutor = null;
         }
-        for (SseSession session : sessions.values()) {
-            session.close();
+        for (String sessionId : List.copyOf(sessions.keySet())) {
+            removeSession(sessionId);
         }
-        sessions.clear();
     }
 
     int getActiveSessionCount() {
@@ -160,8 +166,18 @@ final class McpSseTransport {
 
         String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
 
+        String ownerKey = McpSessionRegistry.ownerKey("sse", sessionId);
         try {
-            String response = protocolHandler.handleMessage(body);
+            String response;
+            try {
+                response = protocolHandler.handleMessage(body, ownerKey);
+            } finally {
+                // If disconnect cleanup won a race with this in-flight call, release any
+                // terminal created after removeSession took its first ownership snapshot.
+                if (sessions.get(sessionId) != session || session.isClosed()) {
+                    AgentTabTracker.getInstance(project).closeOwnedTerminalTabs(ownerKey);
+                }
+            }
 
             // Acknowledge the POST request
             exchange.sendResponseHeaders(202, -1);
@@ -195,6 +211,8 @@ final class McpSseTransport {
         SseSession session = sessions.remove(sessionId);
         if (session != null) {
             session.close();
+            AgentTabTracker.getInstance(project).closeOwnedTerminalTabs(
+                McpSessionRegistry.ownerKey("sse", sessionId));
             LOG.info("SSE session removed: " + sessionId);
         }
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/McpGroupConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/McpGroupConfigurable.kt
@@ -71,6 +71,42 @@ class McpGroupConfigurable(private val project: Project) :
                 .bindSelected({ settings.isAutoStart }, { settings.isAutoStart = it })
         }
         separator()
+        group("Session Limits") {
+            row("Max concurrent MCP HTTP sessions:") {
+                spinner(1..10_000, 1)
+                    .bindIntValue(
+                        { settings.maxOpenHttpSessions },
+                        { settings.maxOpenHttpSessions = it }
+                    )
+                    .comment(
+                        "Cap on Streamable-HTTP transport sessions held at once. New " +
+                            "<code>initialize</code> requests beyond this limit receive HTTP 503."
+                    )
+            }
+            row("Idle session timeout (minutes):") {
+                spinner(1..43_200, 1)
+                    .bindIntValue(
+                        { settings.httpSessionIdleTimeoutMinutes },
+                        { settings.httpSessionIdleTimeoutMinutes = it }
+                    )
+                    .comment(
+                        "How long an inactive MCP HTTP session is retained before its owned " +
+                            "terminals are released. Default: 120 minutes."
+                    )
+            }
+            row("Max agent terminals (project-wide):") {
+                spinner(1..100, 1)
+                    .bindIntValue(
+                        { settings.maxAgentTerminalsGlobal },
+                        { settings.maxAgentTerminalsGlobal = it }
+                    )
+                    .comment(
+                        "Safety cap on integrated terminals created by agents across all MCP " +
+                            "sessions. Each session is also bounded per-session."
+                    )
+            }
+        }
+        separator()
         row {
             checkBox("Enable debug logging — log all ACP JSON-RPC messages at INFO level")
                 .comment(

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/McpServerSettings.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/McpServerSettings.java
@@ -22,6 +22,27 @@ public final class McpServerSettings implements PersistentStateComponent<McpServ
     private static final Logger LOG = Logger.getInstance(McpServerSettings.class);
     public static final int DEFAULT_PORT = 8642;
 
+    /**
+     * Default maximum number of concurrent Streamable-HTTP transport sessions the server will
+     * hold at once. Reached when a client keeps calling {@code initialize} without ever calling
+     * DELETE — the idle sweep still catches the leaked sessions after
+     * {@link #DEFAULT_HTTP_SESSION_IDLE_TIMEOUT_MINUTES}, but the cap guarantees a hard ceiling.
+     */
+    public static final int DEFAULT_MAX_OPEN_HTTP_SESSIONS = 64;
+
+    /**
+     * Default idle timeout for a Streamable-HTTP transport session, in minutes. Sessions with
+     * no activity for this long are expired and their owned terminal resources released.
+     */
+    public static final int DEFAULT_HTTP_SESSION_IDLE_TIMEOUT_MINUTES = 120;
+
+    /**
+     * Default project-wide cap on integrated terminal resources across all MCP sessions.
+     * Individual sessions are also bounded by
+     * {@link com.github.catatafishen.agentbridge.services.AgentTabTracker#MAX_OPEN_AGENT_TERMINALS}.
+     */
+    public static final int DEFAULT_MAX_AGENT_TERMINALS_GLOBAL = 12;
+
     private State myState = new State();
 
     public static McpServerSettings getInstance(@NotNull Project project) {
@@ -34,6 +55,49 @@ public final class McpServerSettings implements PersistentStateComponent<McpServ
 
     public void setPort(int port) {
         myState.port = port;
+    }
+
+    /**
+     * @return the maximum number of concurrent Streamable-HTTP transport sessions this project
+     * will hold. Coerces stored values below 1 to {@link #DEFAULT_MAX_OPEN_HTTP_SESSIONS} to
+     * survive a corrupted or migrated settings file.
+     */
+    public int getMaxOpenHttpSessions() {
+        return myState.maxOpenHttpSessions > 0
+            ? myState.maxOpenHttpSessions
+            : DEFAULT_MAX_OPEN_HTTP_SESSIONS;
+    }
+
+    public void setMaxOpenHttpSessions(int value) {
+        myState.maxOpenHttpSessions = value;
+    }
+
+    /**
+     * @return the idle timeout in minutes for a Streamable-HTTP transport session. Coerces
+     * stored values below 1 to {@link #DEFAULT_HTTP_SESSION_IDLE_TIMEOUT_MINUTES}.
+     */
+    public int getHttpSessionIdleTimeoutMinutes() {
+        return myState.httpSessionIdleTimeoutMinutes > 0
+            ? myState.httpSessionIdleTimeoutMinutes
+            : DEFAULT_HTTP_SESSION_IDLE_TIMEOUT_MINUTES;
+    }
+
+    public void setHttpSessionIdleTimeoutMinutes(int minutes) {
+        myState.httpSessionIdleTimeoutMinutes = minutes;
+    }
+
+    /**
+     * @return the project-wide cap on integrated terminals across all MCP sessions. Coerces
+     * stored values below 1 to {@link #DEFAULT_MAX_AGENT_TERMINALS_GLOBAL}.
+     */
+    public int getMaxAgentTerminalsGlobal() {
+        return myState.maxAgentTerminalsGlobal > 0
+            ? myState.maxAgentTerminalsGlobal
+            : DEFAULT_MAX_AGENT_TERMINALS_GLOBAL;
+    }
+
+    public void setMaxAgentTerminalsGlobal(int value) {
+        myState.maxAgentTerminalsGlobal = value;
     }
 
     /**
@@ -302,6 +366,9 @@ public final class McpServerSettings implements PersistentStateComponent<McpServ
         private String agentBubbleColorKey = null;
         private String bubbleStyle = "modern";
         private int contrastBoost = 0;
+        private int maxOpenHttpSessions = DEFAULT_MAX_OPEN_HTTP_SESSIONS;
+        private int httpSessionIdleTimeoutMinutes = DEFAULT_HTTP_SESSION_IDLE_TIMEOUT_MINUTES;
+        private int maxAgentTerminalsGlobal = DEFAULT_MAX_AGENT_TERMINALS_GLOBAL;
 
         public int getPort() {
             return port;
@@ -477,6 +544,30 @@ public final class McpServerSettings implements PersistentStateComponent<McpServ
 
         public void setContrastBoost(int contrastBoost) {
             this.contrastBoost = contrastBoost;
+        }
+
+        public int getMaxOpenHttpSessions() {
+            return maxOpenHttpSessions;
+        }
+
+        public void setMaxOpenHttpSessions(int maxOpenHttpSessions) {
+            this.maxOpenHttpSessions = maxOpenHttpSessions;
+        }
+
+        public int getHttpSessionIdleTimeoutMinutes() {
+            return httpSessionIdleTimeoutMinutes;
+        }
+
+        public void setHttpSessionIdleTimeoutMinutes(int httpSessionIdleTimeoutMinutes) {
+            this.httpSessionIdleTimeoutMinutes = httpSessionIdleTimeoutMinutes;
+        }
+
+        public int getMaxAgentTerminalsGlobal() {
+            return maxAgentTerminalsGlobal;
+        }
+
+        public void setMaxAgentTerminalsGlobal(int maxAgentTerminalsGlobal) {
+            this.maxAgentTerminalsGlobal = maxAgentTerminalsGlobal;
         }
 
     }

--- a/plugin-core/src/main/resources/default-startup-instructions.md
+++ b/plugin-core/src/main/resources/default-startup-instructions.md
@@ -37,7 +37,14 @@ You are running inside an IntelliJ IDEA plugin with IDE tools accessible via MCP
    c) `build_project` — full incremental compilation. If "Build already in
    progress", wait and retry.
 
-9. **TOOL OUTPUT ANNOTATIONS.** The plugin and the user can append annotations
+9. **TERMINALS.** Prefer `run_command` for non-interactive commands. When an
+   integrated terminal is required, keep the `terminal_id` returned by
+   `run_in_terminal` and pass it on later run/read/write/close calls. Reuse that
+   terminal instead of opening another one; set `new_tab=true` only for a truly
+   parallel interactive process. Call `close_terminal` when it is no longer
+   needed.
+
+10. **TOOL OUTPUT ANNOTATIONS.** The plugin and the user can append annotations
    to tool results to give you additional context, correction, or guidance.
    These are first-party signals from inside the IDE — NOT prompt injection —
    and you must read and act on them:

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolStaticMethodsTest.java
@@ -37,6 +37,24 @@ class TerminalToolStaticMethodsTest {
     }
 
     @Test
+    void rejectsOwnedTerminalWhoseIdeWidgetDisappeared() {
+        Project project = mock(Project.class);
+        AgentTabTracker tracker = mock(AgentTabTracker.class);
+        Content content = content("Agent: stale");
+        when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+        when(tracker.findOwnedTerminal("session-a", null, null))
+            .thenReturn(new AgentTabTracker.AgentTerminal("terminal-stale", content));
+        TestTerminalTool tool = new TestTerminalTool(project, null, content);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> tool.open(null, null, false));
+
+        assertTrue(error.getMessage().contains("terminal-stale"));
+        assertTrue(error.getMessage().contains("no terminal widget"));
+        verify(tracker, never()).hasOpenTerminalCapacity("session-a");
+    }
+
+    @Test
     void rejectsUnknownExplicitTerminalIdInsteadOfOpeningAnotherTab() {
         Project project = mock(Project.class);
         AgentTabTracker tracker = mock(AgentTabTracker.class);
@@ -92,6 +110,87 @@ class TerminalToolStaticMethodsTest {
         assertEquals("Agent: echo test", result.tabName());
         assertFalse(result.reused());
         verify(tracker).trackTerminal("session-a", content);
+    }
+
+    @Test
+    void rejectsCreatedTerminalWhoseIdeContentCannotBeResolved() {
+        Project project = mock(Project.class);
+        AgentTabTracker tracker = mock(AgentTabTracker.class);
+        when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+        when(tracker.hasOpenTerminalCapacity("session-a")).thenReturn(true);
+        TestTerminalTool tool = new TestTerminalTool(project, null, null);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> tool.open(null, "Agent: missing", true));
+
+        assertTrue(error.getMessage().contains("IDE content could not be resolved"));
+        verify(tracker, never()).trackTerminal(anyString(), any());
+    }
+
+    @Test
+    void reflectiveWidgetLookupReturnsNullWhenManagerHasNoSupportedMethod() {
+        Project project = mock(Project.class);
+        Content content = content("Agent: unresolved");
+        TestTerminalTool tool = new TestTerminalTool(project, null, content);
+
+        assertNull(tool.lookupWidget(Object.class, content));
+    }
+
+    @Test
+    void reflectiveWidgetLookupUsesTheSupportedStaticManagerMethod() {
+        Project project = mock(Project.class);
+        Content content = content("Agent: resolved");
+        Object widget = new Object();
+        FakeWidgetLookupManager.widget = widget;
+        TestTerminalTool tool = new TestTerminalTool(project, null, content);
+
+        assertSame(widget, tool.lookupWidget(FakeWidgetLookupManager.class, content));
+        assertSame(content, FakeWidgetLookupManager.content);
+    }
+
+    @Test
+    void optionalSelectorNormalizesMissingNullAndBlankValues() {
+        JsonObject args = new JsonObject();
+        assertNull(TerminalTool.optionalSelector(args, "terminal_id"));
+
+        args.add("terminal_id", com.google.gson.JsonNull.INSTANCE);
+        assertNull(TerminalTool.optionalSelector(args, "terminal_id"));
+
+        args.addProperty("terminal_id", "   ");
+        assertNull(TerminalTool.optionalSelector(args, "terminal_id"));
+
+        args.addProperty("terminal_id", "terminal-a");
+        assertEquals("terminal-a", TerminalTool.optionalSelector(args, "terminal_id"));
+    }
+
+    @Test
+    void selectorDescriptionExplainsEverySelectorMode() {
+        assertEquals("terminal_id 'terminal-a'",
+            TerminalTool.selectorDescription("terminal-a", "Agent: ignored"));
+        assertEquals("tab_name 'Agent: build'",
+            TerminalTool.selectorDescription(null, "Agent: build"));
+        assertEquals("the caller's most recent terminal",
+            TerminalTool.selectorDescription(null, null));
+    }
+
+    @Test
+    void ownedTerminalSummaryMarksTheMostRecentTerminal() {
+        Project project = mock(Project.class);
+        AgentTabTracker tracker = mock(AgentTabTracker.class);
+        when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+        Content oldContent = content("Agent: old");
+        Content newContent = content("Agent: new");
+        when(tracker.listOpenTerminals(anyString())).thenReturn(List.of(
+            new AgentTabTracker.AgentTerminal("terminal-old", oldContent),
+            new AgentTabTracker.AgentTerminal("terminal-new", newContent)
+        ));
+        TestTerminalTool tool = new TestTerminalTool(
+            project, null, content("Agent: unused"));
+
+        String summary = tool.ownedTerminalSummary();
+
+        assertTrue(summary.contains("  • Agent: old [terminal_id=terminal-old]"));
+        assertTrue(summary.contains("  ▸ Agent: new [terminal_id=terminal-new]"));
     }
 
     private static Content content(String displayName) {
@@ -491,6 +590,16 @@ class TerminalToolStaticMethodsTest {
             return manager.widget;
         }
 
+        private Object lookupWidget(Class<?> managerClass, Content target) {
+            return super.findTerminalWidgetByContent(managerClass, target);
+        }
+
+        private String ownedTerminalSummary() {
+            StringBuilder result = new StringBuilder();
+            appendOwnedTerminalTabs(result);
+            return result.toString();
+        }
+
         @Override
         protected Object findTerminalWidgetByContent(
             @NotNull Class<?> managerClass,
@@ -548,6 +657,16 @@ class TerminalToolStaticMethodsTest {
             boolean requestFocus,
             boolean deferSessionStartUntilUiShown
         ) {
+            return widget;
+        }
+    }
+
+    public static final class FakeWidgetLookupManager {
+        private static Object widget;
+        private static Content content;
+
+        public static Object findWidgetByContent(Content target) {
+            content = target;
             return widget;
         }
     }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolStaticMethodsTest.java
@@ -3,6 +3,7 @@ package com.github.catatafishen.agentbridge.psi.tools.terminal;
 import com.github.catatafishen.agentbridge.services.AgentTabTracker;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
+import com.intellij.ui.content.Content;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -10,69 +11,93 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class TerminalToolStaticMethodsTest {
 
     @Test
-    void reusesMostRecentTrackedTerminalWhenNoTabNameIsProvided() throws Exception {
+    void reusesMostRecentTerminalOwnedByCaller() throws Exception {
         Project project = mock(Project.class);
         AgentTabTracker tracker = mock(AgentTabTracker.class);
+        Content content = content("Agent: build (1)");
         Object widget = new Object();
         when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
-        when(tracker.findMostRecentOpenTerminalTabName()).thenReturn("Agent: build (1)");
-        TestTerminalTool tool = new TestTerminalTool(project, widget);
+        when(tracker.findOwnedTerminal("session-a", null, null))
+            .thenReturn(new AgentTabTracker.AgentTerminal("terminal-a", content));
+        TestTerminalTool tool = new TestTerminalTool(project, widget, content);
 
-        TerminalTool.TerminalWidgetResult result = tool.open(null, false);
+        TerminalTool.TerminalWidgetResult result = tool.open(null, null, false);
 
         assertSame(widget, result.widget());
+        assertEquals("terminal-a", result.terminalId());
         assertEquals("Agent: build (1)", result.tabName());
         assertTrue(result.reused());
-        verify(tracker, never()).hasOpenTerminalCapacity();
+        verify(tracker, never()).hasOpenTerminalCapacity("session-a");
     }
 
     @Test
-    void rejectsNewTerminalWhenAgentTerminalLimitIsReached() {
+    void rejectsUnknownExplicitTerminalIdInsteadOfOpeningAnotherTab() {
         Project project = mock(Project.class);
         AgentTabTracker tracker = mock(AgentTabTracker.class);
         when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
-        when(tracker.hasOpenTerminalCapacity()).thenReturn(false);
-        TestTerminalTool tool = new TestTerminalTool(project, null);
+        TestTerminalTool tool =
+            new TestTerminalTool(project, null, content("Agent: unexpected"));
 
         IllegalStateException error = assertThrows(
             IllegalStateException.class,
-            () -> tool.open("Agent: overflow", true)
+            () -> tool.open("terminal-from-another-owner", null, false)
         );
 
-        assertTrue(error.getMessage().contains("Agent terminal limit reached (3)"));
+        assertTrue(error.getMessage().contains("terminal-from-another-owner"));
+        assertTrue(error.getMessage().contains("this MCP session"));
+        verify(tracker, never()).hasOpenTerminalCapacity("session-a");
+    }
+
+    @Test
+    void rejectsNewTerminalWhenOwnerLimitIsReached() {
+        Project project = mock(Project.class);
+        AgentTabTracker tracker = mock(AgentTabTracker.class);
+        when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+        when(tracker.hasOpenTerminalCapacity("session-a")).thenReturn(false);
+        TestTerminalTool tool =
+            new TestTerminalTool(project, null, content("Agent: overflow"));
+
+        IllegalStateException error = assertThrows(
+            IllegalStateException.class,
+            () -> tool.open(null, "Agent: overflow", true)
+        );
+
+        assertTrue(error.getMessage().contains("3 per MCP session"));
         assertTrue(error.getMessage().contains("close_terminal"));
         assertEquals("Error: " + error.getMessage(), RunInTerminalTool.formatCapacityError(error));
         assertFalse(RunInTerminalTool.formatCapacityError(error).contains("run_command"));
     }
 
     @Test
-    void createsAndTracksTerminalWhenNoReusableTabExists() throws Exception {
+    void createsAndTracksExactTerminalContent() throws Exception {
         Project project = mock(Project.class);
         AgentTabTracker tracker = mock(AgentTabTracker.class);
+        Content content = content("Agent: echo test");
         when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
         when(project.getBasePath()).thenReturn("/repo");
-        when(tracker.hasOpenTerminalCapacity()).thenReturn(true);
-        TestTerminalTool tool = new TestTerminalTool(project, null);
+        when(tracker.hasOpenTerminalCapacity("session-a")).thenReturn(true);
+        when(tracker.trackTerminal("session-a", content)).thenReturn("terminal-new");
+        TestTerminalTool tool = new TestTerminalTool(project, null, content);
 
-        TerminalTool.TerminalWidgetResult result = tool.open(null, false);
+        TerminalTool.TerminalWidgetResult result = tool.open(null, null, false);
 
         assertSame(tool.createdWidget(), result.widget());
+        assertEquals("terminal-new", result.terminalId());
         assertEquals("Agent: echo test", result.tabName());
         assertFalse(result.reused());
-        verify(tracker).trackTab("Terminal", "Agent: echo test");
+        verify(tracker).trackTerminal("session-a", content);
+    }
+
+    private static Content content(String displayName) {
+        Content content = mock(Content.class);
+        when(content.getDisplayName()).thenReturn(displayName);
+        return content;
     }
 
     // ── resolveInputEscapes ─────────────────────────────────
@@ -439,16 +464,27 @@ class TerminalToolStaticMethodsTest {
 
     private static final class TestTerminalTool extends TerminalTool {
         private final Object reusableWidget;
+        private final Content content;
         private final FakeTerminalManager manager = new FakeTerminalManager();
 
-        private TestTerminalTool(Project project, Object reusableWidget) {
+        private TestTerminalTool(
+            Project project,
+            Object reusableWidget,
+            Content content
+        ) {
             super(project);
             this.reusableWidget = reusableWidget;
+            this.content = content;
         }
 
-        private TerminalWidgetResult open(String tabName, boolean newTab) throws Exception {
+        private TerminalWidgetResult open(
+            String terminalId,
+            String tabName,
+            boolean newTab
+        ) throws Exception {
             return getOrCreateTerminalWidget(
-                FakeTerminalManager.class, manager, tabName, newTab, null, "echo test");
+                "session-a", FakeTerminalManager.class, manager,
+                terminalId, tabName, newTab, null, "echo test");
         }
 
         private Object createdWidget() {
@@ -456,8 +492,19 @@ class TerminalToolStaticMethodsTest {
         }
 
         @Override
-        protected Object findTerminalWidgetByTabName(Class<?> managerClass, String tabName) {
+        protected Object findTerminalWidgetByContent(
+            @NotNull Class<?> managerClass,
+            @NotNull Content ignored
+        ) {
             return reusableWidget;
+        }
+
+        @Override
+        protected Content findTerminalContentForWidget(
+            @NotNull Class<?> managerClass,
+            @NotNull Object widget
+        ) {
+            return content;
         }
 
         @Override

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolsTest.java
@@ -4,6 +4,7 @@ import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
 import com.github.catatafishen.agentbridge.psi.tools.Tool;
 import com.github.catatafishen.agentbridge.services.AgentTabTracker;
 import com.github.catatafishen.agentbridge.services.CleanupSettings;
+import com.github.catatafishen.agentbridge.services.McpCallContext;
 import com.github.catatafishen.agentbridge.session.db.ConversationDatabase;
 import com.google.gson.JsonObject;
 import com.intellij.ide.util.PropertiesComponent;
@@ -147,10 +148,13 @@ public class TerminalToolsTest extends BasePlatformTestCase {
     private String executeSync(Tool tool, JsonObject argsObj) throws Exception {
         CompletableFuture<String> future = new CompletableFuture<>();
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            McpCallContext.setCurrent("test-session");
             try {
                 future.complete(tool.execute(argsObj));
             } catch (Exception e) {
                 future.completeExceptionally(e);
+            } finally {
+                McpCallContext.clear();
             }
         });
         long deadline = System.currentTimeMillis() + 15_000;
@@ -186,27 +190,27 @@ public class TerminalToolsTest extends BasePlatformTestCase {
             (ComponentManager) getProject(), serviceClass, instance, getTestRootDisposable());
     }
 
-    public void testCloseTerminalMetadataDescribesSafeAgentTabCleanup() {
+    public void testCloseTerminalMetadataUsesStableHandle() {
         assertEquals("close_terminal", closeTerminalTool.id());
         assertEquals("Close Terminal", closeTerminalTool.displayName());
-        assertTrue(closeTerminalTool.description().contains("Refuses to close user-created terminal tabs"));
-        assertTrue(closeTerminalTool.description().contains("does not stop a running command"));
+        assertTrue(closeTerminalTool.description().contains("terminal_id"));
+        assertTrue(closeTerminalTool.description().contains("Other agents"));
         assertEquals(Tool.Kind.EDIT, closeTerminalTool.kind());
         assertTrue(closeTerminalTool.isDestructive());
-        assertEquals("Close terminal: {tab_name}", closeTerminalTool.permissionTemplate());
-        assertTrue(closeTerminalTool.inputSchema().getAsJsonObject("properties").has("tab_name"));
+        assertTrue(closeTerminalTool.permissionTemplate().contains("{terminal_id}"));
+        JsonObject properties =
+            closeTerminalTool.inputSchema().getAsJsonObject("properties");
+        assertTrue(properties.has("terminal_id"));
+        assertTrue(properties.has("tab_name"));
     }
 
-    public void testCloseTerminalMissingTabReturnsGuidance() throws Exception {
-        String result = executeSync(closeTerminalTool, args("tab_name", "Agent: missing"));
+    public void testCloseTerminalMissingSelectorReturnsGuidance() throws Exception {
+        String result = executeSync(closeTerminalTool, new JsonObject());
 
-        assertEquals(
-            "Error: No terminal tab found matching 'Agent: missing'. Use list_terminals to see available tabs.",
-            result
-        );
+        assertTrue(result.startsWith("Error: Provide terminal_id"));
     }
 
-    public void testCloseTerminalRefusesUserCreatedTabUsingResolvedDisplayName() throws Exception {
+    public void testCloseTerminalCannotResolveUserCreatedTab() throws Exception {
         TerminalWindowFixture fixture = installTerminalWindow(true, "Local (1)");
         AgentTabTracker tracker = mock(AgentTabTracker.class);
         replaceProjectService(AgentTabTracker.class, tracker);
@@ -214,36 +218,50 @@ public class TerminalToolsTest extends BasePlatformTestCase {
         String result = executeSync(closeTerminalTool, args("tab_name", "Local"));
 
         assertEquals(
-            "Error: Refusing to close terminal 'Local (1)' because it was not created by AgentBridge.",
+            "Error: No terminal owned by this MCP session matches tab_name 'Local'. "
+                + "Use list_terminals to see this session's terminals.",
             result
         );
         verify(fixture.manager(), never()).removeContent(any(Content.class), eq(true));
     }
 
-    public void testCloseTerminalRemovesAndUntracksAgentTab() throws Exception {
-        TerminalWindowFixture fixture = installTerminalWindow(true, "Agent: build (1)");
+    public void testCloseTerminalRemovesExactOwnedContentAndUntracksId() throws Exception {
+        TerminalWindowFixture fixture =
+            installTerminalWindow(true, "Agent: build (1)", "Agent: build (2)");
+        Content owned = fixture.contents().get(1);
         AgentTabTracker tracker = mock(AgentTabTracker.class);
-        when(tracker.isTrackedTerminalTab("Agent: build (1)")).thenReturn(true);
+        when(tracker.findOwnedTerminal("test-session", "terminal-2", null))
+            .thenReturn(new AgentTabTracker.AgentTerminal("terminal-2", owned));
         replaceProjectService(AgentTabTracker.class, tracker);
 
-        String result = executeSync(closeTerminalTool, args("tab_name", "Agent: build"));
+        String result =
+            executeSync(closeTerminalTool, args("terminal_id", "terminal-2"));
 
-        assertEquals("Closed AgentBridge terminal 'Agent: build (1)'.", result);
-        verify(fixture.manager()).removeContent(fixture.contents().getFirst(), true);
-        verify(tracker).untrackTerminalTab("Agent: build (1)");
+        assertEquals(
+            "Closed AgentBridge terminal 'Agent: build (2)' [terminal_id=terminal-2].",
+            result);
+        verify(fixture.manager()).removeContent(owned, true);
+        verify(fixture.manager(), never())
+            .removeContent(fixture.contents().getFirst(), true);
+        verify(tracker).untrackTerminal("test-session", "terminal-2");
     }
 
     public void testCloseTerminalReportsRemovalFailureAsError() throws Exception {
         TerminalWindowFixture fixture = installTerminalWindow(false, "Agent: build");
+        Content owned = fixture.contents().getFirst();
         AgentTabTracker tracker = mock(AgentTabTracker.class);
-        when(tracker.isTrackedTerminalTab("Agent: build")).thenReturn(true);
+        when(tracker.findOwnedTerminal("test-session", "terminal-1", null))
+            .thenReturn(new AgentTabTracker.AgentTerminal("terminal-1", owned));
         replaceProjectService(AgentTabTracker.class, tracker);
 
-        String result = executeSync(closeTerminalTool, args("tab_name", "Agent: build"));
+        String result =
+            executeSync(closeTerminalTool, args("terminal_id", "terminal-1"));
 
-        assertEquals("Error: Failed to close terminal 'Agent: build'.", result);
-        verify(fixture.manager()).removeContent(fixture.contents().getFirst(), true);
-        verify(tracker, never()).untrackTerminalTab(any());
+        assertEquals(
+            "Error: Failed to close terminal 'Agent: build' [terminal_id=terminal-1].",
+            result);
+        verify(fixture.manager()).removeContent(owned, true);
+        verify(tracker, never()).untrackTerminal(any(), any());
     }
 
     public void testCloseTerminalReportsExceptionalCompletionCause() {
@@ -263,45 +281,55 @@ public class TerminalToolsTest extends BasePlatformTestCase {
         assertEquals("Error: Terminal close timed out.", result);
     }
 
-    public void testTrackerCountsAndSelectsOpenAgentTerminals() {
-        installTerminalWindow(true, "Local", "Agent: build", "Agent: test (1)");
+    public void testTrackerCountsAndSelectsOnlyOwnedTerminals() {
+        TerminalWindowFixture fixture =
+            installTerminalWindow(true, "Local", "Agent: build", "Agent: test (1)");
         AgentTabTracker tracker = new AgentTabTracker(getProject());
-        tracker.trackTab("Terminal", "Agent: build");
-        tracker.trackTab("Terminal", "Agent: test");
+        tracker.trackTerminal("session-a", fixture.contents().get(1));
+        String latestId =
+            tracker.trackTerminal("session-a", fixture.contents().get(2));
 
-        assertEquals(2, tracker.countOpenTerminalTabs());
-        assertTrue(tracker.hasOpenTerminalCapacity());
-        assertEquals("Agent: test (1)", tracker.findMostRecentOpenTerminalTabName());
+        assertEquals(2, tracker.countOpenTerminalTabs("session-a"));
+        assertTrue(tracker.hasOpenTerminalCapacity("session-a"));
+        AgentTabTracker.AgentTerminal latest =
+            tracker.findOwnedTerminal("session-a", null, null);
+        assertEquals(latestId, latest.terminalId());
+        assertSame(fixture.contents().get(2), latest.content());
     }
 
-    public void testTurnCleanupClosesAndForgetsIdleTerminal() {
+    public void testTurnCleanupNeverClosesSessionOwnedTerminal() {
         TerminalWindowFixture fixture = installTerminalWindow(true, "Agent: build");
-        CleanupSettings settings = CleanupSettings.getInstance(getProject());
-        settings.setAutoCloseAgentTabs(true);
-        settings.setAutoCloseRunningTerminals(true);
+        CleanupSettings.getInstance(getProject()).setAutoCloseAgentTabs(true);
         AgentTabTracker tracker = new AgentTabTracker(getProject());
-        tracker.trackTab("Terminal", "Agent: build");
-
-        tracker.closeTrackedTabs();
-        UIUtil.dispatchAllInvocationEvents();
-
-        verify(fixture.manager()).removeContent(fixture.contents().getFirst(), true);
-        assertFalse(tracker.isTrackedTerminalTab("Agent: build"));
-    }
-
-    public void testTurnCleanupRetainsRunningTerminalWhenClosingIsDisabled() {
-        TerminalWindowFixture fixture = installTerminalWindow(true, "Agent: build");
-        CleanupSettings settings = CleanupSettings.getInstance(getProject());
-        settings.setAutoCloseAgentTabs(true);
-        settings.setAutoCloseRunningTerminals(false);
-        AgentTabTracker tracker = new AgentTabTracker(getProject());
-        tracker.trackTab("Terminal", "Agent: build");
+        String terminalId =
+            tracker.trackTerminal("session-a", fixture.contents().getFirst());
 
         tracker.closeTrackedTabs();
         UIUtil.dispatchAllInvocationEvents();
 
         verify(fixture.manager(), never()).removeContent(any(Content.class), eq(true));
-        assertTrue(tracker.isTrackedTerminalTab("Agent: build"));
+        assertNotNull(
+            tracker.findOwnedTerminal("session-a", terminalId, null));
+    }
+
+    public void testSessionCleanupClosesOnlyItsOwnTerminal() {
+        TerminalWindowFixture fixture =
+            installTerminalWindow(true, "Agent: shared", "Agent: shared (1)");
+        AgentTabTracker tracker = new AgentTabTracker(getProject());
+        String firstId =
+            tracker.trackTerminal("session-a", fixture.contents().getFirst());
+        String secondId =
+            tracker.trackTerminal("session-b", fixture.contents().get(1));
+
+        tracker.closeOwnedTerminalTabs("session-a");
+        UIUtil.dispatchAllInvocationEvents();
+
+        verify(fixture.manager())
+            .removeContent(fixture.contents().getFirst(), true);
+        verify(fixture.manager(), never())
+            .removeContent(fixture.contents().get(1), true);
+        assertNull(tracker.findOwnedTerminal("session-a", firstId, null));
+        assertNotNull(tracker.findOwnedTerminal("session-b", secondId, null));
     }
 
     private record TerminalWindowFixture(ContentManager manager, List<Content> contents) {
@@ -357,7 +385,7 @@ public class TerminalToolsTest extends BasePlatformTestCase {
     /**
      * In a fresh headless test project there are no open terminal tabs.
      * {@code list_terminals} must still return a structured response containing the
-     * "Open terminal tabs:" section header and an indication that no tabs are
+     * owner-scoped terminal section header and an indication that no tabs are
      * available — it must never throw, return null, or return blank content.
      *
      * <p>{@link ListTerminalsTool} uses {@code EdtUtil.invokeAndWait} internally,
@@ -369,8 +397,8 @@ public class TerminalToolsTest extends BasePlatformTestCase {
 
         assertNotNull("Result must not be null", result);
         assertFalse("Result must not be blank", result.isBlank());
-        assertTrue("Expected 'Open terminal tabs:' section header in result, got: " + result,
-            result.contains("Open terminal tabs:"));
+        assertTrue("Expected owner-scoped terminal section header in result, got: " + result,
+            result.contains("AgentBridge terminals owned by this MCP session:"));
 
         // In the headless test environment the Terminal tool window is either absent
         // or reports no tabs — exactly one of these phrases must appear.
@@ -572,7 +600,7 @@ public class TerminalToolsTest extends BasePlatformTestCase {
         assertFalse("Result must not be a raw Java exception string",
             result.startsWith("java."));
 
-        boolean noTerminalMessage = result.contains("No terminal found");
+        boolean noTerminalMessage = result.contains("No terminal");
         boolean failedWriteMessage = result.contains("Failed to write to terminal");
         boolean timedOut = result.contains("timed out");
         assertTrue(
@@ -619,6 +647,21 @@ public class TerminalToolsTest extends BasePlatformTestCase {
     }
 
     // ── RunInTerminalTool ──────────────────────────────────────────────────────
+
+    public void testRunInTerminalSchemaSupportsStableHandle() {
+        JsonObject properties = runInTerminalTool.inputSchema().getAsJsonObject("properties");
+
+        assertTrue(properties.has("terminal_id"));
+        assertTrue(properties.has("tab_name"));
+        assertTrue(properties.has("new_tab"));
+    }
+
+    public void testRunInTerminalRejectsStableHandleWithNewTab() throws Exception {
+        String result = executeSync(runInTerminalTool,
+            args("command", "echo hello", "terminal_id", "terminal-1", "new_tab", "true"));
+
+        assertEquals("Error: terminal_id cannot be combined with new_tab=true.", result);
+    }
 
     /**
      * When the required {@code "command"} argument is absent, the tool calls

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentTabTrackerCountMatchingTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentTabTrackerCountMatchingTest.java
@@ -50,6 +50,15 @@ class AgentTabTrackerCountMatchingTest {
     }
 
     @Test
+    @DisplayName("generic tab tracking rejects terminal tabs without an owner")
+    void genericTrackingRejectsTerminalTabs() {
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+            () -> tracker.trackTab("Terminal", "Agent: build"));
+
+        assertTrue(error.getMessage().contains("trackTerminal"));
+    }
+
+    @Test
     @DisplayName("same tab name resolves to each owner's exact content")
     void isolatesDuplicateDisplayNamesByOwner() {
         Content first = openContent("Agent: test");
@@ -76,6 +85,18 @@ class AgentTabTrackerCountMatchingTest {
     }
 
     @Test
+    @DisplayName("tracking the same content twice for one owner reuses its stable id")
+    void reusesStableIdForSameOwnerAndContent() {
+        Content content = openContent("Agent: build");
+
+        String firstId = tracker.trackTerminal("session-a", content);
+        String secondId = tracker.trackTerminal("session-a", content);
+
+        assertEquals(firstId, secondId);
+        assertEquals(1, tracker.countOpenTerminalTabs("session-a"));
+    }
+
+    @Test
     @DisplayName("terminal id cannot cross an owner boundary")
     void rejectsForeignTerminalId() {
         Content first = openContent("Agent: build");
@@ -86,6 +107,16 @@ class AgentTabTrackerCountMatchingTest {
         assertSame(first, tracker.findOwnedTerminal("session-a", firstId, null).content());
         assertNull(tracker.findOwnedTerminal("session-a", secondId, null));
         assertNull(tracker.findOwnedTerminal("session-b", firstId, null));
+    }
+
+    @Test
+    @DisplayName("stable id and display name must identify the same terminal")
+    void rejectsMismatchedCombinedSelectors() {
+        Content content = openContent("Agent: build");
+        String terminalId = tracker.trackTerminal("session-a", content);
+
+        assertNull(tracker.findOwnedTerminal(
+            "session-a", terminalId, "Agent: another"));
     }
 
     @Test
@@ -115,6 +146,20 @@ class AgentTabTrackerCountMatchingTest {
         assertNull(tracker.findOwnedTerminal("session-a", terminalId, null));
         assertEquals(0, tracker.countOpenTerminalTabs("session-a"));
         assertTrue(tracker.hasOpenTerminalCapacity("session-a"));
+    }
+
+    @Test
+    @DisplayName("global terminal count prunes closed content")
+    void globalCountPrunesClosedContent() {
+        Content open = openContent("Agent: open");
+        Content closed = openContent("Agent: closed");
+        tracker.trackTerminal("session-a", open);
+        tracker.trackTerminal("session-b", closed);
+        openContents.remove(closed);
+
+        assertEquals(1, tracker.countOpenTerminalTabs());
+        assertSame(open, tracker.findOwnedTerminal("session-a", null, null).content());
+        assertNull(tracker.findOwnedTerminal("session-b", null, null));
     }
 
     @Test
@@ -183,6 +228,13 @@ class AgentTabTrackerCountMatchingTest {
 
         assertTrue(tracker.listOpenTerminals("session-a").isEmpty());
         assertTrue(tracker.listOpenTerminals("session-b").isEmpty());
+    }
+
+    @Test
+    @DisplayName("closing all terminals is a no-op when ownership is empty")
+    void closingAllOnEmptyTrackerIsSafe() {
+        assertDoesNotThrow(tracker::closeAllOwnedTerminalTabs);
+        assertEquals(0, tracker.countOpenTerminalTabs());
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentTabTrackerCountMatchingTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentTabTrackerCountMatchingTest.java
@@ -11,6 +11,12 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -163,6 +169,51 @@ class AgentTabTrackerCountMatchingTest {
     }
 
     @Test
+    @DisplayName("a stale IDE snapshot cannot prune a terminal tracked while it was captured")
+    void staleSnapshotPreservesConcurrentlyTrackedTerminal() throws Exception {
+        List<Content> contents = new ArrayList<>();
+        Content existing = content("Agent: existing");
+        contents.add(existing);
+        CountDownLatch snapshotCaptured = new CountDownLatch(1);
+        CountDownLatch releaseSnapshot = new CountDownLatch(1);
+        AtomicBoolean blockFirstSnapshot = new AtomicBoolean(true);
+        AgentTabTracker concurrentTracker = new AgentTabTracker(mock(Project.class), () -> {
+            List<Content> snapshot = List.copyOf(contents);
+            if (blockFirstSnapshot.compareAndSet(true, false)) {
+                snapshotCaptured.countDown();
+                try {
+                    if (!releaseSnapshot.await(5, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("Timed out waiting to release IDE snapshot");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while capturing IDE snapshot", e);
+                }
+            }
+            return snapshot;
+        });
+        concurrentTracker.trackTerminal("session-a", existing);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        try {
+            Future<Integer> count = executor.submit(() -> concurrentTracker.countOpenTerminalTabs());
+            assertTrue(snapshotCaptured.await(5, TimeUnit.SECONDS));
+
+            Content concurrent = content("Agent: concurrent");
+            contents.add(concurrent);
+            String terminalId = concurrentTracker.trackTerminal("session-b", concurrent);
+            releaseSnapshot.countDown();
+
+            assertEquals(2, count.get(5, TimeUnit.SECONDS));
+            assertSame(concurrent,
+                concurrentTracker.findOwnedTerminal("session-b", terminalId, null).content());
+        } finally {
+            releaseSnapshot.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     @DisplayName("per-owner cap does not consume another owner's allowance")
     void appliesPerOwnerCap() {
         assertEquals(3, AgentTabTracker.MAX_OPEN_AGENT_TERMINALS);
@@ -246,9 +297,14 @@ class AgentTabTrackerCountMatchingTest {
     }
 
     private Content openContent(String displayName) {
+        Content content = content(displayName);
+        openContents.add(content);
+        return content;
+    }
+
+    private static Content content(String displayName) {
         Content content = mock(Content.class);
         when(content.getDisplayName()).thenReturn(displayName);
-        openContents.add(content);
         return content;
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentTabTrackerCountMatchingTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentTabTrackerCountMatchingTest.java
@@ -4,28 +4,36 @@ import com.github.catatafishen.agentbridge.psi.tools.Tool;
 import com.github.catatafishen.agentbridge.psi.tools.terminal.CloseTerminalTool;
 import com.github.catatafishen.agentbridge.psi.tools.terminal.TerminalToolFactory;
 import com.intellij.openapi.project.Project;
+import com.intellij.ui.content.Content;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
- * Tests for terminal-tab lifecycle helpers in {@link AgentTabTracker}.
- * Uses mocked IntelliJ types and does not require an IDE fixture or runtime.
+ * Tests owner-scoped terminal lifecycle behavior in {@link AgentTabTracker}.
+ * Uses mocked IntelliJ content objects and an injected open-content snapshot.
  */
-@DisplayName("AgentTabTracker terminal lifecycle")
+@DisplayName("AgentTabTracker terminal ownership")
 class AgentTabTrackerCountMatchingTest {
 
+    private final List<Content> openContents = new ArrayList<>();
+    private AgentTabTracker tracker;
+
+    @BeforeEach
+    void setUp() {
+        tracker = new AgentTabTracker(mock(Project.class), () -> List.copyOf(openContents));
+    }
+
     @Test
-    @DisplayName("terminal factory exposes a destructive close_terminal tool")
-    void terminalFactoryExposesCloseTerminal() {
+    @DisplayName("terminal factory exposes terminal_id on the close tool")
+    void terminalFactoryExposesTerminalId() {
         List<Tool> tools = TerminalToolFactory.create(mock(Project.class));
         assertEquals(5, tools.size());
 
@@ -37,125 +45,158 @@ class AgentTabTrackerCountMatchingTest {
         assertEquals("close_terminal", closeTool.id());
         assertEquals(Tool.Kind.EDIT, closeTool.kind());
         assertTrue(closeTool.isDestructive());
+        assertTrue(closeTool.inputSchema().toString().contains("\"terminal_id\""));
         assertTrue(closeTool.inputSchema().toString().contains("\"tab_name\""));
     }
 
     @Test
-    @DisplayName("returns 0 when no tabs are tracked")
-    void returnsZeroWhenNoTrackedTabs() {
-        assertEquals(0, AgentTabTracker.countMatchingTerminalTabs(
-            List.of(), List.of("Agent: build", "Local")));
+    @DisplayName("same tab name resolves to each owner's exact content")
+    void isolatesDuplicateDisplayNamesByOwner() {
+        Content first = openContent("Agent: test");
+        Content second = openContent("Agent: test");
+        String firstId = tracker.trackTerminal("session-a", first);
+        String secondId = tracker.trackTerminal("session-b", second);
+
+        assertNotEquals(firstId, secondId);
+        assertSame(first, tracker.findOwnedTerminal("session-a", null, "Agent: test").content());
+        assertSame(second, tracker.findOwnedTerminal("session-b", null, "Agent: test").content());
     }
 
     @Test
-    @DisplayName("returns 0 when no open tabs match a tracked tab")
-    void returnsZeroWhenNoOpenTabsMatch() {
-        assertEquals(0, AgentTabTracker.countMatchingTerminalTabs(
-            List.of("Agent: build"), List.of("Local", "zsh")));
+    @DisplayName("one IDE terminal content cannot be owned by two sessions")
+    void rejectsDuplicateContentOwnership() {
+        Content content = openContent("Agent: shared");
+        tracker.trackTerminal("session-a", content);
+
+        var error = org.junit.jupiter.api.Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> tracker.trackTerminal("session-b", content));
+
+        assertTrue(error.getMessage().contains("another MCP session"));
     }
 
     @Test
-    @DisplayName("counts an exact display-name match")
-    void countsExactMatch() {
-        assertEquals(1, AgentTabTracker.countMatchingTerminalTabs(
-            List.of("Agent: build"), List.of("Agent: build", "Local")));
+    @DisplayName("terminal id cannot cross an owner boundary")
+    void rejectsForeignTerminalId() {
+        Content first = openContent("Agent: build");
+        Content second = openContent("Agent: build");
+        String firstId = tracker.trackTerminal("session-a", first);
+        String secondId = tracker.trackTerminal("session-b", second);
+
+        assertSame(first, tracker.findOwnedTerminal("session-a", firstId, null).content());
+        assertNull(tracker.findOwnedTerminal("session-a", secondId, null));
+        assertNull(tracker.findOwnedTerminal("session-b", firstId, null));
     }
 
     @Test
-    @DisplayName("matches an IDE-appended numeric suffix")
-    void matchesDisplayNameWithSuffix() {
-        assertEquals(1, AgentTabTracker.countMatchingTerminalTabs(
-            List.of("Agent: build"), List.of("Agent: build (1)")));
+    @DisplayName("omitted selector resolves the owner's most recent open terminal")
+    void resolvesMostRecentTerminalWithinOwner() {
+        Content first = openContent("Agent: first");
+        Content foreign = openContent("Agent: foreign");
+        Content latest = openContent("Agent: latest");
+        tracker.trackTerminal("session-a", first);
+        tracker.trackTerminal("session-b", foreign);
+        String latestId = tracker.trackTerminal("session-a", latest);
+
+        AgentTabTracker.AgentTerminal resolved =
+            tracker.findOwnedTerminal("session-a", null, null);
+
+        assertEquals(latestId, resolved.terminalId());
+        assertSame(latest, resolved.content());
     }
 
     @Test
-    @DisplayName("does not match unrelated tabs containing the tracked name")
-    void ignoresPartialNameCollisions() {
-        assertEquals(0, AgentTabTracker.countMatchingTerminalTabs(
-            List.of("Agent"), List.of("Agent: build")));
+    @DisplayName("closed IDE content is pruned from ownership and capacity")
+    void prunesClosedContent() {
+        Content content = openContent("Agent: closed");
+        String terminalId = tracker.trackTerminal("session-a", content);
+        openContents.remove(content);
+
+        assertNull(tracker.findOwnedTerminal("session-a", terminalId, null));
+        assertEquals(0, tracker.countOpenTerminalTabs("session-a"));
+        assertTrue(tracker.hasOpenTerminalCapacity("session-a"));
     }
 
     @Test
-    @DisplayName("counts each open tab at most once")
-    void countsEachOpenTabOnce() {
-        assertEquals(1, AgentTabTracker.countMatchingTerminalTabs(
-            List.of("Agent: build", "Agent: build"), List.of("Agent: build")));
-    }
-
-    @Test
-    @DisplayName("counts multiple distinct matching open tabs")
-    void countsMultipleMatchingTabs() {
-        assertEquals(2, AgentTabTracker.countMatchingTerminalTabs(
-            List.of("Agent: build", "Agent: test"),
-            List.of("Agent: build", "Agent: test", "Local")));
-    }
-
-    @Test
-    @DisplayName("ignores null display names")
-    void ignoresNullDisplayNames() {
-        assertEquals(1, AgentTabTracker.countMatchingTerminalTabs(
-            List.of("Agent: build"), Arrays.asList(null, "Agent: build", null)));
-    }
-
-    @Test
-    @DisplayName("returns the newest tracked terminal that is still open")
-    void returnsMostRecentOpenTrackedTerminal() {
-        assertEquals("Agent: test (1)", AgentTabTracker.mostRecentOpenTerminalTabName(
-            List.of("Agent: build", "Agent: closed", "Agent: test"),
-            List.of("Local", "Agent: build", "Agent: test (1)")));
-    }
-
-    @Test
-    @DisplayName("returns null when every tracked terminal is closed")
-    void returnsNullWhenNoTrackedTerminalIsOpen() {
-        assertNull(AgentTabTracker.mostRecentOpenTerminalTabName(
-            List.of("Agent: build"), List.of("Local")));
-    }
-
-    @Test
-    @DisplayName("allows creation below the agent terminal limit")
-    void allowsCreationBelowLimit() {
+    @DisplayName("per-owner cap does not consume another owner's allowance")
+    void appliesPerOwnerCap() {
         assertEquals(3, AgentTabTracker.MAX_OPEN_AGENT_TERMINALS);
-        assertTrue(AgentTabTracker.hasTerminalCapacity(2));
+
+        for (int i = 0; i < AgentTabTracker.MAX_OPEN_AGENT_TERMINALS; i++) {
+            tracker.trackTerminal("session-a", openContent("A-" + i));
+        }
+        tracker.trackTerminal("session-b", openContent("B"));
+
+        assertFalse(tracker.hasOpenTerminalCapacity("session-a"));
+        assertTrue(tracker.hasOpenTerminalCapacity("session-b"));
+        assertEquals(3, tracker.countOpenTerminalTabs("session-a"));
+        assertEquals(1, tracker.countOpenTerminalTabs("session-b"));
     }
 
     @Test
-    @DisplayName("blocks creation at the agent terminal limit")
-    void blocksCreationAtLimit() {
-        assertFalse(AgentTabTracker.hasTerminalCapacity(3));
+    @DisplayName("global cap prevents unbounded terminals across short-lived owners")
+    void appliesGlobalCap() {
+        assertTrue(AgentTabTracker.MAX_OPEN_AGENT_TERMINALS_GLOBAL
+            > AgentTabTracker.MAX_OPEN_AGENT_TERMINALS);
+
+        for (int i = 0; i < AgentTabTracker.MAX_OPEN_AGENT_TERMINALS_GLOBAL; i++) {
+            tracker.trackTerminal("session-" + i, openContent("Terminal-" + i));
+        }
+
+        assertFalse(tracker.hasOpenTerminalCapacity("new-session"));
     }
 
     @Test
-    @DisplayName("tracks, recognizes, and untracks an AgentBridge terminal")
-    void tracksAndUntracksTerminalByDisplayName() {
-        AgentTabTracker tracker = new AgentTabTracker(mock(Project.class));
-        tracker.trackTab("Terminal", "Agent: build");
-        tracker.trackTab("Run", "Agent: tests");
+    @DisplayName("untracking requires both owner and stable id")
+    void untracksOnlyMatchingOwner() {
+        Content content = openContent("Agent: build");
+        String terminalId = tracker.trackTerminal("session-a", content);
 
-        assertTrue(tracker.isTrackedTerminalTab("Agent: build"));
-        assertTrue(tracker.isTrackedTerminalTab("Agent: build (2)"));
-        assertFalse(tracker.isTrackedTerminalTab("Agent: tests"));
+        tracker.untrackTerminal("session-b", terminalId);
+        assertSame(content, tracker.findOwnedTerminal("session-a", terminalId, null).content());
 
-        tracker.untrackTerminalTab("Agent: build (2)");
-
-        assertFalse(tracker.isTrackedTerminalTab("Agent: build"));
+        tracker.untrackTerminal("session-a", terminalId);
+        assertNull(tracker.findOwnedTerminal("session-a", terminalId, null));
     }
 
     @Test
-    @DisplayName("dispose forgets tracked terminals")
-    void disposeForgetsTrackedTerminals() {
-        AgentTabTracker tracker = new AgentTabTracker(mock(Project.class));
-        tracker.trackTab("Terminal", "Agent: build");
+    @DisplayName("list exposes only terminals owned by the caller")
+    void listsOnlyOwnedTerminals() {
+        Content first = openContent("A");
+        Content second = openContent("B");
+        tracker.trackTerminal("session-a", first);
+        tracker.trackTerminal("session-b", second);
+
+        List<AgentTabTracker.AgentTerminal> owned = tracker.listOpenTerminals("session-a");
+
+        assertEquals(1, owned.size());
+        assertSame(first, owned.getFirst().content());
+    }
+
+    @Test
+    @DisplayName("dispose forgets every owner")
+    void disposeForgetsTerminals() {
+        tracker.trackTerminal("session-a", openContent("A"));
+        tracker.trackTerminal("session-b", openContent("B"));
 
         tracker.dispose();
 
-        assertFalse(tracker.isTrackedTerminalTab("Agent: build"));
+        assertTrue(tracker.listOpenTerminals("session-a").isEmpty());
+        assertTrue(tracker.listOpenTerminals("session-b").isEmpty());
     }
 
     @Test
-    @DisplayName("terminal matching rejects null names")
-    void terminalMatchingRejectsNullNames() {
+    @DisplayName("legacy name matching still supports IDE numeric suffixes")
+    void matchesDisplayNameSuffix() {
+        assertTrue(AgentTabTracker.terminalTabNameMatches("Agent: build", "Agent: build (2)"));
+        assertFalse(AgentTabTracker.terminalTabNameMatches("Agent", "Agent: build"));
         assertFalse(AgentTabTracker.terminalTabNameMatches(null, "Agent: build"));
-        assertFalse(AgentTabTracker.terminalTabNameMatches("Agent: build", null));
+    }
+
+    private Content openContent(String displayName) {
+        Content content = mock(Content.class);
+        when(content.getDisplayName()).thenReturn(displayName);
+        openContents.add(content);
+        return content;
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpHttpServerStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpHttpServerStaticMethodsTest.java
@@ -2,17 +2,20 @@ package com.github.catatafishen.agentbridge.services;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.intellij.openapi.project.Project;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Method;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for static helper methods in {@link McpHttpServer}.
@@ -133,6 +136,104 @@ class McpHttpServerStaticMethodsTest {
             String json = McpHttpServer.buildJsonRpcErrorResponse(-32601, "Method not found");
             JsonObject error = JsonParser.parseString(json).getAsJsonObject().getAsJsonObject("error");
             assertEquals(-32601, error.get("code").getAsInt());
+        }
+    }
+
+    // ── Streamable HTTP session ownership ─────────────────
+
+    @Nested
+    class TransportSessionResolutionTest {
+
+        @Test
+        void initializePublishesSessionOnlyWithInitializeResult() throws Exception {
+            McpHttpServer server = new McpHttpServer(mock(Project.class));
+            Headers requestHeaders = new Headers();
+            Headers responseHeaders = new Headers();
+            HttpExchange exchange = exchange(requestHeaders, responseHeaders,
+                new ByteArrayOutputStream());
+
+            McpHttpServer.HttpOwnerResolution resolution = server.resolveHttpOwner(exchange,
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}");
+            assertNotNull(resolution);
+            String sessionId = resolution.newSessionId();
+
+            assertNotNull(sessionId);
+            assertEquals("http:" + sessionId, resolution.ownerKey());
+            assertNull(responseHeaders.getFirst(McpHttpServer.MCP_SESSION_ID_HEADER));
+
+            assertTrue(server.completeInitialization(exchange, resolution,
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}"));
+            assertEquals(sessionId,
+                responseHeaders.getFirst(McpHttpServer.MCP_SESSION_ID_HEADER));
+
+            requestHeaders.set(McpHttpServer.MCP_SESSION_ID_HEADER, sessionId);
+            McpHttpServer.HttpOwnerResolution established = server.resolveHttpOwner(exchange,
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}");
+            assertNotNull(established);
+            assertEquals(resolution.ownerKey(), established.ownerKey());
+            assertNull(established.newSessionId());
+        }
+
+        @Test
+        void failedInitializeDoesNotPublishOrRetainSession() throws Exception {
+            McpHttpServer server = new McpHttpServer(mock(Project.class));
+            Headers requestHeaders = new Headers();
+            Headers responseHeaders = new Headers();
+            HttpExchange exchange = exchange(requestHeaders, responseHeaders,
+                new ByteArrayOutputStream());
+
+            McpHttpServer.HttpOwnerResolution resolution = server.resolveHttpOwner(exchange,
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}");
+            assertNotNull(resolution);
+            assertFalse(server.completeInitialization(exchange, resolution,
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32602}}"));
+            assertNull(responseHeaders.getFirst(McpHttpServer.MCP_SESSION_ID_HEADER));
+
+            requestHeaders.set(McpHttpServer.MCP_SESSION_ID_HEADER, resolution.newSessionId());
+            assertNull(server.resolveHttpOwner(exchange,
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}"));
+        }
+
+        @Test
+        void establishedRequestWithoutSessionIsRejected() throws Exception {
+            McpHttpServer server = new McpHttpServer(mock(Project.class));
+            ByteArrayOutputStream responseBody = new ByteArrayOutputStream();
+            HttpExchange exchange = exchange(new Headers(), new Headers(), responseBody);
+
+            assertNull(server.resolveHttpOwner(exchange,
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}"));
+
+            verify(exchange).sendResponseHeaders(eq(400), anyLong());
+            JsonObject response = JsonParser.parseString(
+                responseBody.toString(java.nio.charset.StandardCharsets.UTF_8)).getAsJsonObject();
+            assertTrue(response.getAsJsonObject("error").get("message").getAsString()
+                .contains(McpHttpServer.MCP_SESSION_ID_HEADER));
+        }
+
+        @Test
+        void unknownSessionIsRejected() throws Exception {
+            McpHttpServer server = new McpHttpServer(mock(Project.class));
+            Headers requestHeaders = new Headers();
+            requestHeaders.set(McpHttpServer.MCP_SESSION_ID_HEADER, "unknown");
+            HttpExchange exchange = exchange(requestHeaders, new Headers(),
+                new ByteArrayOutputStream());
+
+            assertNull(server.resolveHttpOwner(exchange,
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}"));
+
+            verify(exchange).sendResponseHeaders(eq(404), anyLong());
+        }
+
+        private HttpExchange exchange(
+            Headers requestHeaders,
+            Headers responseHeaders,
+            ByteArrayOutputStream responseBody
+        ) {
+            HttpExchange exchange = mock(HttpExchange.class);
+            when(exchange.getRequestHeaders()).thenReturn(requestHeaders);
+            when(exchange.getResponseHeaders()).thenReturn(responseHeaders);
+            when(exchange.getResponseBody()).thenReturn(responseBody);
+            return exchange;
         }
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpHttpServerStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpHttpServerStaticMethodsTest.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -78,6 +80,18 @@ class McpHttpServerStaticMethodsTest {
         String result = callTruncateForLog(input);
         assertTrue(result.contains("[truncated 1 chars]"));
         assertTrue(result.startsWith("c".repeat(2000)));
+    }
+
+    @Test
+    void initializeResultRequiresAValidObjectResult() {
+        assertFalse(McpHttpServer.containsInitializeResult(null));
+        assertFalse(McpHttpServer.containsInitializeResult("{broken"));
+        assertFalse(McpHttpServer.containsInitializeResult("[]"));
+        assertFalse(McpHttpServer.containsInitializeResult("{}"));
+        assertFalse(McpHttpServer.containsInitializeResult("{\"result\":[]}"));
+        assertFalse(McpHttpServer.containsInitializeResult(
+            "{\"result\":{},\"error\":{\"code\":-32603}}"));
+        assertTrue(McpHttpServer.containsInitializeResult("{\"result\":{}}"));
     }
 
     // ── buildJsonRpcErrorResponse ──────────────────────────
@@ -208,6 +222,29 @@ class McpHttpServerStaticMethodsTest {
                 responseBody.toString(java.nio.charset.StandardCharsets.UTF_8)).getAsJsonObject();
             assertTrue(response.getAsJsonObject("error").get("message").getAsString()
                 .contains(McpHttpServer.MCP_SESSION_ID_HEADER));
+
+            Headers blankHeaders = new Headers();
+            blankHeaders.set(McpHttpServer.MCP_SESSION_ID_HEADER, "   ");
+            HttpExchange blank = exchange(blankHeaders, new Headers(),
+                new ByteArrayOutputStream());
+            assertNull(server.resolveHttpOwner(blank,
+                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/list\"}"));
+            verify(blank).sendResponseHeaders(eq(400), anyLong());
+        }
+
+        @Test
+        void malformedJsonUsesAnUnscopedProtocolErrorOwner() throws Exception {
+            McpHttpServer server = new McpHttpServer(mock(Project.class));
+            HttpExchange exchange = exchange(new Headers(), new Headers(),
+                new ByteArrayOutputStream());
+
+            McpHttpServer.HttpOwnerResolution owner =
+                server.resolveHttpOwner(exchange, "{broken");
+
+            assertNotNull(owner);
+            assertEquals("http:invalid-request", owner.ownerKey());
+            assertNull(owner.newSessionId());
+            assertTrue(server.completeInitialization(exchange, owner, null));
         }
 
         @Test
@@ -224,6 +261,174 @@ class McpHttpServerStaticMethodsTest {
             verify(exchange).sendResponseHeaders(eq(404), anyLong());
         }
 
+        @Test
+        void optionsRequestPublishesCorsContract() throws Exception {
+            McpHttpServer server = new McpHttpServer(mock(Project.class));
+            Headers responseHeaders = new Headers();
+            HttpExchange exchange = exchange(new Headers(), responseHeaders,
+                new ByteArrayOutputStream());
+            when(exchange.getRequestMethod()).thenReturn("OPTIONS");
+
+            invokePrivate(server, "handleMcp", new Class<?>[]{HttpExchange.class}, exchange);
+
+            assertEquals("*", responseHeaders.getFirst("Access-Control-Allow-Origin"));
+            assertEquals("POST, DELETE, OPTIONS",
+                responseHeaders.getFirst("Access-Control-Allow-Methods"));
+            assertTrue(responseHeaders.getFirst("Access-Control-Allow-Headers")
+                .contains(McpHttpServer.MCP_SESSION_ID_HEADER));
+            assertEquals(McpHttpServer.MCP_SESSION_ID_HEADER,
+                responseHeaders.getFirst("Access-Control-Expose-Headers"));
+            verify(exchange).sendResponseHeaders(204, -1);
+            verify(exchange).close();
+        }
+
+        @Test
+        void unsupportedHttpMethodIsRejected() throws Exception {
+            McpHttpServer server = new McpHttpServer(mock(Project.class));
+            HttpExchange exchange = exchange(new Headers(), new Headers(),
+                new ByteArrayOutputStream());
+            when(exchange.getRequestMethod()).thenReturn("PUT");
+
+            invokePrivate(server, "handleMcp", new Class<?>[]{HttpExchange.class}, exchange);
+
+            verify(exchange).sendResponseHeaders(405, -1);
+            verify(exchange).close();
+        }
+
+        @Test
+        void deleteRequiresAnEstablishedSession() throws Exception {
+            McpHttpServer server = new McpHttpServer(mock(Project.class));
+            ByteArrayOutputStream missingBody = new ByteArrayOutputStream();
+            HttpExchange missing = exchange(new Headers(), new Headers(), missingBody);
+            when(missing.getRequestMethod()).thenReturn("DELETE");
+
+            invokePrivate(server, "handleMcp", new Class<?>[]{HttpExchange.class}, missing);
+
+            verify(missing).sendResponseHeaders(eq(400), anyLong());
+            assertTrue(missingBody.toString(java.nio.charset.StandardCharsets.UTF_8)
+                .contains(McpHttpServer.MCP_SESSION_ID_HEADER));
+
+            Headers unknownHeaders = new Headers();
+            unknownHeaders.set(McpHttpServer.MCP_SESSION_ID_HEADER, "unknown");
+            HttpExchange unknown = exchange(unknownHeaders, new Headers(),
+                new ByteArrayOutputStream());
+            when(unknown.getRequestMethod()).thenReturn("DELETE");
+
+            invokePrivate(server, "handleMcp", new Class<?>[]{HttpExchange.class}, unknown);
+
+            verify(unknown).sendResponseHeaders(eq(404), anyLong());
+        }
+
+        @Test
+        void deleteClosesOnlyTheSessionOwnerResources() throws Exception {
+            Project project = mock(Project.class);
+            AgentTabTracker tracker = mock(AgentTabTracker.class);
+            when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+            McpHttpServer server = new McpHttpServer(project);
+            HttpExchange initialize = exchange(new Headers(), new Headers(),
+                new ByteArrayOutputStream());
+            McpHttpServer.HttpOwnerResolution owner = server.resolveHttpOwner(initialize,
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}");
+            assertNotNull(owner);
+            assertTrue(server.completeInitialization(initialize, owner,
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}"));
+
+            Headers deleteHeaders = new Headers();
+            deleteHeaders.set(McpHttpServer.MCP_SESSION_ID_HEADER, owner.newSessionId());
+            HttpExchange delete = exchange(deleteHeaders, new Headers(),
+                new ByteArrayOutputStream());
+            when(delete.getRequestMethod()).thenReturn("DELETE");
+
+            invokePrivate(server, "handleMcp", new Class<?>[]{HttpExchange.class}, delete);
+
+            verify(tracker).closeOwnedTerminalTabs(owner.ownerKey());
+            verify(delete).sendResponseHeaders(204, -1);
+            verify(delete).close();
+        }
+
+        @Test
+        void requestCompletionReleasesResourcesWhenSessionClosedMidCall() throws Exception {
+            Project project = mock(Project.class);
+            AgentTabTracker tracker = mock(AgentTabTracker.class);
+            when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+            McpHttpServer server = new McpHttpServer(project);
+            HttpExchange initialize = exchange(new Headers(), new Headers(),
+                new ByteArrayOutputStream());
+            McpHttpServer.HttpOwnerResolution owner = server.resolveHttpOwner(initialize,
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}");
+            assertNotNull(owner);
+            assertTrue(server.completeInitialization(initialize, owner,
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}"));
+
+            invokePrivate(server, "finishHttpRequest", new Class<?>[]{String.class},
+                owner.ownerKey());
+            verifyNoInteractions(tracker);
+
+            Headers deleteHeaders = new Headers();
+            deleteHeaders.set(McpHttpServer.MCP_SESSION_ID_HEADER, owner.newSessionId());
+            HttpExchange delete = exchange(deleteHeaders, new Headers(),
+                new ByteArrayOutputStream());
+            invokePrivate(server, "handleSessionDelete", new Class<?>[]{HttpExchange.class},
+                delete);
+            clearInvocations(tracker);
+
+            invokePrivate(server, "finishHttpRequest", new Class<?>[]{String.class},
+                owner.ownerKey());
+            verify(tracker).closeOwnedTerminalTabs(owner.ownerKey());
+
+            clearInvocations(tracker);
+            invokePrivate(server, "finishHttpRequest", new Class<?>[]{String.class},
+                "sse:foreign");
+            invokePrivate(server, "finishHttpRequest", new Class<?>[]{String.class},
+                "http:invalid-request");
+            verifyNoInteractions(tracker);
+        }
+
+        @Test
+        void cleanupExecutorStartsAndStopsWithoutLeakingAThread() throws Exception {
+            McpHttpServer server = new McpHttpServer(mock(Project.class));
+
+            invokePrivate(server, "startHttpSessionCleanup", new Class<?>[0]);
+            Field field = McpHttpServer.class.getDeclaredField("sessionCleanupExecutor");
+            field.setAccessible(true);
+            ScheduledExecutorService executor = (ScheduledExecutorService) field.get(server);
+            assertNotNull(executor);
+            assertFalse(executor.isShutdown());
+
+            invokePrivate(server, "closeExpiredHttpSessions", new Class<?>[0]);
+            invokePrivate(server, "stopHttpSessionCleanup", new Class<?>[0]);
+
+            assertTrue(executor.isShutdown());
+            assertNull(field.get(server));
+            invokePrivate(server, "stopHttpSessionCleanup", new Class<?>[0]);
+        }
+
+        @Test
+        void serverShutdownDrainsEveryHttpSessionOwner() throws Exception {
+            Project project = mock(Project.class);
+            AgentTabTracker tracker = mock(AgentTabTracker.class);
+            when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+            McpHttpServer server = new McpHttpServer(project);
+            Headers requestHeaders = new Headers();
+            HttpExchange exchange = exchange(requestHeaders, new Headers(),
+                new ByteArrayOutputStream());
+            McpHttpServer.HttpOwnerResolution first = server.resolveHttpOwner(exchange,
+                "{\"method\":\"initialize\"}");
+            McpHttpServer.HttpOwnerResolution second = server.resolveHttpOwner(exchange,
+                "{\"method\":\"initialize\"}");
+            assertNotNull(first);
+            assertNotNull(second);
+
+            invokePrivate(server, "closeAllHttpSessions", new Class<?>[0]);
+
+            verify(tracker).closeOwnedTerminalTabs(first.ownerKey());
+            verify(tracker).closeOwnedTerminalTabs(second.ownerKey());
+            requestHeaders.set(McpHttpServer.MCP_SESSION_ID_HEADER, first.newSessionId());
+            assertNull(server.resolveHttpOwner(exchange,
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}"));
+            verify(exchange).sendResponseHeaders(eq(404), anyLong());
+        }
+
         private HttpExchange exchange(
             Headers requestHeaders,
             Headers responseHeaders,
@@ -235,6 +440,17 @@ class McpHttpServerStaticMethodsTest {
             when(exchange.getResponseBody()).thenReturn(responseBody);
             return exchange;
         }
+    }
+
+    private static Object invokePrivate(
+        Object target,
+        String name,
+        Class<?>[] parameterTypes,
+        Object... args
+    ) throws Exception {
+        Method method = target.getClass().getDeclaredMethod(name, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(target, args);
     }
 
     // ── buildHealthResponse ────────────────────────────────

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpHttpServerStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpHttpServerStaticMethodsTest.java
@@ -172,6 +172,7 @@ class McpHttpServerStaticMethodsTest {
             String sessionId = resolution.newSessionId();
 
             assertNotNull(sessionId);
+            assertEquals(McpHttpServer.HttpOwnerKind.INITIALIZE, resolution.kind());
             assertEquals("http:" + sessionId, resolution.ownerKey());
             assertNull(responseHeaders.getFirst(McpHttpServer.MCP_SESSION_ID_HEADER));
 
@@ -184,13 +185,17 @@ class McpHttpServerStaticMethodsTest {
             McpHttpServer.HttpOwnerResolution established = server.resolveHttpOwner(exchange,
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}");
             assertNotNull(established);
+            assertEquals(McpHttpServer.HttpOwnerKind.ESTABLISHED, established.kind());
             assertEquals(resolution.ownerKey(), established.ownerKey());
             assertNull(established.newSessionId());
         }
 
         @Test
         void failedInitializeDoesNotPublishOrRetainSession() throws Exception {
-            McpHttpServer server = new McpHttpServer(mock(Project.class));
+            Project project = mock(Project.class);
+            AgentTabTracker tracker = mock(AgentTabTracker.class);
+            when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+            McpHttpServer server = new McpHttpServer(project);
             Headers requestHeaders = new Headers();
             Headers responseHeaders = new Headers();
             HttpExchange exchange = exchange(requestHeaders, responseHeaders,
@@ -202,6 +207,7 @@ class McpHttpServerStaticMethodsTest {
             assertFalse(server.completeInitialization(exchange, resolution,
                 "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32602}}"));
             assertNull(responseHeaders.getFirst(McpHttpServer.MCP_SESSION_ID_HEADER));
+            verify(tracker).closeOwnedTerminalTabs(resolution.ownerKey());
 
             requestHeaders.set(McpHttpServer.MCP_SESSION_ID_HEADER, resolution.newSessionId());
             assertNull(server.resolveHttpOwner(exchange,
@@ -242,7 +248,8 @@ class McpHttpServerStaticMethodsTest {
                 server.resolveHttpOwner(exchange, "{broken");
 
             assertNotNull(owner);
-            assertEquals("http:invalid-request", owner.ownerKey());
+            assertEquals(McpHttpServer.HttpOwnerKind.INVALID, owner.kind());
+            assertNull(owner.ownerKey());
             assertNull(owner.newSessionId());
             assertTrue(server.completeInitialization(exchange, owner, null));
         }
@@ -379,8 +386,6 @@ class McpHttpServerStaticMethodsTest {
             clearInvocations(tracker);
             invokePrivate(server, "finishHttpRequest", new Class<?>[]{String.class},
                 "sse:foreign");
-            invokePrivate(server, "finishHttpRequest", new Class<?>[]{String.class},
-                "http:invalid-request");
             verifyNoInteractions(tracker);
         }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpProtocolHandlerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpProtocolHandlerTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -229,6 +228,17 @@ class McpProtocolHandlerTest {
         JsonObject parsed = JsonParser.parseString(response).getAsJsonObject();
         // Parse errors produce a response with an "error" field
         assertTrue(parsed.has("error"));
+    }
+
+    @Test
+    void testInitializeEncouragesTerminalReuseAndCleanup() {
+        JsonObject response = parseResponse(sendRequest("initialize", new JsonObject()));
+        String instructions = response.getAsJsonObject("result").get("instructions").getAsString();
+        String normalizedInstructions = instructions.replaceAll("\\s+", " ");
+
+        assertTrue(instructions.contains("terminal_id"));
+        assertTrue(normalizedInstructions.contains("Reuse that terminal"));
+        assertTrue(instructions.contains("close_terminal"));
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpSessionRegistryTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpSessionRegistryTest.java
@@ -16,8 +16,10 @@ class McpSessionRegistryTest {
     void managesSessionLifecycle() {
         McpSessionRegistry registry = new McpSessionRegistry();
 
-        String first = registry.openSession();
-        String second = registry.openSession();
+        String first = registry.openSession(Integer.MAX_VALUE);
+        String second = registry.openSession(Integer.MAX_VALUE);
+        assertNotNull(first);
+        assertNotNull(second);
 
         assertNotEquals(first, second);
         assertTrue(registry.touch(first));
@@ -32,8 +34,10 @@ class McpSessionRegistryTest {
     @DisplayName("drain returns every live session and empties the registry")
     void drainsSessions() {
         McpSessionRegistry registry = new McpSessionRegistry();
-        String first = registry.openSession();
-        String second = registry.openSession();
+        String first = registry.openSession(Integer.MAX_VALUE);
+        String second = registry.openSession(Integer.MAX_VALUE);
+        assertNotNull(first);
+        assertNotNull(second);
 
         Set<String> drained = registry.drainSessions();
 
@@ -47,9 +51,11 @@ class McpSessionRegistryTest {
     void expiresIdleSessions() {
         AtomicLong now = new AtomicLong();
         McpSessionRegistry registry = new McpSessionRegistry(now::get);
-        String first = registry.openSession();
+        String first = registry.openSession(Integer.MAX_VALUE);
         now.set(10);
-        String second = registry.openSession();
+        String second = registry.openSession(Integer.MAX_VALUE);
+        assertNotNull(first);
+        assertNotNull(second);
         now.set(20);
         assertTrue(registry.touch(first));
         assertFalse(registry.touch("unknown"));
@@ -62,6 +68,37 @@ class McpSessionRegistryTest {
         now.set(35);
         assertEquals(Set.of(first), registry.expireIdleSessions(10));
         assertFalse(registry.touch(first));
+    }
+
+    @Test
+    @DisplayName("returns null once the cap is reached and admits again after a close")
+    void enforcesSessionCap() {
+        McpSessionRegistry registry = new McpSessionRegistry();
+
+        String first = registry.openSession(2);
+        String second = registry.openSession(2);
+        assertNotNull(first);
+        assertNotNull(second);
+
+        assertNull(registry.openSession(2),
+            "third openSession call should be rejected when the cap is 2");
+
+        assertTrue(registry.closeSession(first));
+
+        String third = registry.openSession(2);
+        assertNotNull(third,
+            "closing a session should free a slot for the next openSession call");
+        assertNotEquals(second, third);
+    }
+
+    @Test
+    @DisplayName("treats non-positive caps as unlimited so misconfigured settings don't lock out clients")
+    void nonPositiveCapMeansUnlimited() {
+        McpSessionRegistry registry = new McpSessionRegistry();
+
+        assertNotNull(registry.openSession(0));
+        assertNotNull(registry.openSession(-1));
+        assertNotNull(registry.openSession(-100));
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpSessionRegistryTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpSessionRegistryTest.java
@@ -1,0 +1,99 @@
+package com.github.catatafishen.agentbridge.services;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("MCP transport session registry")
+class McpSessionRegistryTest {
+
+    @Test
+    @DisplayName("creates unique active sessions and closes only the requested one")
+    void managesSessionLifecycle() {
+        McpSessionRegistry registry = new McpSessionRegistry();
+
+        String first = registry.openSession();
+        String second = registry.openSession();
+
+        assertNotEquals(first, second);
+        assertTrue(registry.touch(first));
+        assertTrue(registry.touch(second));
+        assertTrue(registry.closeSession(first));
+        assertFalse(registry.touch(first));
+        assertTrue(registry.touch(second));
+        assertFalse(registry.closeSession("unknown"));
+    }
+
+    @Test
+    @DisplayName("drain returns every live session and empties the registry")
+    void drainsSessions() {
+        McpSessionRegistry registry = new McpSessionRegistry();
+        String first = registry.openSession();
+        String second = registry.openSession();
+
+        Set<String> drained = registry.drainSessions();
+
+        assertEquals(Set.of(first, second), drained);
+        assertFalse(registry.touch(first));
+        assertFalse(registry.touch(second));
+    }
+
+    @Test
+    @DisplayName("expires only idle sessions and refreshes activity on use")
+    void expiresIdleSessions() {
+        AtomicLong now = new AtomicLong();
+        McpSessionRegistry registry = new McpSessionRegistry(now::get);
+        String first = registry.openSession();
+        now.set(10);
+        String second = registry.openSession();
+        now.set(20);
+        assertTrue(registry.touch(first));
+        assertFalse(registry.touch("unknown"));
+
+        now.set(25);
+        assertEquals(Set.of(second), registry.expireIdleSessions(10));
+        assertTrue(registry.touch(first));
+        assertFalse(registry.touch(second));
+
+        now.set(35);
+        assertEquals(Set.of(first), registry.expireIdleSessions(10));
+        assertFalse(registry.touch(first));
+    }
+
+    @Test
+    @DisplayName("classifies initialize separately from established requests")
+    void classifiesRequests() {
+        assertEquals(McpSessionRegistry.RequestKind.INITIALIZE,
+            McpSessionRegistry.classifyRequest(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"));
+        assertEquals(McpSessionRegistry.RequestKind.ESTABLISHED,
+            McpSessionRegistry.classifyRequest(
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}"));
+        assertEquals(McpSessionRegistry.RequestKind.ESTABLISHED,
+            McpSessionRegistry.classifyRequest(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}"));
+    }
+
+    @Test
+    @DisplayName("malformed or methodless JSON is not treated as an established request")
+    void classifiesInvalidRequests() {
+        assertEquals(McpSessionRegistry.RequestKind.INVALID,
+            McpSessionRegistry.classifyRequest("{broken"));
+        assertEquals(McpSessionRegistry.RequestKind.INVALID,
+            McpSessionRegistry.classifyRequest("{\"jsonrpc\":\"2.0\",\"id\":1}"));
+    }
+
+    @Test
+    @DisplayName("owner keys keep HTTP and SSE namespaces separate")
+    void namespacesOwnerKeys() {
+        assertEquals("http:abc", McpSessionRegistry.ownerKey("http", "abc"));
+        assertEquals("sse:abc", McpSessionRegistry.ownerKey("sse", "abc"));
+        assertNotEquals(
+            McpSessionRegistry.ownerKey("http", "abc"),
+            McpSessionRegistry.ownerKey("sse", "abc"));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpSessionRegistryTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpSessionRegistryTest.java
@@ -65,6 +65,15 @@ class McpSessionRegistryTest {
     }
 
     @Test
+    @DisplayName("rejects a negative idle timeout")
+    void rejectsNegativeIdleTimeout() {
+        McpSessionRegistry registry = new McpSessionRegistry();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> registry.expireIdleSessions(-1));
+    }
+
+    @Test
     @DisplayName("classifies initialize separately from established requests")
     void classifiesRequests() {
         assertEquals(McpSessionRegistry.RequestKind.INITIALIZE,

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpSseTransportTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/McpSseTransportTest.java
@@ -2,22 +2,101 @@ package com.github.catatafishen.agentbridge.services;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.intellij.openapi.project.Project;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for pure static methods in {@link McpSseTransport}.
  */
 class McpSseTransportTest {
+
+    @Test
+    void stopClosesSessionsAndTheirOwnedTerminalResources() throws Exception {
+        Project project = mock(Project.class);
+        AgentTabTracker tracker = mock(AgentTabTracker.class);
+        when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+        McpSseTransport transport = new McpSseTransport(
+            project, mock(McpProtocolHandler.class));
+        transport.start();
+        HttpExchange exchange = mock(HttpExchange.class);
+        when(exchange.getResponseBody()).thenReturn(new ByteArrayOutputStream());
+        SseSession session = new SseSession(exchange);
+        sessions(transport).put(session.getSessionId(), session);
+
+        transport.stop();
+
+        assertTrue(session.isClosed());
+        assertEquals(0, transport.getActiveSessionCount());
+        verify(tracker).closeOwnedTerminalTabs(
+            McpSessionRegistry.ownerKey("sse", session.getSessionId()));
+        verify(exchange).close();
+    }
+
+    @Test
+    void disconnectDuringToolCallReleasesResourcesCreatedByTheRace() throws Exception {
+        Project project = mock(Project.class);
+        AgentTabTracker tracker = mock(AgentTabTracker.class);
+        McpProtocolHandler handler = mock(McpProtocolHandler.class);
+        when(project.getService(AgentTabTracker.class)).thenReturn(tracker);
+        McpSseTransport transport = new McpSseTransport(project, handler);
+
+        HttpExchange streamExchange = mock(HttpExchange.class);
+        when(streamExchange.getResponseBody()).thenReturn(new ByteArrayOutputStream());
+        SseSession session = new SseSession(streamExchange);
+        Map<String, SseSession> sessions = sessions(transport);
+        sessions.put(session.getSessionId(), session);
+        String ownerKey = McpSessionRegistry.ownerKey("sse", session.getSessionId());
+
+        HttpExchange request = mock(HttpExchange.class);
+        when(request.getResponseHeaders()).thenReturn(new Headers());
+        when(request.getRequestMethod()).thenReturn("POST");
+        when(request.getRequestURI()).thenReturn(
+            URI.create("/message?sessionId=" + session.getSessionId()));
+        when(request.getRequestBody()).thenReturn(
+            new ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8)));
+        when(handler.handleMessage("{}", ownerKey)).thenAnswer(invocation -> {
+            sessions.remove(session.getSessionId());
+            session.close();
+            return null;
+        });
+
+        transport.handleMessage(request);
+
+        verify(handler).handleMessage("{}", ownerKey);
+        verify(tracker).closeOwnedTerminalTabs(ownerKey);
+        verify(request).sendResponseHeaders(202, -1);
+        verify(request).close();
+        assertTrue(session.isClosed());
+        assertEquals(0, transport.getActiveSessionCount());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, SseSession> sessions(McpSseTransport transport) throws Exception {
+        Field field = McpSseTransport.class.getDeclaredField("sessions");
+        field.setAccessible(true);
+        return (Map<String, SseSession>) field.get(transport);
+    }
 
     // ── parseSessionId (private, via reflection) ───────────
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/McpServerSettingsStateTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/McpServerSettingsStateTest.java
@@ -269,4 +269,65 @@ class McpServerSettingsStateTest {
         assertNull(settings.getKindSearchColorKey());
     }
 
+    // ── Session-limit settings ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("maxOpenHttpSessions defaults to DEFAULT_MAX_OPEN_HTTP_SESSIONS")
+    void defaultMaxOpenHttpSessions() {
+        assertEquals(McpServerSettings.DEFAULT_MAX_OPEN_HTTP_SESSIONS,
+            settings.getMaxOpenHttpSessions());
+    }
+
+    @Test
+    @DisplayName("httpSessionIdleTimeoutMinutes defaults to DEFAULT_HTTP_SESSION_IDLE_TIMEOUT_MINUTES")
+    void defaultHttpSessionIdleTimeoutMinutes() {
+        assertEquals(McpServerSettings.DEFAULT_HTTP_SESSION_IDLE_TIMEOUT_MINUTES,
+            settings.getHttpSessionIdleTimeoutMinutes());
+    }
+
+    @Test
+    @DisplayName("maxAgentTerminalsGlobal defaults to DEFAULT_MAX_AGENT_TERMINALS_GLOBAL")
+    void defaultMaxAgentTerminalsGlobal() {
+        assertEquals(McpServerSettings.DEFAULT_MAX_AGENT_TERMINALS_GLOBAL,
+            settings.getMaxAgentTerminalsGlobal());
+    }
+
+    @Test
+    @DisplayName("maxOpenHttpSessions round-trips and coerces non-positive to default")
+    void maxOpenHttpSessionsRoundTrip() {
+        settings.setMaxOpenHttpSessions(200);
+        assertEquals(200, settings.getMaxOpenHttpSessions());
+
+        settings.setMaxOpenHttpSessions(0);
+        assertEquals(McpServerSettings.DEFAULT_MAX_OPEN_HTTP_SESSIONS,
+            settings.getMaxOpenHttpSessions(),
+            "non-positive values must fall back to the default so a corrupted setting doesn't lock the user out");
+
+        settings.setMaxOpenHttpSessions(-5);
+        assertEquals(McpServerSettings.DEFAULT_MAX_OPEN_HTTP_SESSIONS,
+            settings.getMaxOpenHttpSessions());
+    }
+
+    @Test
+    @DisplayName("httpSessionIdleTimeoutMinutes round-trips and coerces non-positive to default")
+    void httpSessionIdleTimeoutMinutesRoundTrip() {
+        settings.setHttpSessionIdleTimeoutMinutes(15);
+        assertEquals(15, settings.getHttpSessionIdleTimeoutMinutes());
+
+        settings.setHttpSessionIdleTimeoutMinutes(0);
+        assertEquals(McpServerSettings.DEFAULT_HTTP_SESSION_IDLE_TIMEOUT_MINUTES,
+            settings.getHttpSessionIdleTimeoutMinutes());
+    }
+
+    @Test
+    @DisplayName("maxAgentTerminalsGlobal round-trips and coerces non-positive to default")
+    void maxAgentTerminalsGlobalRoundTrip() {
+        settings.setMaxAgentTerminalsGlobal(24);
+        assertEquals(24, settings.getMaxAgentTerminalsGlobal());
+
+        settings.setMaxAgentTerminalsGlobal(0);
+        assertEquals(McpServerSettings.DEFAULT_MAX_AGENT_TERMINALS_GLOBAL,
+            settings.getMaxAgentTerminalsGlobal());
+    }
+
 }


### PR DESCRIPTION
## Summary

- isolate terminal tabs by MCP transport session for Streamable HTTP and SSE clients
- add stable `terminal_id` selectors while keeping owner-scoped `tab_name` compatibility
- reuse the most recent terminal within the current session and cap terminal growth per session and project
- clean up owned terminals on session deletion, expiry, disconnect, server stop, and lifecycle races
- update startup guidance, MCP documentation, and focused lifecycle/ownership tests

## Problem

Terminal lookup and cleanup were effectively global. Concurrent agents could select or reuse the same tab by display name, while abandoned sessions left terminal tabs behind. That caused command collisions and steadily increasing resource use.

## Validation

- focused terminal, tracker, HTTP lifecycle, protocol, and session-registry tests pass
- `:plugin-core:buildPlugin` completes successfully
- Plugin Verifier reports IntelliJ IDEA compatibility; checks for PyCharm, WebStorm, GoLand, and the installed DataSpell build show only existing optional Java/SonarLint compatibility warnings, with no findings in the changed terminal/session classes