### PR TITLE
feat: add ESC keybinding to stop in-progress agent sessions

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -1250,6 +1250,7 @@ class ChatToolWindowContent(
                 override fun onNudge() = onNudgeClicked()
                 override fun onQueue() = onQueueMessageClicked()
                 override fun onForceStopAndSend() = this@ChatToolWindowContent.onForceStopAndSend()
+                override fun onStopAgent() = stopAgent()
                 override fun onNewConversation() {
                     promptOrchestrator.currentSessionId = null
                     consolePanel.addSessionSeparator(
@@ -1543,6 +1544,10 @@ class ChatToolWindowContent(
                     java.awt.event.InputEvent.CTRL_DOWN_MASK
                 )
             ) to "Stop && send"
+            list += PromptShortcutAction.resolveKeystroke(
+                PromptShortcutAction.STOP_AGENT_ID,
+                KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_ESCAPE, 0)
+            ) to "Stop"
             list += PromptShortcutAction.resolveKeystroke(
                 PromptShortcutAction.QUEUE_ID,
                 KeyStroke.getKeyStroke(

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptEditorSetup.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptEditorSetup.kt
@@ -45,6 +45,7 @@ internal class PromptEditorSetup(
         fun onNudge()
         fun onQueue()
         fun onForceStopAndSend()
+        fun onStopAgent()
         fun onNewConversation()
         fun clearAndRemoveNudge(id: String)
         fun refreshShortcutHints()
@@ -67,6 +68,7 @@ internal class PromptEditorSetup(
         registerUpArrowRecall(contentComponent)
         registerPasteIntercept(editor, contentComponent)
         registerTriggerCharDetection(editor)
+        registerEscStop(contentComponent)
     }
 
     fun setupContextMenu(editor: EditorEx) {
@@ -281,6 +283,20 @@ internal class PromptEditorSetup(
                     java.awt.event.KeyEvent.VK_ENTER,
                     java.awt.event.InputEvent.CTRL_DOWN_MASK or java.awt.event.InputEvent.SHIFT_DOWN_MASK
                 )
+            ),
+            contentComponent
+        )
+    }
+
+    private fun registerEscStop(contentComponent: JComponent) {
+        object : AnAction() {
+            override fun actionPerformed(e: AnActionEvent) {
+                if (callbacks.isSending) callbacks.onStopAgent()
+            }
+        }.registerCustomShortcutSet(
+            PromptShortcutAction.resolveShortcutSet(
+                PromptShortcutAction.STOP_AGENT_ID,
+                KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_ESCAPE, 0)
             ),
             contentComponent
         )

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutAction.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutAction.java
@@ -25,6 +25,7 @@ public final class PromptShortcutAction extends AnAction {
     public static final String STOP_AND_SEND_ID = "AgentBridge.Prompt.StopAndSend";
     public static final String QUEUE_ID = "AgentBridge.Prompt.Queue";
     public static final String SHOW_SHORTCUTS_ID = "AgentBridge.Prompt.ShowShortcuts";
+    public static final String STOP_AGENT_ID = "AgentBridge.StopAgent";
 
     /**
      * Returns the shortcut set for the given action ID from the active keymap,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutAction.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutAction.java
@@ -25,7 +25,7 @@ public final class PromptShortcutAction extends AnAction {
     public static final String STOP_AND_SEND_ID = "AgentBridge.Prompt.StopAndSend";
     public static final String QUEUE_ID = "AgentBridge.Prompt.Queue";
     public static final String SHOW_SHORTCUTS_ID = "AgentBridge.Prompt.ShowShortcuts";
-    public static final String STOP_AGENT_ID = "AgentBridge.StopAgent";
+    public static final String STOP_AGENT_ID = "AgentBridge.Prompt.StopAgent";
 
     /**
      * Returns the shortcut set for the given action ID from the active keymap,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ShortcutCheatSheetPopup.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ShortcutCheatSheetPopup.kt
@@ -51,6 +51,11 @@ object ShortcutCheatSheetPopup {
             "Queue (send after agent finishes)"
         ),
         ShortcutRow(
+            PromptShortcutAction.STOP_AGENT_ID,
+            KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
+            "Stop agent"
+        ),
+        ShortcutRow(
             PromptShortcutAction.SHOW_SHORTCUTS_ID,
             KeyStroke.getKeyStroke(KeyEvent.VK_SLASH, InputEvent.CTRL_DOWN_MASK),
             "Show this popup"

--- a/plugin-core/src/main/resources/META-INF/plugin.xml
+++ b/plugin-core/src/main/resources/META-INF/plugin.xml
@@ -397,6 +397,12 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, OpenCod
             description="Show all available chat prompt keyboard shortcuts">
       <keyboard-shortcut keymap="$default" first-keystroke="ctrl SLASH"/>
     </action>
+    <action id="AgentBridge.StopAgent"
+            class="com.github.catatafishen.agentbridge.ui.PromptShortcutAction"
+            text="Stop Agent"
+            description="Stop the currently running agent session">
+      <keyboard-shortcut keymap="$default" first-keystroke="ESCAPE"/>
+    </action>
     <action id="AgentBridge.Review.RevertAgentEdits"
             class="com.github.catatafishen.agentbridge.psi.review.RevertAgentEditsAction"
             text="Revert Agent Edits"

--- a/plugin-core/src/main/resources/META-INF/plugin.xml
+++ b/plugin-core/src/main/resources/META-INF/plugin.xml
@@ -397,7 +397,7 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, OpenCod
             description="Show all available chat prompt keyboard shortcuts">
       <keyboard-shortcut keymap="$default" first-keystroke="ctrl SLASH"/>
     </action>
-    <action id="AgentBridge.StopAgent"
+    <action id="AgentBridge.Prompt.StopAgent"
             class="com.github.catatafishen.agentbridge.ui.PromptShortcutAction"
             text="Stop Agent"
             description="Stop the currently running agent session">


### PR DESCRIPTION
## Summary

The Stop button in the toolbar was mouse-only — no keyboard shortcut existed to kill a running agent session. Adds **ESC** as the default keybinding so users can panic-slam their way out.

## Motivation

When an agent is misbehaving (infinite loop, wrong direction, burning tokens), every second counts. The only way to stop it was to hunt for the small toolbar button. ESC is the universal get-me-out-of-here key and it was conspicuously absent.

## Changes

**5 files, 33 insertions:**

- PromptShortcutAction.java — New STOP_AGENT_ID constant (AgentBridge.StopAgent)
- plugin.xml — Register action with ESC default keybinding
- PromptEditorSetup.kt — New onStopAgent() callback + registerEscStop() method
- ChatToolWindowContent.kt — Wire callback to stopAgent(), add ESC hint to toolbar bar
- ShortcutCheatSheetPopup.kt — Add Stop agent row to Ctrl+/ cheat sheet

## Design

Follows the **same two-layer shortcut pattern** as Enter / Ctrl+Enter / Ctrl+Shift+Enter:

1. **plugin.xml action** — appears in Settings > Keymap > AgentBridge Chat Prompt > Stop Agent, user-customizable
2. **Local registration** on the prompt editor content component — only fires when the chat input has focus

### Scope and safety

- **ESC is scoped to the prompt editor** — it does not interfere with IDE-level ESC (close popup, exit search, dismiss notification) because the shortcut is registered on the editor component, not globally
- **Guarded by isSending** — when the agent is idle, ESC is a no-op; prevents accidental stops
- **No-op when no agent is running** — the registerEscStop action checks callbacks.isSending before calling onStopAgent()

### What stopAgent() does

- Cancels the current turn via PromptOrchestrator.stop()
- Cancels all in-flight MCP tool calls via InFlightMcpToolRegistry.cancelInFlight()
- Cancels running console rows
- Restores any queued follow-up messages back to the input box
- Notifies the user about leftover terminal tabs the agent left open

## UI surface

- Shortcut hint bar (bottom of chat) — Agent is busy — shows Esc > Stop hint chip
- Ctrl+/ cheat sheet — Always — shows Stop agent row
- Settings > Keymap — Always — shows Stop Agent under AgentBridge group, rebindable

## Testing

- compileKotlin + compileJava — build passes
- ESC hint appears in toolbar only when agent is running
- ESC does nothing when agent is idle
- Ctrl+/ cheat sheet shows the new row
- Action appears in Keymap settings

## Dev build

A installable zip is available for testing:
https://github.com/jelloeater-agent/agentbridge/releases/tag/dev-20260715-1312-00da6bcdc

Install: Settings > Plugins > gear icon > Install Plugin from Disk > select the .zip