### PR TITLE
fix: use HTTP MCP server for Kiro 2.14.1+ so @agentbridge tools load

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/AcpClient.java
@@ -1721,6 +1721,61 @@ public abstract class AcpClient extends AbstractClient {
         return McpStdioLaunch.describeUnavailable();
     }
 
+    /**
+     * Builds an HTTP MCP server config pointing at the in-IDE {@link McpServerControl} HTTP
+     * endpoint ({@code http://127.0.0.1:<mcpPort>/mcp}).
+     *
+     * <p>Use this instead of {@link #buildMcpStdioServer(String, int)} for agents that advertise
+     * {@code mcpCapabilities.http} at initialize time. Some agents (e.g. Kiro 2.14.1) silently
+     * ignore stdio MCP servers passed over ACP and only load MCP tools when an HTTP server is
+     * supplied, even though the same {@code McpHttpServer} backs both transports.</p>
+     *
+     * @param serverName the MCP server name advertised to the agent
+     * @param mcpPort     the port of the running in-IDE HTTP MCP server; must be positive
+     * @return the HTTP MCP server JSON object
+     * @throws IllegalStateException if {@code mcpPort} is not a valid running port
+     */
+    protected final @NotNull JsonObject buildMcpHttpServer(String serverName, int mcpPort) {
+        if (mcpPort <= 0) {
+            throw new IllegalStateException(
+                "Cannot configure HTTP MCP server — the in-IDE MCP server is not running "
+                    + "(no port available). IntelliJ tools will be unavailable.");
+        }
+        return buildMcpHttpServerJson(serverName, mcpPort);
+    }
+
+    /**
+     * Pure builder for the HTTP MCP server JSON shape. Extracted for unit testing.
+     *
+     * <p>The {@code headers} array is mandatory: Kiro 2.14.1's ACP {@code session/new} parser
+     * requires an HTTP MCP entry to carry a {@code headers} array (even when empty). Omitting it,
+     * or sending {@code headers} as an object instead of an array, makes the Kiro ACP process exit
+     * cleanly (exit code 0, no error) the moment it parses {@code session/new} — killing the whole
+     * session before any MCP connection is attempted. An empty array is correct here because the
+     * in-IDE {@link com.github.catatafishen.agentbridge.services.McpHttpServer} does not require
+     * authentication headers. (See issue #948.)</p>
+     */
+    static @NotNull JsonObject buildMcpHttpServerJson(String serverName, int mcpPort) {
+        JsonObject server = new JsonObject();
+        server.addProperty("type", "http");
+        server.addProperty("name", serverName);
+        server.addProperty("url", "http://127.0.0.1:" + mcpPort + "/mcp");
+        server.add("headers", new JsonArray());
+        return server;
+    }
+
+    /**
+     * Whether the agent advertised {@code agentCapabilities.mcpCapabilities.http} during
+     * initialization. Agents that support HTTP MCP transport should be given an HTTP MCP server
+     * (see {@link #buildMcpHttpServer(String, int)}) rather than a stdio one.
+     */
+    protected final boolean advertisesHttpMcp() {
+        return capabilities != null
+            && capabilities.agentCapabilities() != null
+            && capabilities.agentCapabilities().mcpCapabilities() != null
+            && Boolean.TRUE.equals(capabilities.agentCapabilities().mcpCapabilities().http());
+    }
+
     private void eagerFetchModels() {
         String cwd = launchCwd != null ? launchCwd : project.getBasePath();
         if (cwd == null) return;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
@@ -275,16 +275,97 @@ public final class KiroClient extends AcpClient {
 
     @Override
     protected void customizeNewSession(String cwd, int mcpPort, JsonObject params) {
-        // Kiro requires mcpServers in session/new params (field is mandatory)
-        JsonObject server = buildMcpStdioServer("agentbridge", mcpPort);
-        if (server == null) {
-            throw new IllegalStateException(
-                "Cannot configure Kiro MCP server — " + describeMcpStdioServerFailure());
+        // Kiro requires mcpServers in session/new params (field is mandatory).
+        //
+        // Kiro 2.14.1 only loads @agentbridge tools when given an HTTP MCP server — it silently
+        // ignores STDIO servers over ACP (never emits kiro.dev/mcp/server_initialized). The HTTP
+        // entry must be shaped exactly (including a `headers` ARRAY — see
+        // AcpClient.buildMcpHttpServerJson); a malformed entry makes Kiro exit cleanly on
+        // session/new. (See issue #948.)
+        //
+        // Transport selection stays version-gated rather than driven by mcpCapabilities.http alone:
+        // older Kiro (e.g. 2.10.0) also advertises mcpCapabilities.http:true, but was only ever
+        // observed with the earlier (headerless) HTTP payload, which crashed its ACP process on
+        // session/new. Whether those versions accept the corrected payload was not verified, so we
+        // conservatively require a known-good version (2.14.1+) before sending HTTP and fall back to
+        // STDIO otherwise. STDIO leaves the session alive (just without @agentbridge tools), which
+        // is no worse than the pre-fix behaviour on those versions — it avoids any risk of
+        // regressing an older Kiro from "session works" to "session dies".
+        JsonObject server;
+        if (advertisesHttpMcp() && supportsHttpMcp(kiroVersion())) {
+            server = buildMcpHttpServer("agentbridge", mcpPort);
+        } else {
+            server = buildMcpStdioServer("agentbridge", mcpPort);
+            if (server == null) {
+                throw new IllegalStateException(
+                    "Cannot configure Kiro MCP server — " + describeMcpStdioServerFailure());
+            }
         }
         JsonArray servers = new JsonArray();
         servers.add(server);
         params.add("mcpServers", servers);
     }
+
+    /**
+     * The Kiro CLI version reported in the ACP {@code initialize} response, or {@code null}
+     * if the agent hasn't initialized yet or didn't report a version.
+     */
+    private @org.jetbrains.annotations.Nullable String kiroVersion() {
+        var caps = getCapabilities();
+        return caps != null && caps.agentInfo() != null ? caps.agentInfo().version() : null;
+    }
+
+    /**
+     * The lowest Kiro CLI version verified to load an HTTP MCP server over ACP with the corrected
+     * {@code session/new} payload (see {@link AcpClient#buildMcpHttpServerJson}). Older versions
+     * advertise {@code mcpCapabilities.http:true} but were only ever exercised with the earlier
+     * headerless payload, which crashed their ACP process; they were not re-verified with the fix,
+     * so they conservatively fall back to the STDIO transport instead.
+     */
+    private static final int[] MIN_HTTP_MCP_VERSION = {2, 14, 1};
+
+    /**
+     * Whether the given Kiro CLI version string (e.g. {@code "2.14.1"}) is at least
+     * {@link #MIN_HTTP_MCP_VERSION}. Unparseable or {@code null} versions return {@code false}
+     * so we conservatively fall back to STDIO.
+     */
+    static boolean supportsHttpMcp(@org.jetbrains.annotations.Nullable String version) {
+        int[] parsed = parseVersion(version);
+        if (parsed == null) {
+            return false;
+        }
+        for (int i = 0; i < MIN_HTTP_MCP_VERSION.length; i++) {
+            int part = i < parsed.length ? parsed[i] : 0;
+            if (part != MIN_HTTP_MCP_VERSION[i]) {
+                return part > MIN_HTTP_MCP_VERSION[i];
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Parses a dotted numeric version string into its {@code major.minor.patch} components.
+     * Trailing pre-release/build suffixes (e.g. {@code "-beta"}, {@code "+build"}) on the last
+     * numeric segment are ignored. Returns {@code null} if no leading numeric component is present.
+     */
+    private static int @org.jetbrains.annotations.Nullable [] parseVersion(
+        @org.jetbrains.annotations.Nullable String version) {
+        if (version == null || version.isBlank()) {
+            return null;
+        }
+        String[] segments = version.trim().split("\\.");
+        int[] parts = new int[segments.length];
+        for (int i = 0; i < segments.length; i++) {
+            java.util.regex.Matcher m = LEADING_DIGITS.matcher(segments[i]);
+            if (!m.find()) {
+                return i == 0 ? null : java.util.Arrays.copyOf(parts, i);
+            }
+            parts[i] = Integer.parseInt(m.group());
+        }
+        return parts;
+    }
+
+    private static final Pattern LEADING_DIGITS = Pattern.compile("^\\d+");
 
     @Override
     protected JsonObject parseToolCallArguments(@NotNull JsonObject update) {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/AcpClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/AcpClientTest.java
@@ -28,6 +28,38 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AcpClientTest {
 
+    // ── buildMcpHttpServerJson (package-private static) ─────────────────
+
+    @Nested
+    class BuildMcpHttpServerJson {
+
+        @Test
+        void producesHttpServerShape() {
+            JsonObject server = AcpClient.buildMcpHttpServerJson("agentbridge", 8643);
+            assertEquals("http", server.get("type").getAsString());
+            assertEquals("agentbridge", server.get("name").getAsString());
+            assertEquals("http://127.0.0.1:8643/mcp", server.get("url").getAsString());
+        }
+
+        @Test
+        void includesEmptyHeadersArray() {
+            // Kiro 2.14.1's session/new parser requires an HTTP MCP entry to carry a `headers`
+            // ARRAY (even when empty). Without it — or with `headers` as an object — the Kiro ACP
+            // process exits cleanly on session/new and the whole session dies. (Issue #948.)
+            JsonObject server = AcpClient.buildMcpHttpServerJson("agentbridge", 8643);
+            assertTrue(server.has("headers"), "HTTP MCP entry must include a headers field");
+            assertTrue(server.get("headers").isJsonArray(), "headers must be a JSON array");
+            assertEquals(0, server.getAsJsonArray("headers").size());
+        }
+
+        @Test
+        void honorsServerNameAndPort() {
+            JsonObject server = AcpClient.buildMcpHttpServerJson("custom", 12345);
+            assertEquals("custom", server.get("name").getAsString());
+            assertEquals("http://127.0.0.1:12345/mcp", server.get("url").getAsString());
+        }
+    }
+
     // ── truncateForLog (private static) ─────────────────────────────────
 
     @Nested

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientTest.java
@@ -92,8 +92,46 @@ class KiroClientTest {
         assertTrue(agentIdx > acpIdx, "--agent must come after acp subcommand");
     }
 
-    // ── buildEnvironmentStatic ──────────────────────────────────────────
+    // ── supportsHttpMcp (version gating) ────────────────────────────────
 
+    @ParameterizedTest
+    @CsvSource({
+        "2.14.1, true",
+        "2.14.2, true",
+        "2.15.0, true",
+        "3.0.0, true",
+        "2.14.0, false",
+        "2.13.9, false",
+        "2.10.0, false",
+        "1.99.99, false",
+        "2.14, false",
+    })
+    void supportsHttpMcp_versionThreshold(String version, boolean expected) {
+        assertEquals(expected, KiroClient.supportsHttpMcp(version));
+    }
+
+    @Test
+    void supportsHttpMcp_nullIsFalse() {
+        assertFalse(KiroClient.supportsHttpMcp(null));
+    }
+
+    @Test
+    void supportsHttpMcp_blankIsFalse() {
+        assertFalse(KiroClient.supportsHttpMcp("   "));
+    }
+
+    @Test
+    void supportsHttpMcp_garbageIsFalse() {
+        assertFalse(KiroClient.supportsHttpMcp("not-a-version"));
+    }
+
+    @Test
+    void supportsHttpMcp_toleratesSuffix() {
+        assertTrue(KiroClient.supportsHttpMcp("2.14.1-beta"));
+        assertTrue(KiroClient.supportsHttpMcp("2.15.0+build.7"));
+    }
+
+    // ── buildEnvironmentStatic ──────────────────────────────────────────
     @Test
     void buildEnvironment_includesRustBacktrace() {
         Map<String, String> env = KiroClient.buildEnvironmentStatic();


### PR DESCRIPTION
## Summary

Fixes #948.

In Kiro CLI sessions, only \`web_fetch\`/\`web_search\` were available — none of the \`@agentbridge/\` MCP tools loaded, leaving the agent with effectively no IDE/file tools.

## Root cause

Kiro 2.14.1 advertises \`mcpCapabilities: { http: true, sse: false }\` during ACP \`initialize\`, but \`KiroClient.customizeNewSession()\` injected a **stdio** MCP server via \`buildMcpStdioServer()\`. Kiro 2.14.1 silently ignores stdio MCP servers passed over ACP, so \`_kiro.dev/mcp/server_initialized\` never fired and no tools loaded.

Switching to an HTTP MCP server (pointing at the already-running \`McpHttpServer\`) surfaced a second, subtler bug: Kiro's \`session/new\` parser **requires the HTTP server entry to carry a \`headers\` field as a JSON array** (even empty \`[]\`). Without it — or with \`headers\` as an object — Kiro exits cleanly (exit code 0, no stderr, never connecting to MCP) the instant it parses \`session/new\`, killing the whole session.

The correct shape is:
\`\`\`json
{"type":"http","name":"agentbridge","url":"http://127.0.0.1:<port>/mcp","headers":[]}
\`\`\`

## The fix

- \`AcpClient\`: added \`buildMcpHttpServer()\` / \`buildMcpHttpServerJson()\` that emit the HTTP MCP server entry **including the mandatory empty \`headers\` array**, plus \`advertisesHttpMcp()\` to honor \`mcpCapabilities.http\`.
- \`KiroClient.customizeNewSession()\`: for Kiro ≥ 2.14.1 that advertises HTTP MCP, inject the HTTP server instead of stdio. Older versions fall back to stdio (no worse than before). The version gate is a conservative safeguard since older Kiro couldn't be re-verified.
- Added unit tests covering the HTTP MCP JSON shape (including the \`headers:[]\` array).

## Verification

- A/B tested directly over ACP against real kiro-cli 2.14.1 (\`--agent-engine v2\`): stdio ❌, http+\`headers:[]\` ✅ — Kiro emits \`_kiro.dev/mcp/server_initialized: agentbridge\` and POSTs \`initialize → notifications/initialized → tools/list\`.
- Verified end-to-end in the real IntelliJ sandbox: all \`@agentbridge/\` tools now load in Kiro sessions.
- Unit tests pass.