### PR TITLE
fix: stabilize auto-format, VCS saves, navigation, and IDE verification

### DIFF
--- a/ide-integration-tests/src/test/kotlin/com/github/catatafishen/agentbridge/integration/GoToDeclarationIntegrationTest.kt
+++ b/ide-integration-tests/src/test/kotlin/com/github/catatafishen/agentbridge/integration/GoToDeclarationIntegrationTest.kt
@@ -11,9 +11,9 @@ import java.time.Duration
  *
  * Points the tool at a *usage* of {@code navigationSymbol} ({@code navigationUsageFile}:{@code line})
  * and asserts the resolved declaration snippet mentions the symbol. This is the bench guard for
- * issue #794 bug #3: for C/C++ leaf identifiers {@code getReference()} is null, so
- * {@code GoToDeclarationTool} resolves via the platform's language-agnostic
- * {@code findReferenceAt}/{@code TargetElementUtil} path — a red cell means that path no longer
+ * issue #794 bug #3: C/C++ leaf identifiers may have no PSI reference, so
+ * {@code GoToDeclarationTool} mirrors the IDE's provider-first declaration pipeline, then uses
+ * {@code TargetElementUtil} and PSI fallbacks. A red cell means that native pipeline no longer
  * resolves against the real CLion Nova backend. RD has no {@code navigationUsageFile} yet, so the
  * cell skips ({@code assumeTrue}) and renders as not-implemented (❓).
  */

--- a/ide-integration-tests/src/test/kotlin/com/github/catatafishen/agentbridge/integration/GoToDeclarationIntegrationTest.kt
+++ b/ide-integration-tests/src/test/kotlin/com/github/catatafishen/agentbridge/integration/GoToDeclarationIntegrationTest.kt
@@ -11,11 +11,12 @@ import java.time.Duration
  *
  * Points the tool at a *usage* of {@code navigationSymbol} ({@code navigationUsageFile}:{@code line})
  * and asserts the resolved declaration snippet mentions the symbol. This is the bench guard for
- * issue #794 bug #3: C/C++ leaf identifiers may have no PSI reference, so
- * {@code GoToDeclarationTool} mirrors the IDE's provider-first declaration pipeline, then uses
- * {@code TargetElementUtil} and PSI fallbacks. A red cell means that native pipeline no longer
- * resolves against the real CLion Nova backend. RD has no {@code navigationUsageFile} yet, so the
- * cell skips ({@code assumeTrue}) and renders as not-implemented (❓).
+ * issue #794 bug #3: CLion Nova delegates {@code GotoDeclaration} to Rider.Backend instead of
+ * exposing C/C++ semantic targets through frontend PSI. The tool must therefore invoke the real
+ * IDE action in a live editor when frontend providers and PSI return nothing. A red cell means
+ * that end-to-end backend navigation no longer resolves in real CLion. RD has no
+ * {@code navigationUsageFile} yet, so the cell skips ({@code assumeTrue}) and renders as
+ * not-implemented (❓).
  */
 class GoToDeclarationIntegrationTest {
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editing/EditingTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editing/EditingTool.java
@@ -5,10 +5,7 @@ import com.github.catatafishen.agentbridge.psi.tools.Tool;
 import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
 import com.github.catatafishen.agentbridge.services.ToolRegistry;
 import com.google.gson.JsonObject;
-import com.intellij.codeInsight.actions.ReformatCodeProcessor;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.command.WriteCommandAction;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
@@ -33,8 +30,6 @@ import java.util.List;
  */
 public abstract class EditingTool extends Tool {
 
-    private static final Logger LOG = Logger.getInstance(EditingTool.class);
-
     protected static final String PARAM_PATH = "path";
     protected static final String PARAM_SYMBOL = "symbol";
     protected static final String PARAM_LINE = "line";
@@ -55,20 +50,9 @@ public abstract class EditingTool extends Tool {
     }
 
     protected void formatInline(VirtualFile vf) {
-        if (vf.getLength() > FileTool.MAX_BYTES_FOR_REFORMAT) {
-            LOG.info("Inline reformat skipped (file too large: " + vf.getLength() + " bytes): " + vf.getPath());
-            FileTool.queueAutoFormat(project, vf.getPath());
-            return;
-        }
-        PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
-        if (psiFile == null) return;
-        WriteCommandAction.runWriteCommandAction(project, "Auto-Format (Symbol Edit)", null, () -> {
-            PsiDocumentManager.getInstance(project).commitAllDocuments();
-            new ReformatCodeProcessor(psiFile, false).run();
-            PsiDocumentManager.getInstance(project).commitAllDocuments();
-        });
-        // Defer import optimization to end of turn so imports added by earlier
-        // edits in the same response are not stripped before later edits use them.
+        // Reformat and import optimization share one deferred background pipeline.
+        // Starting a single-file processor here only queues another background task and,
+        // when wrapped in our own write action, can deadlock the EDT against that task's read phase.
         FileTool.queueAutoFormat(project, vf.getPath());
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
@@ -80,6 +80,13 @@ public abstract class FileTool extends Tool {
     private static final long AUTO_FORMAT_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(30);
 
     /**
+     * Bound each processor invocation so a timeout retains only a small failed chunk instead of
+     * restarting an arbitrarily large queue from the beginning on every retry.
+     */
+    @VisibleForTesting
+    static final int AUTO_FORMAT_BATCH_SIZE = 10;
+
+    /**
      * Files larger than this threshold skip import optimization during deferred auto-format.
      * Import optimization resolves every symbol reference to determine unused imports, so it
      * remains size-guarded even though the processor now runs off the EDT.
@@ -164,32 +171,51 @@ public abstract class FileTool extends Tool {
 
     static boolean flushWhileLocked(Project project, AutoFormatState state,
                                     long deadlineNanos) {
-        List<String> currentBatch = List.of();
+        return flushWhileLocked(
+            project,
+            state,
+            deadlineNanos,
+            (paths, deadline) -> processAutoFormatBatch(project, paths, deadline));
+    }
+
+    @VisibleForTesting
+    static boolean flushWhileLocked(Project project, AutoFormatState state,
+                                    long deadlineNanos,
+                                    AutoFormatBatchProcessor processor) {
+        List<String> remainingPaths = List.of();
         try {
             while (!project.isDisposed()) {
-                currentBatch = state.drain();
-                if (currentBatch.isEmpty()) return true;
+                if (remainingPaths.isEmpty()) {
+                    remainingPaths = state.drain();
+                    if (remainingPaths.isEmpty()) return true;
+                }
                 if (Thread.currentThread().isInterrupted()) {
-                    state.requeueFirst(currentBatch);
+                    state.requeueFirst(remainingPaths);
                     Thread.currentThread().interrupt();
                     LOG.warn("Deferred auto-format interrupted before processing");
                     return false;
                 }
-                if (!processAutoFormatBatch(project, currentBatch, deadlineNanos)) {
-                    state.requeueFirst(currentBatch);
+
+                int batchSize = Math.min(AUTO_FORMAT_BATCH_SIZE, remainingPaths.size());
+                List<String> currentBatch =
+                    new ArrayList<>(remainingPaths.subList(0, batchSize));
+                if (!processor.process(currentBatch, deadlineNanos)) {
+                    state.requeueFirst(remainingPaths);
                     return false;
                 }
-                currentBatch = List.of();
+                remainingPaths = batchSize == remainingPaths.size()
+                    ? List.of()
+                    : new ArrayList<>(remainingPaths.subList(batchSize, remainingPaths.size()));
             }
 
-            state.requeueFirst(currentBatch);
+            state.requeueFirst(remainingPaths);
             return false;
         } catch (ProcessCanceledException e) {
-            state.requeueFirst(currentBatch);
+            state.requeueFirst(remainingPaths);
             LOG.warn("Deferred auto-format cancelled before completion");
             return false;
         } catch (RuntimeException e) {
-            state.requeueFirst(currentBatch);
+            state.requeueFirst(remainingPaths);
             LOG.warn("Deferred auto-format failed; queued files were retained", e);
             return false;
         }
@@ -301,7 +327,12 @@ public abstract class FileTool extends Tool {
     @Nullable
     private static ResolvedFormatFile resolveFormatFile(Project project, String path) {
         VirtualFile virtualFile = ToolUtils.resolveVirtualFile(project, path);
-        if (!isUsableFormatFile(virtualFile)) return null;
+        if (!isUsableFormatFile(virtualFile)) {
+            if (virtualFile != null && virtualFile.isValid() && !virtualFile.isWritable()) {
+                LOG.info("Deferred auto-format skipped (read-only): " + path);
+            }
+            return null;
+        }
 
         long fileBytes = virtualFile.getLength();
         if (fileBytes > MAX_BYTES_FOR_REFORMAT) {
@@ -322,7 +353,7 @@ public abstract class FileTool extends Tool {
 
     @VisibleForTesting
     static boolean isUsableFormatFile(@Nullable VirtualFile virtualFile) {
-        return virtualFile != null && virtualFile.isValid();
+        return virtualFile != null && virtualFile.isValid() && virtualFile.isWritable();
     }
 
     @VisibleForTesting
@@ -387,6 +418,11 @@ public abstract class FileTool extends Tool {
     }
 
     @FunctionalInterface
+    interface AutoFormatBatchProcessor {
+        boolean process(List<String> paths, long deadlineNanos);
+    }
+
+    @FunctionalInterface
     interface LayoutProcessorRunner {
         boolean run(List<PsiFile> files, boolean optimizeImports);
     }
@@ -405,7 +441,12 @@ public abstract class FileTool extends Tool {
 
         @VisibleForTesting
         boolean isIdle() {
-            return !flushLock.isLocked() && !hasPending();
+            if (!flushLock.tryLock()) return false;
+            try {
+                return !hasPending();
+            } finally {
+                flushLock.unlock();
+            }
         }
 
         private boolean hasPending() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
@@ -8,10 +8,11 @@ import com.github.catatafishen.agentbridge.psi.review.AgentEditSession;
 import com.github.catatafishen.agentbridge.psi.tools.Tool;
 import com.github.catatafishen.agentbridge.services.ToolRegistry;
 import com.github.catatafishen.agentbridge.settings.McpServerSettings;
+import com.intellij.codeInsight.actions.AbstractLayoutCodeProcessor;
 import com.intellij.codeInsight.actions.OptimizeImportsProcessor;
 import com.intellij.codeInsight.actions.ReformatCodeProcessor;
-import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.EditorCustomElementRenderer;
@@ -25,11 +26,13 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.fileEditor.TextEditor;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.util.ProgressIndicatorBase;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.ReadonlyStatusHandler;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.util.Alarm;
@@ -41,10 +44,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Abstract base for file tools. Provides shared static utilities for
@@ -69,167 +76,300 @@ public abstract class FileTool extends Tool {
 
     // ── Deferred auto-format (per-project) ────────────────────────────────────
 
-    /**
-     * Maximum number of files to process in a single auto-format flush.
-     * Prevents EDT saturation when many files are queued: each file's format
-     * runs inside a WriteCommandAction (blocking EDT). Overflow is requeued.
-     */
-    private static final int MAX_AUTO_FORMAT_FILES = 10;
+    private static final long AUTO_FORMAT_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(30);
 
     /**
      * Files larger than this threshold skip import optimization during deferred auto-format.
-     * OptimizeImportsProcessor resolves every symbol reference to determine unused imports —
-     * on large Kotlin files (e.g. 116 KB) this can block the EDT for 30+ seconds, causing
-     * cascading timeouts in write_file, run_command, and git_commit.
+     * Import optimization resolves every symbol reference to determine unused imports, so it
+     * remains size-guarded even though the processor now runs off the EDT.
      */
     public static final long MAX_BYTES_FOR_OPTIMIZE_IMPORTS = 50 * 1024L;
 
     /**
-     * Files larger than this threshold skip both optimize-imports and reformat during deferred
-     * auto-format. ReformatCodeProcessor on very large files can still block the EDT for
-     * 10–20 seconds — above this size it is safer to skip formatting entirely.
+     * Files larger than this threshold skip both import optimization and reformatting.
      */
     public static final long MAX_BYTES_FOR_REFORMAT = 100 * 1024L;
 
-    private static final ConcurrentHashMap<Project, Set<String>> PENDING_AUTO_FORMAT =
-        new ConcurrentHashMap<>();
+    /**
+     * Weak project keys keep per-project queues and locks scoped to the project lifetime.
+     * Access to the map itself is synchronized; each state protects its own ordered path set.
+     */
+    private static final Map<Project, AutoFormatState> AUTO_FORMAT_STATES =
+        Collections.synchronizedMap(new WeakHashMap<>());
 
     public static void queueAutoFormat(Project project, String path) {
-        PENDING_AUTO_FORMAT.computeIfAbsent(project,
-            k -> Collections.synchronizedSet(new LinkedHashSet<>())).add(path);
+        if (project.isDisposed()) return;
+        getOrCreateAutoFormatState(project).add(path);
     }
 
-    public static void flushPendingAutoFormat(Project project) {
-        Set<String> pathSet = PENDING_AUTO_FORMAT.remove(project);
-        if (pathSet == null || pathSet.isEmpty()) return;
-
-        List<String> paths = new ArrayList<>(pathSet);
-
-        // Safety cap: if too many files are queued, process only the first batch and requeue
-        // the rest. This prevents EDT saturation from blocking the editor for 30+ seconds.
-        if (paths.size() > MAX_AUTO_FORMAT_FILES) {
-            LOG.warn("Auto-format batch capped at " + MAX_AUTO_FORMAT_FILES + " of " + paths.size()
-                + " files; requeueing overflow for the next turn");
-            List<String> overflow = paths.subList(MAX_AUTO_FORMAT_FILES, paths.size());
-            PENDING_AUTO_FORMAT.merge(project,
-                Collections.synchronizedSet(new LinkedHashSet<>(overflow)),
-                (existing, added) -> {
-                    existing.addAll(added);
-                    return existing;
-                });
-            paths = new ArrayList<>(paths.subList(0, MAX_AUTO_FORMAT_FILES));
+    /**
+     * Flushes deferred formatting and returns only after the JetBrains processors and document
+     * save have actually completed.
+     *
+     * <p>The processor pipeline must run on a background thread. Calling this method from the EDT
+     * schedules a background flush and returns {@code false}; callers that require a durable
+     * working tree (notably Git write tools) must treat that as an incomplete flush and abort.
+     */
+    public static boolean flushPendingAutoFormat(Project project) {
+        if (project.isDisposed()) {
+            removeAutoFormatState(project);
+            return false;
         }
 
-        if (com.intellij.openapi.application.ApplicationManager.getApplication().isDispatchThread()) {
-            for (String pathStr : paths) {
-                formatSingleFile(project, pathStr);
-            }
-            saveAllDocuments();
-            return;
+        AutoFormatState state = getAutoFormatState(project);
+        if (state == null || state.isIdle()) return true;
+
+        if (ApplicationManager.getApplication().isDispatchThread()) {
+            ApplicationManager.getApplication().executeOnPooledThread(
+                () -> flushPendingAutoFormat(project));
+            return false;
         }
 
-        java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
-        AtomicBoolean cancelled = new AtomicBoolean(false);
+        return flushOnBackgroundThread(project, state);
+    }
 
-        scheduleNextFormat(project, paths, 0, latch, cancelled);
-
+    private static boolean flushOnBackgroundThread(Project project, AutoFormatState state) {
+        long deadlineNanos = System.nanoTime() + AUTO_FORMAT_TIMEOUT_NANOS;
         try {
-            if (!latch.await(30, java.util.concurrent.TimeUnit.SECONDS)) {
-                // Stop the EDT chain — without this, remaining invokeLater tasks would keep running
-                // after we return, blocking the EDT and causing subsequent invokeAndWait calls to time out.
-                cancelled.set(true);
-                LOG.warn("flushPendingAutoFormat timed out after 30 seconds");
+            if (!tryAcquireFlushLock(state, deadlineNanos)) {
+                LOG.warn("Deferred auto-format timed out waiting for another flush");
+                return false;
             }
         } catch (InterruptedException e) {
-            cancelled.set(true);
             Thread.currentThread().interrupt();
-            LOG.warn("flushPendingAutoFormat interrupted");
+            LOG.warn("Deferred auto-format interrupted while waiting for the flush lock");
+            return false;
         }
-    }
 
-    /**
-     * Chains auto-format operations sequentially via {@code invokeLater}, one file per EDT event.
-     * <p>
-     * Unlike bulk-dispatching all files at once, chaining allows the EDT to process paint and
-     * input events between each file — keeping the editor responsive during multi-file formatting.
-     * The {@code cancelled} flag is checked before each step so that a background-thread timeout
-     * in {@link #flushPendingAutoFormat} immediately stops further scheduling.
-     */
-    private static void scheduleNextFormat(Project project, List<String> paths, int index,
-                                           java.util.concurrent.CountDownLatch latch,
-                                           AtomicBoolean cancelled) {
-        if (cancelled.get() || project.isDisposed()) {
-            latch.countDown(); // no-op if background thread already timed out
-            return;
-        }
-        if (index >= paths.size()) {
-            saveAllDocuments();
-            latch.countDown();
-            return;
-        }
-        EdtUtil.invokeLater(() -> {
-            if (!cancelled.get() && !project.isDisposed()) {
-                formatSingleFile(project, paths.get(index));
-            }
-            scheduleNextFormat(project, paths, index + 1, latch, cancelled);
-        });
-    }
-
-    /**
-     * Formats and optimizes imports for a single file inside a write action.
-     *
-     * <p>Size-guarded: {@link OptimizeImportsProcessor} resolves every symbol in the file to
-     * detect unused imports — on large Kotlin files this can block the EDT for 30+ seconds.
-     * {@link ReformatCodeProcessor} is also expensive above ~100 KB. Files that exceed the
-     * configured thresholds are logged and skipped to prevent cascading tool timeouts.</p>
-     */
-    private static void formatSingleFile(Project project, String pathStr) {
         try {
-            VirtualFile vf = ToolUtils.resolveVirtualFile(project, pathStr);
-            if (vf == null) return;
-            long fileBytes = vf.getLength();
-            if (fileBytes > MAX_BYTES_FOR_REFORMAT) {
-                LOG.info("Deferred auto-format skipped (file too large for reformat: " + fileBytes + " bytes): " + pathStr);
-                return;
-            }
-            boolean runOptimizeImports = fileBytes <= MAX_BYTES_FOR_OPTIMIZE_IMPORTS;
-            PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
-            if (psiFile == null) return;
-            // AbstractLayoutCodeProcessor.runProcessFile() calls ensureFilesWritable() internally.
-            // For non-project files this may show an "unlock file?" dialog — which is illegal
-            // inside a write action (causes "AWT events not allowed inside write action").
-            // Pre-resolve write access here, outside the write action, so the dialog (if any)
-            // is shown before we acquire the write lock.
-            ReadonlyStatusHandler.OperationStatus writeStatus =
-                ReadonlyStatusHandler.getInstance(project).ensureFilesWritable(Collections.singletonList(vf));
-            if (writeStatus.hasReadonlyFiles()) {
-                LOG.info("Deferred auto-format skipped (read-only): " + pathStr);
-                return;
-            }
-            Document doc = psiFile.getViewProvider().getDocument();
-            WriteCommandAction.runWriteCommandAction(project, "Auto-Format (Deferred)", null, () -> {
-                if (doc != null)
-                    PsiDocumentManager.getInstance(project).commitDocument(doc);
-                if (runOptimizeImports) new OptimizeImportsProcessor(project, psiFile).run();
-                new ReformatCodeProcessor(psiFile, false).run();
-                if (doc != null)
-                    PsiDocumentManager.getInstance(project).commitDocument(doc);
-            });
-            if (runOptimizeImports) {
-                LOG.info("Deferred auto-format (optimize-imports + reformat): " + pathStr);
-            } else {
-                LOG.info("Deferred auto-format (reformat only, large file " + fileBytes + " bytes): " + pathStr);
-            }
-        } catch (Exception e) {
-            LOG.warn("Deferred auto-format failed for " + pathStr + ": " + e.getMessage());
+            return flushWhileLocked(project, state, deadlineNanos);
+        } finally {
+            state.flushLock.unlock();
         }
     }
 
-    private static void saveAllDocuments() {
+    private static boolean tryAcquireFlushLock(AutoFormatState state, long deadlineNanos)
+        throws InterruptedException {
+        long lockWaitNanos = deadlineNanos - System.nanoTime();
+        return lockWaitNanos > 0
+            && state.flushLock.tryLock(lockWaitNanos, TimeUnit.NANOSECONDS);
+    }
+
+    private static boolean flushWhileLocked(Project project, AutoFormatState state,
+                                            long deadlineNanos) {
+        List<String> currentBatch = List.of();
         try {
-            WriteAction.run(() -> FileDocumentManager.getInstance().saveAllDocuments());
-        } catch (Exception e) {
-            LOG.warn("Failed to save documents after auto-format", e);
+            while (!project.isDisposed()) {
+                currentBatch = state.drain();
+                if (currentBatch.isEmpty()) return true;
+                if (Thread.currentThread().isInterrupted()) {
+                    state.requeueFirst(currentBatch);
+                    Thread.currentThread().interrupt();
+                    LOG.warn("Deferred auto-format interrupted before processing");
+                    return false;
+                }
+                if (!processAutoFormatBatch(project, currentBatch, deadlineNanos)) {
+                    state.requeueFirst(currentBatch);
+                    return false;
+                }
+                currentBatch = List.of();
+            }
+
+            state.requeueFirst(currentBatch);
+            return false;
+        } catch (ProcessCanceledException e) {
+            state.requeueFirst(currentBatch);
+            LOG.warn("Deferred auto-format cancelled before completion");
+            return false;
+        } catch (RuntimeException e) {
+            state.requeueFirst(currentBatch);
+            LOG.warn("Deferred auto-format failed; queued files were retained", e);
+            return false;
+        }
+    }
+
+    private static boolean processAutoFormatBatch(Project project, List<String> paths,
+                                                  long deadlineNanos) {
+        long remainingNanos = deadlineNanos - System.nanoTime();
+        if (remainingNanos <= 0) {
+            LOG.warn("Deferred auto-format timed out before processing could start");
+            return false;
+        }
+
+        ProgressIndicatorBase indicator = new ProgressIndicatorBase();
+        ScheduledFuture<?> cancellation = com.intellij.util.concurrency.AppExecutorUtil
+            .getAppScheduledExecutorService()
+            .schedule(indicator::cancel, remainingNanos, TimeUnit.NANOSECONDS);
+        AtomicBoolean completed = new AtomicBoolean(false);
+        try {
+            ProgressManager.getInstance().runProcess(
+                () -> completed.set(runAutoFormatBatch(project, paths, indicator)),
+                indicator);
+            if (indicator.isCanceled()) {
+                LOG.warn("Deferred auto-format exceeded the 30-second deadline");
+                return false;
+            }
+            return completed.get();
+        } finally {
+            cancellation.cancel(false);
+        }
+    }
+
+    private static boolean runAutoFormatBatch(Project project, List<String> paths,
+                                              ProgressIndicator indicator) {
+        FormatPlan plan = createFormatPlan(project, paths, indicator);
+        boolean optimizedAndReformatted =
+            runLayoutProcessor(project, plan.optimizeAndReformat(), true, indicator);
+        if (!optimizedAndReformatted) return false;
+
+        boolean reformatted =
+            runLayoutProcessor(project, plan.reformatOnly(), false, indicator);
+        if (!reformatted) return false;
+
+        indicator.checkCanceled();
+        FileDocumentManager documentManager = FileDocumentManager.getInstance();
+        documentManager.saveAllDocuments();
+        for (Document document : plan.documents()) {
+            if (documentManager.isDocumentUnsaved(document)) {
+                LOG.warn("Deferred auto-format completed, but a processed document remained unsaved");
+                return false;
+            }
+        }
+
+        LOG.info("Deferred auto-format completed for " + paths.size() + " queued file(s)");
+        return true;
+    }
+
+    private static FormatPlan createFormatPlan(Project project, List<String> paths,
+                                               ProgressIndicator indicator) {
+        List<PsiFile> optimizeAndReformat = new ArrayList<>();
+        List<PsiFile> reformatOnly = new ArrayList<>();
+        List<Document> documents = new ArrayList<>();
+
+        for (String path : paths) {
+            indicator.checkCanceled();
+            ResolvedFormatFile resolved = resolveFormatFile(project, path);
+            if (resolved != null) {
+                addToFormatPlan(resolved, optimizeAndReformat, reformatOnly, documents);
+            }
+        }
+
+        return new FormatPlan(optimizeAndReformat, reformatOnly, documents);
+    }
+
+    @Nullable
+    private static ResolvedFormatFile resolveFormatFile(Project project, String path) {
+        VirtualFile virtualFile = ToolUtils.resolveVirtualFile(project, path);
+        if (virtualFile == null || !virtualFile.isValid()) return null;
+
+        long fileBytes = virtualFile.getLength();
+        if (fileBytes > MAX_BYTES_FOR_REFORMAT) {
+            LOG.info("Deferred auto-format skipped (file too large: "
+                + fileBytes + " bytes): " + path);
+            return null;
+        }
+
+        return ReadAction.nonBlocking(() -> {
+                PsiFile psiFile = PsiManager.getInstance(project).findFile(virtualFile);
+                if (psiFile == null) return null;
+                Document document = FileDocumentManager.getInstance().getDocument(virtualFile);
+                return new ResolvedFormatFile(psiFile, document, fileBytes);
+            })
+            .expireWith(project)
+            .executeSynchronously();
+    }
+
+    private static void addToFormatPlan(ResolvedFormatFile resolved,
+                                        List<PsiFile> optimizeAndReformat,
+                                        List<PsiFile> reformatOnly,
+                                        List<Document> documents) {
+        if (resolved.document() != null) documents.add(resolved.document());
+        if (resolved.fileBytes() <= MAX_BYTES_FOR_OPTIMIZE_IMPORTS) {
+            optimizeAndReformat.add(resolved.psiFile());
+        } else {
+            reformatOnly.add(resolved.psiFile());
+        }
+    }
+
+    private static boolean runLayoutProcessor(Project project, List<PsiFile> files,
+                                              boolean optimizeImports,
+                                              ProgressIndicator indicator) {
+        if (files.isEmpty()) return true;
+
+        PsiFile[] fileArray = files.toArray(new PsiFile[0]);
+        AbstractLayoutCodeProcessor processor =
+            new ReformatCodeProcessor(project, fileArray, null, false);
+        if (optimizeImports) {
+            processor = new OptimizeImportsProcessor(processor);
+        }
+        processor.setProcessAllFilesAsSingleUndoStep(false);
+        return processor.processFilesUnderProgress(indicator);
+    }
+
+    private static AutoFormatState getOrCreateAutoFormatState(Project project) {
+        synchronized (AUTO_FORMAT_STATES) {
+            return AUTO_FORMAT_STATES.computeIfAbsent(project, ignored -> new AutoFormatState());
+        }
+    }
+
+    @Nullable
+    private static AutoFormatState getAutoFormatState(Project project) {
+        synchronized (AUTO_FORMAT_STATES) {
+            return AUTO_FORMAT_STATES.get(project);
+        }
+    }
+
+    private static void removeAutoFormatState(Project project) {
+        synchronized (AUTO_FORMAT_STATES) {
+            AUTO_FORMAT_STATES.remove(project);
+        }
+    }
+
+    private record ResolvedFormatFile(PsiFile psiFile, @Nullable Document document, long fileBytes) {
+    }
+
+    private record FormatPlan(List<PsiFile> optimizeAndReformat,
+                              List<PsiFile> reformatOnly,
+                              List<Document> documents) {
+    }
+
+    private static final class AutoFormatState {
+        private final LinkedHashSet<String> pendingPaths = new LinkedHashSet<>();
+        private final ReentrantLock flushLock = new ReentrantLock();
+
+        private void add(String path) {
+            synchronized (pendingPaths) {
+                pendingPaths.add(path);
+            }
+        }
+
+        private boolean isIdle() {
+            return !flushLock.isLocked() && !hasPending();
+        }
+
+        private boolean hasPending() {
+            synchronized (pendingPaths) {
+                return !pendingPaths.isEmpty();
+            }
+        }
+
+        private List<String> drain() {
+            synchronized (pendingPaths) {
+                if (pendingPaths.isEmpty()) return List.of();
+                List<String> paths = new ArrayList<>(pendingPaths);
+                pendingPaths.clear();
+                return paths;
+            }
+        }
+
+        private void requeueFirst(List<String> paths) {
+            if (paths.isEmpty()) return;
+            synchronized (pendingPaths) {
+                LinkedHashSet<String> combined = new LinkedHashSet<>(paths);
+                combined.addAll(pendingPaths);
+                pendingPaths.clear();
+                pendingPaths.addAll(combined);
+            }
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
@@ -155,8 +155,8 @@ public abstract class FileTool extends Tool {
             && state.flushLock.tryLock(lockWaitNanos, TimeUnit.NANOSECONDS);
     }
 
-    private static boolean flushWhileLocked(Project project, AutoFormatState state,
-                                            long deadlineNanos) {
+    static boolean flushWhileLocked(Project project, AutoFormatState state,
+                                    long deadlineNanos) {
         List<String> currentBatch = List.of();
         try {
             while (!project.isDisposed()) {
@@ -333,11 +333,11 @@ public abstract class FileTool extends Tool {
                               List<Document> documents) {
     }
 
-    private static final class AutoFormatState {
+    static final class AutoFormatState {
         private final LinkedHashSet<String> pendingPaths = new LinkedHashSet<>();
         private final ReentrantLock flushLock = new ReentrantLock();
 
-        private void add(String path) {
+        void add(String path) {
             synchronized (pendingPaths) {
                 pendingPaths.add(path);
             }
@@ -353,7 +353,7 @@ public abstract class FileTool extends Tool {
             }
         }
 
-        private List<String> drain() {
+        List<String> drain() {
             synchronized (pendingPaths) {
                 if (pendingPaths.isEmpty()) return List.of();
                 List<String> paths = new ArrayList<>(pendingPaths);
@@ -362,7 +362,7 @@ public abstract class FileTool extends Tool {
             }
         }
 
-        private void requeueFirst(List<String> paths) {
+        void requeueFirst(List<String> paths) {
             if (paths.isEmpty()) return;
             synchronized (pendingPaths) {
                 LinkedHashSet<String> combined = new LinkedHashSet<>(paths);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
@@ -38,6 +38,7 @@ import com.intellij.psi.PsiManager;
 import com.intellij.util.Alarm;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.awt.*;
 import java.util.ArrayList;
@@ -129,7 +130,13 @@ public abstract class FileTool extends Tool {
     }
 
     private static boolean flushOnBackgroundThread(Project project, AutoFormatState state) {
-        long deadlineNanos = System.nanoTime() + AUTO_FORMAT_TIMEOUT_NANOS;
+        return flushOnBackgroundThread(project, state, AUTO_FORMAT_TIMEOUT_NANOS);
+    }
+
+    @VisibleForTesting
+    static boolean flushOnBackgroundThread(Project project, AutoFormatState state,
+                                           long timeoutNanos) {
+        long deadlineNanos = System.nanoTime() + timeoutNanos;
         try {
             if (!tryAcquireFlushLock(state, deadlineNanos)) {
                 LOG.warn("Deferred auto-format timed out waiting for another flush");
@@ -190,6 +197,13 @@ public abstract class FileTool extends Tool {
 
     private static boolean processAutoFormatBatch(Project project, List<String> paths,
                                                   long deadlineNanos) {
+        return runAutoFormatWithDeadline(
+            deadlineNanos, indicator -> runAutoFormatBatch(project, paths, indicator));
+    }
+
+    @VisibleForTesting
+    static boolean runAutoFormatWithDeadline(long deadlineNanos,
+                                             AutoFormatBatchRunner runner) {
         long remainingNanos = deadlineNanos - System.nanoTime();
         if (remainingNanos <= 0) {
             LOG.warn("Deferred auto-format timed out before processing could start");
@@ -203,7 +217,7 @@ public abstract class FileTool extends Tool {
         AtomicBoolean completed = new AtomicBoolean(false);
         try {
             ProgressManager.getInstance().runProcess(
-                () -> completed.set(runAutoFormatBatch(project, paths, indicator)),
+                () -> completed.set(runner.run(indicator)),
                 indicator);
             if (indicator.isCanceled()) {
                 LOG.warn("Deferred auto-format exceeded the 30-second deadline");
@@ -217,26 +231,53 @@ public abstract class FileTool extends Tool {
 
     private static boolean runAutoFormatBatch(Project project, List<String> paths,
                                               ProgressIndicator indicator) {
-        FormatPlan plan = createFormatPlan(project, paths, indicator);
-        boolean optimizedAndReformatted =
-            runLayoutProcessor(project, plan.optimizeAndReformat(), true, indicator);
-        if (!optimizedAndReformatted) return false;
+        return runAutoFormatBatch(
+            project,
+            paths,
+            indicator,
+            (files, optimizeImports) ->
+                runLayoutProcessor(project, files, optimizeImports, indicator),
+            FileDocumentManager.getInstance());
+    }
 
-        boolean reformatted =
-            runLayoutProcessor(project, plan.reformatOnly(), false, indicator);
-        if (!reformatted) return false;
+    @VisibleForTesting
+    static boolean runAutoFormatBatch(Project project, List<String> paths,
+                                      ProgressIndicator indicator,
+                                      LayoutProcessorRunner runner,
+                                      FileDocumentManager documentManager) {
+        FormatPlan plan = createFormatPlan(project, paths, indicator);
+        boolean formatted = runFormatProcessors(
+            plan.optimizeAndReformat(),
+            plan.reformatOnly(),
+            runner);
+        if (!formatted) return false;
 
         indicator.checkCanceled();
-        FileDocumentManager documentManager = FileDocumentManager.getInstance();
+        return saveProcessedDocuments(
+            documentManager, plan.documents(), paths.size());
+    }
+
+    @VisibleForTesting
+    static boolean runFormatProcessors(List<PsiFile> optimizeAndReformat,
+                                       List<PsiFile> reformatOnly,
+                                       LayoutProcessorRunner runner) {
+        if (!runner.run(optimizeAndReformat, true)) return false;
+        return runner.run(reformatOnly, false);
+    }
+
+    @VisibleForTesting
+    static boolean saveProcessedDocuments(FileDocumentManager documentManager,
+                                          List<Document> documents,
+                                          int processedPathCount) {
         documentManager.saveAllDocuments();
-        for (Document document : plan.documents()) {
+        for (Document document : documents) {
             if (documentManager.isDocumentUnsaved(document)) {
                 LOG.warn("Deferred auto-format completed, but a processed document remained unsaved");
                 return false;
             }
         }
 
-        LOG.info("Deferred auto-format completed for " + paths.size() + " queued file(s)");
+        LOG.info("Deferred auto-format completed for " + processedPathCount + " queued file(s)");
         return true;
     }
 
@@ -260,7 +301,7 @@ public abstract class FileTool extends Tool {
     @Nullable
     private static ResolvedFormatFile resolveFormatFile(Project project, String path) {
         VirtualFile virtualFile = ToolUtils.resolveVirtualFile(project, path);
-        if (virtualFile == null || !virtualFile.isValid()) return null;
+        if (!isUsableFormatFile(virtualFile)) return null;
 
         long fileBytes = virtualFile.getLength();
         if (fileBytes > MAX_BYTES_FOR_REFORMAT) {
@@ -279,10 +320,16 @@ public abstract class FileTool extends Tool {
             .executeSynchronously();
     }
 
-    private static void addToFormatPlan(ResolvedFormatFile resolved,
-                                        List<PsiFile> optimizeAndReformat,
-                                        List<PsiFile> reformatOnly,
-                                        List<Document> documents) {
+    @VisibleForTesting
+    static boolean isUsableFormatFile(@Nullable VirtualFile virtualFile) {
+        return virtualFile != null && virtualFile.isValid();
+    }
+
+    @VisibleForTesting
+    static void addToFormatPlan(ResolvedFormatFile resolved,
+                                List<PsiFile> optimizeAndReformat,
+                                List<PsiFile> reformatOnly,
+                                List<Document> documents) {
         if (resolved.document() != null) documents.add(resolved.document());
         if (resolved.fileBytes() <= MAX_BYTES_FOR_OPTIMIZE_IMPORTS) {
             optimizeAndReformat.add(resolved.psiFile());
@@ -325,7 +372,8 @@ public abstract class FileTool extends Tool {
         }
     }
 
-    private record ResolvedFormatFile(PsiFile psiFile, @Nullable Document document, long fileBytes) {
+    @VisibleForTesting
+    record ResolvedFormatFile(PsiFile psiFile, @Nullable Document document, long fileBytes) {
     }
 
     private record FormatPlan(List<PsiFile> optimizeAndReformat,
@@ -333,9 +381,21 @@ public abstract class FileTool extends Tool {
                               List<Document> documents) {
     }
 
+    @FunctionalInterface
+    interface AutoFormatBatchRunner {
+        boolean run(ProgressIndicator indicator);
+    }
+
+    @FunctionalInterface
+    interface LayoutProcessorRunner {
+        boolean run(List<PsiFile> files, boolean optimizeImports);
+    }
+
+    @VisibleForTesting
     static final class AutoFormatState {
         private final LinkedHashSet<String> pendingPaths = new LinkedHashSet<>();
-        private final ReentrantLock flushLock = new ReentrantLock();
+        @VisibleForTesting
+        final ReentrantLock flushLock = new ReentrantLock();
 
         void add(String path) {
             synchronized (pendingPaths) {
@@ -343,7 +403,8 @@ public abstract class FileTool extends Tool {
             }
         }
 
-        private boolean isIdle() {
+        @VisibleForTesting
+        boolean isIdle() {
             return !flushLock.isLocked() && !hasPending();
         }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitDiffTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitDiffTool.java
@@ -61,7 +61,6 @@ public final class GitDiffTool extends GitTool {
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
-        flushAndSave();
 
         String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
         String root = resolveRepoRootOrError(repoParam);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStatusTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStatusTool.java
@@ -52,7 +52,6 @@ public final class GitStatusTool extends GitTool {
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
-        flushAndSave();
 
         boolean verbose = args.has(PARAM_VERBOSE) && args.get(PARAM_VERBOSE).getAsBoolean();
         String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
@@ -11,13 +11,11 @@ import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
 import com.github.catatafishen.agentbridge.services.ToolRegistry;
 import com.github.catatafishen.agentbridge.ui.renderers.GitOperationRenderer;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.changes.VcsDirtyScopeManager;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
-import com.intellij.psi.PsiDocumentManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -452,7 +450,10 @@ public abstract class GitTool extends Tool {
      * Called before git commands that need the working tree up-to-date.
      */
     protected void flushAndSave() {
-        FileTool.flushPendingAutoFormat(project);
+        if (!FileTool.flushPendingAutoFormat(project)) {
+            throw new IllegalStateException(
+                "Git operation aborted: deferred auto-format did not complete. Retry the operation.");
+        }
         saveAllDocuments();
     }
 
@@ -580,12 +581,10 @@ public abstract class GitTool extends Tool {
         });
     }
 
-    private void saveAllDocuments() {
-        EdtUtil.invokeAndWait(() ->
-            WriteAction.run(() -> {
-                PsiDocumentManager.getInstance(project).commitAllDocuments();
-                FileDocumentManager.getInstance().saveAllDocuments();
-            }));
+    static void saveAllDocuments() {
+        // FileDocumentManager supports background saves and acquires its own narrow write actions.
+        // Wrapping the whole save in an EDT write action can deadlock against background PSI reads.
+        FileDocumentManager.getInstance().saveAllDocuments();
     }
 
     // ── VCS Log follow-along ─────────────────────────────────

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GoToDeclarationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GoToDeclarationTool.java
@@ -171,30 +171,38 @@ public final class GoToDeclarationTool extends RefactoringTool {
                 document.getLineCount() + FORMAT_LINES_SUFFIX;
         }
 
-        int[] nativeOffset = {-1};
-        Editor editor = openNavigationEditor(document, vf);
-        if (editor == null) return "Error: Cannot open editor for: " + pathStr;
-        String psiResult = ApplicationManager.getApplication().runReadAction(
-            (Computable<String>) () -> {
-                PsiFile psiFile = PsiDocumentManager.getInstance(project).getPsiFile(document);
-                if (psiFile == null) {
-                    return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_CANNOT_PARSE + pathStr;
-                }
-                return resolveAndFormatDeclaration(
-                    psiFile, document, editor, targetLine, symbolName, declInfo, nativeOffset);
-            });
+        IdeDeclarationNavigator.EditorState previousEditor =
+            IdeDeclarationNavigator.captureEditorState(project);
+        try {
+            int[] nativeOffset = {-1};
+            Editor editor = openNavigationEditor(document, vf);
+            if (editor == null) return "Error: Cannot open editor for: " + pathStr;
+            String psiResult = ApplicationManager.getApplication().runReadAction(
+                (Computable<String>) () -> {
+                    PsiFile psiFile = PsiDocumentManager.getInstance(project).getPsiFile(document);
+                    if (psiFile == null) {
+                        return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_CANNOT_PARSE + pathStr;
+                    }
+                    return resolveAndFormatDeclaration(
+                        psiFile, document, editor, targetLine, symbolName, declInfo, nativeOffset);
+                });
 
-        if (psiResult != null) return psiResult;
-        if (nativeOffset[0] >= 0) {
-            IdeDeclarationNavigator.Location location =
-                declarationNavigator.navigate(vf, nativeOffset[0]);
-            if (location != null) {
-                String nativeResult = formatNavigatedDeclaration(location, symbolName, declInfo);
-                if (nativeResult != null) return nativeResult;
+            if (psiResult != null) return psiResult;
+            if (nativeOffset[0] >= 0) {
+                IdeDeclarationNavigator.Location location =
+                    declarationNavigator.navigate(vf, nativeOffset[0]);
+                if (location != null) {
+                    String nativeResult =
+                        formatNavigatedDeclaration(location, symbolName, declInfo);
+                    if (nativeResult != null) return nativeResult;
+                }
             }
+            return err("Could not resolve declaration for '" + symbolName
+                + "' at line " + targetLine + " in " + pathStr
+                + ". The symbol may be unresolved or from an unindexed library.");
+        } finally {
+            IdeDeclarationNavigator.restoreEditorState(project, previousEditor);
         }
-        return err("Could not resolve declaration for '" + symbolName + "' at line " + targetLine +
-            " in " + pathStr + ". The symbol may be unresolved or from an unindexed library.");
     }
 
     private @Nullable String resolveAndFormatDeclaration(
@@ -245,7 +253,7 @@ public final class GoToDeclarationTool extends RefactoringTool {
         EdtUtil.invokeAndWait(() -> {
             PsiDocumentManager.getInstance(project).commitDocument(document);
             editor[0] = FileEditorManager.getInstance(project).openTextEditor(
-                new OpenFileDescriptor(project, vf, 0), true);
+                new OpenFileDescriptor(project, vf, 0), false);
         });
         return editor[0];
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GoToDeclarationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GoToDeclarationTool.java
@@ -11,8 +11,9 @@ import com.intellij.codeInsight.navigation.action.GotoDeclarationUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.TextRange;
@@ -24,6 +25,7 @@ import com.intellij.psi.PsiPolyVariantReference;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveResult;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,8 +39,16 @@ public final class GoToDeclarationTool extends RefactoringTool {
     private static final String PARAM_SYMBOL = "symbol";
     private static final String FORMAT_LINES_SUFFIX = " lines)";
 
+    private final DeclarationNavigator declarationNavigator;
+
     public GoToDeclarationTool(Project project) {
+        this(project, (sourceFile, sourceOffset) ->
+            new IdeDeclarationNavigator(project).navigate(sourceFile, sourceOffset));
+    }
+
+    GoToDeclarationTool(Project project, DeclarationNavigator declarationNavigator) {
         super(project);
+        this.declarationNavigator = declarationNavigator;
     }
 
     @Override
@@ -161,44 +171,81 @@ public final class GoToDeclarationTool extends RefactoringTool {
                 document.getLineCount() + FORMAT_LINES_SUFFIX;
         }
 
-        Editor editor = createNavigationEditor(document, vf);
-        try {
-            return ApplicationManager.getApplication().runReadAction(
-                (Computable<String>) () -> {
-                    PsiFile psiFile = PsiDocumentManager.getInstance(project).getPsiFile(document);
-                    if (psiFile == null) {
-                        return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_CANNOT_PARSE + pathStr;
-                    }
-                    return resolveAndFormatDeclaration(
-                        psiFile, document, editor, pathStr, targetLine, symbolName, declInfo);
-                });
-        } finally {
-            EdtUtil.invokeAndWait(() -> EditorFactory.getInstance().releaseEditor(editor));
+        int[] nativeOffset = {-1};
+        Editor editor = openNavigationEditor(document, vf);
+        if (editor == null) return "Error: Cannot open editor for: " + pathStr;
+        String psiResult = ApplicationManager.getApplication().runReadAction(
+            (Computable<String>) () -> {
+                PsiFile psiFile = PsiDocumentManager.getInstance(project).getPsiFile(document);
+                if (psiFile == null) {
+                    return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_CANNOT_PARSE + pathStr;
+                }
+                return resolveAndFormatDeclaration(
+                    psiFile, document, editor, targetLine, symbolName, declInfo, nativeOffset);
+            });
+
+        if (psiResult != null) return psiResult;
+        if (nativeOffset[0] >= 0) {
+            IdeDeclarationNavigator.Location location =
+                declarationNavigator.navigate(vf, nativeOffset[0]);
+            if (location != null) {
+                String nativeResult = formatNavigatedDeclaration(location, symbolName, declInfo);
+                if (nativeResult != null) return nativeResult;
+            }
         }
+        return err("Could not resolve declaration for '" + symbolName + "' at line " + targetLine +
+            " in " + pathStr + ". The symbol may be unresolved or from an unindexed library.");
     }
 
-    private String resolveAndFormatDeclaration(PsiFile psiFile, Document document, Editor editor,
-                                               String pathStr, int targetLine, String symbolName,
-                                               String[] declInfo) {
+    private @Nullable String resolveAndFormatDeclaration(
+        PsiFile psiFile, Document document, Editor editor, int targetLine, String symbolName,
+        String[] declInfo, int[] nativeOffset) {
         int lineStartOffset = document.getLineStartOffset(targetLine - 1);
         int lineEndOffset = document.getLineEndOffset(targetLine - 1);
 
         List<PsiElement> declarations = resolveDeclarationsOnLine(
-            psiFile, document, editor, lineStartOffset, lineEndOffset, symbolName);
-        if (declarations.isEmpty()) {
-            return err("Could not resolve declaration for '" + symbolName + "' at line " + targetLine +
-                " in " + pathStr + ". The symbol may be unresolved or from an unindexed library.");
-        }
+            psiFile, document, editor, lineStartOffset, lineEndOffset, symbolName, nativeOffset);
+        if (declarations.isEmpty()) return null;
 
         captureDeclInfo(declarations.getFirst(), declInfo);
         return formatDeclarationResults(declarations, symbolName);
     }
 
-    private Editor createNavigationEditor(Document document, VirtualFile vf) {
+    private @Nullable String formatNavigatedDeclaration(
+        IdeDeclarationNavigator.Location location, String symbolName, String[] declInfo) {
+        return ApplicationManager.getApplication().runReadAction((Computable<String>) () -> {
+            VirtualFile declarationFile = location.file();
+            Document declarationDocument =
+                FileDocumentManager.getInstance().getDocument(declarationFile);
+            if (declarationDocument == null) return null;
+
+            int offset = Math.max(0,
+                Math.min(location.offset(), declarationDocument.getTextLength()));
+            int declarationLine = declarationDocument.getLineNumber(offset) + 1;
+            String basePath = project.getBasePath();
+            String declarationPath = resolveDeclPath(declarationFile, basePath);
+
+            declInfo[0] = basePath == null
+                ? declarationFile.getPath()
+                : relativize(basePath, declarationFile.getPath());
+            declInfo[1] = String.valueOf(declarationLine);
+
+            StringBuilder result = new StringBuilder();
+            result.append("Declaration of '").append(symbolName).append("':\n\n");
+            result.append("  File: ").append(declarationPath).append("\n");
+            result.append("  Line: ").append(declarationLine).append("\n");
+            appendDeclarationContext(result, declarationDocument, declarationLine);
+            result.append("\n");
+            return result.toString();
+        });
+    }
+
+    private @Nullable Editor openNavigationEditor(Document document, VirtualFile vf) {
         Editor[] editor = new Editor[1];
         EdtUtil.invokeAndWait(() -> {
             PsiDocumentManager.getInstance(project).commitDocument(document);
-            editor[0] = EditorFactory.getInstance().createEditor(document, project, vf, true);
+            editor[0] = FileEditorManager.getInstance(project).openTextEditor(
+                new OpenFileDescriptor(project, vf, 0), true);
         });
         return editor[0];
     }
@@ -206,26 +253,28 @@ public final class GoToDeclarationTool extends RefactoringTool {
     /**
      * Finds declarations for {@code symbolName} occurring anywhere on the target line.
      * <p>
-     * Uses the same provider-first order as the IDE's Go to Declaration action, followed by the
-     * existing language-agnostic PSI fallbacks:
+     * Tries the platform's non-UI declaration APIs before the caller invokes the live
+     * {@code GotoDeclaration} action:
      *
      * <ol>
-     *   <li>Ask registered declaration providers first. Product plugins such as CLion Nova expose
-     *       semantic navigation through {@link GotoDeclarationUtil}, even when no leaf
-     *       {@link PsiReference} exists.</li>
-     *   <li>Use {@link TargetElementUtil#findTargetElement(Editor, int, int)} with the same
-     *       accepted-target flags as the IDE action. Product backends can contribute target
-     *       evaluators here even when declaration providers return no result.</li>
+     *   <li>Ask registered frontend declaration providers through {@link GotoDeclarationUtil}.</li>
+     *   <li>Use {@link TargetElementUtil#findTargetElement(Editor, int, int)} with the platform's
+     *       accepted-target flags.</li>
      *   <li>Ask {@link PsiFile#findReferenceAt(int)} and handle polyvariant references via
      *       {@link PsiPolyVariantReference#multiResolve}.</li>
      *   <li>If no reference resolves, walk up the PSI tree because some language plugins attach
      *       the reference to a parent expression rather than the leaf identifier.</li>
-     *   <li>Finally, if the caret sits on a declaration itself, return the enclosing named element.</li>
+     *   <li>Finally, accept a named ancestor only when its name equals the requested symbol. This
+     *       covers a caret on the declaration itself without returning an enclosing method or
+     *       class for an unresolved usage.</li>
      * </ol>
+     *
+     * <p>If all of these return nothing, {@link #findAndFormatDeclaration} invokes the IDE action
+     * in a real project editor. That path covers backend-delegated products such as CLion Nova.
      */
     private List<PsiElement> resolveDeclarationsOnLine(
         PsiFile psiFile, Document document, Editor editor, int lineStartOffset,
-        int lineEndOffset, String symbolName) {
+        int lineEndOffset, String symbolName, int[] nativeOffset) {
         List<PsiElement> declarations = new ArrayList<>();
         if (symbolName.isEmpty()) return declarations;
         String lineText = document.getText(new TextRange(lineStartOffset, lineEndOffset));
@@ -236,6 +285,7 @@ public final class GoToDeclarationTool extends RefactoringTool {
             if (symIdx < 0) break;
             if (isWholeIdentifierMatch(lineText, symIdx, symbolName.length())) {
                 int rawOffset = lineStartOffset + symIdx;
+                if (nativeOffset[0] < 0) nativeOffset[0] = rawOffset;
                 PsiElement[] nativeTargets = findNativeDeclarationTargets(
                     psiFile, editor, rawOffset);
                 if (nativeTargets.length > 0) {
@@ -244,7 +294,7 @@ public final class GoToDeclarationTool extends RefactoringTool {
                 }
 
                 int offset = TargetElementUtil.adjustOffset(psiFile, document, rawOffset);
-                resolveAtOffset(psiFile, offset, declarations);
+                resolveAtOffset(psiFile, offset, symbolName, declarations);
                 if (!declarations.isEmpty()) return declarations;
             }
             searchFrom = symIdx + symbolName.length();
@@ -283,11 +333,12 @@ public final class GoToDeclarationTool extends RefactoringTool {
     /**
      * Resolves the reference at {@code offset} via the platform-level
      * {@link PsiFile#findReferenceAt(int)}, then falls back to walking up the PSI tree (some
-     * language plugins attach the reference to a parent node rather than the leaf identifier),
-     * and finally to {@link TargetElementUtil#getNamedElement(PsiElement)} for the
-     * "go to declaration on a declaration" case.
+     * language plugins attach the reference to a parent node rather than the leaf identifier).
+     * For the "go to declaration on a declaration" case, the nearest named ancestor is accepted
+     * only when its name equals {@code symbolName}.
      */
-    private static void resolveAtOffset(PsiFile psiFile, int offset, List<PsiElement> declarations) {
+    private static void resolveAtOffset(
+        PsiFile psiFile, int offset, String symbolName, List<PsiElement> declarations) {
         PsiReference ref = psiFile.findReferenceAt(offset);
         if (ref != null) {
             addResolved(ref, declarations);
@@ -305,7 +356,9 @@ public final class GoToDeclarationTool extends RefactoringTool {
         }
         if (elementAt != null) {
             com.intellij.psi.PsiNamedElement ancestor = ToolUtils.findNearestNamedAncestor(elementAt);
-            if (ancestor != null) declarations.add(ancestor);
+            if (ancestor != null && symbolName.equals(ancestor.getName())) {
+                declarations.add(ancestor);
+            }
         }
     }
 
@@ -319,6 +372,12 @@ public final class GoToDeclarationTool extends RefactoringTool {
             PsiElement resolved = ref.resolve();
             if (resolved != null) declarations.add(resolved);
         }
+    }
+
+    @FunctionalInterface
+    interface DeclarationNavigator {
+        @Nullable IdeDeclarationNavigator.Location navigate(
+            @NotNull VirtualFile sourceFile, int sourceOffset);
     }
 
     private static final int MAX_PARENT_WALK = 5;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GoToDeclarationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GoToDeclarationTool.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiManager;
 import com.intellij.psi.PsiPolyVariantReference;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveResult;
@@ -153,7 +152,8 @@ public final class GoToDeclarationTool extends RefactoringTool {
         VirtualFile vf = resolveVirtualFile(pathStr);
         if (vf == null) return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_FILE_NOT_FOUND + pathStr;
 
-        Document document = FileDocumentManager.getInstance().getDocument(vf);
+        Document document = ApplicationManager.getApplication().runReadAction(
+            (Computable<Document>) () -> FileDocumentManager.getInstance().getDocument(vf));
         if (document == null) return "Error: Cannot get document for: " + pathStr;
 
         if (targetLine < 1 || targetLine > document.getLineCount()) {
@@ -161,15 +161,17 @@ public final class GoToDeclarationTool extends RefactoringTool {
                 document.getLineCount() + FORMAT_LINES_SUFFIX;
         }
 
-        PsiFile psiFile = ApplicationManager.getApplication().runReadAction(
-            (Computable<PsiFile>) () -> PsiManager.getInstance(project).findFile(vf));
-        if (psiFile == null) return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_CANNOT_PARSE + pathStr;
-
         Editor editor = createNavigationEditor(document, vf);
         try {
             return ApplicationManager.getApplication().runReadAction(
-                (Computable<String>) () -> resolveAndFormatDeclaration(
-                    psiFile, document, editor, pathStr, targetLine, symbolName, declInfo));
+                (Computable<String>) () -> {
+                    PsiFile psiFile = PsiDocumentManager.getInstance(project).getPsiFile(document);
+                    if (psiFile == null) {
+                        return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_CANNOT_PARSE + pathStr;
+                    }
+                    return resolveAndFormatDeclaration(
+                        psiFile, document, editor, pathStr, targetLine, symbolName, declInfo);
+                });
         } finally {
             EdtUtil.invokeAndWait(() -> EditorFactory.getInstance().releaseEditor(editor));
         }
@@ -211,6 +213,9 @@ public final class GoToDeclarationTool extends RefactoringTool {
      *   <li>Ask registered declaration providers first. Product plugins such as CLion Nova expose
      *       semantic navigation through {@link GotoDeclarationUtil}, even when no leaf
      *       {@link PsiReference} exists.</li>
+     *   <li>Use {@link TargetElementUtil#findTargetElement(Editor, int, int)} with the same
+     *       accepted-target flags as the IDE action. Product backends can contribute target
+     *       evaluators here even when declaration providers return no result.</li>
      *   <li>Ask {@link PsiFile#findReferenceAt(int)} and handle polyvariant references via
      *       {@link PsiPolyVariantReference#multiResolve}.</li>
      *   <li>If no reference resolves, walk up the PSI tree because some language plugins attach
@@ -231,10 +236,10 @@ public final class GoToDeclarationTool extends RefactoringTool {
             if (symIdx < 0) break;
             if (isWholeIdentifierMatch(lineText, symIdx, symbolName.length())) {
                 int rawOffset = lineStartOffset + symIdx;
-                PsiElement[] providerTargets =
-                    GotoDeclarationUtil.findTargetElementsFromProviders(editor, rawOffset, psiFile);
-                if (providerTargets != null && providerTargets.length > 0) {
-                    declarations.addAll(List.of(providerTargets));
+                PsiElement[] nativeTargets = findNativeDeclarationTargets(
+                    psiFile, editor, rawOffset);
+                if (nativeTargets.length > 0) {
+                    declarations.addAll(List.of(nativeTargets));
                     return declarations;
                 }
 
@@ -245,6 +250,23 @@ public final class GoToDeclarationTool extends RefactoringTool {
             searchFrom = symIdx + symbolName.length();
         }
         return declarations;
+    }
+
+    private static PsiElement[] findNativeDeclarationTargets(
+        PsiFile psiFile, Editor editor, int offset) {
+        PsiElement[] providerTargets =
+            GotoDeclarationUtil.findTargetElementsFromProviders(editor, offset, psiFile);
+        if (providerTargets != null && providerTargets.length > 0) {
+            return providerTargets;
+        }
+
+        int platformFlags = TargetElementUtil.getInstance().getAllAccepted()
+            & ~TargetElementUtil.ELEMENT_NAME_ACCEPTED;
+        PsiElement platformTarget = TargetElementUtil.getInstance()
+            .findTargetElement(editor, platformFlags, offset);
+        return platformTarget == null
+            ? PsiElement.EMPTY_ARRAY
+            : new PsiElement[]{platformTarget};
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GoToDeclarationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GoToDeclarationTool.java
@@ -1,18 +1,23 @@
 package com.github.catatafishen.agentbridge.psi.tools.refactoring;
 
+import com.github.catatafishen.agentbridge.psi.EdtUtil;
 import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.psi.tools.FqnResolver;
 import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
 import com.github.catatafishen.agentbridge.ui.renderers.GoToDeclarationRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.codeInsight.TargetElementUtil;
+import com.intellij.codeInsight.navigation.action.GotoDeclarationUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
@@ -111,8 +116,7 @@ public final class GoToDeclarationTool extends RefactoringTool {
         }
 
         String[] declInfo = new String[2];
-        String result = ApplicationManager.getApplication().runReadAction(
-            (Computable<String>) () -> findAndFormatDeclaration(pathStr, targetLine, symbolName, declInfo));
+        String result = findAndFormatDeclaration(pathStr, targetLine, symbolName, declInfo);
 
         if (declInfo[0] != null && declInfo[1] != null) {
             int declLine = Integer.parseInt(declInfo[1]);
@@ -149,9 +153,6 @@ public final class GoToDeclarationTool extends RefactoringTool {
         VirtualFile vf = resolveVirtualFile(pathStr);
         if (vf == null) return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_FILE_NOT_FOUND + pathStr;
 
-        PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
-        if (psiFile == null) return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_CANNOT_PARSE + pathStr;
-
         Document document = FileDocumentManager.getInstance().getDocument(vf);
         if (document == null) return "Error: Cannot get document for: " + pathStr;
 
@@ -159,11 +160,29 @@ public final class GoToDeclarationTool extends RefactoringTool {
             return "Error: Line " + targetLine + " is out of bounds (file has " +
                 document.getLineCount() + FORMAT_LINES_SUFFIX;
         }
+
+        PsiFile psiFile = ApplicationManager.getApplication().runReadAction(
+            (Computable<PsiFile>) () -> PsiManager.getInstance(project).findFile(vf));
+        if (psiFile == null) return ToolUtils.ERROR_PREFIX + ToolUtils.ERROR_CANNOT_PARSE + pathStr;
+
+        Editor editor = createNavigationEditor(document, vf);
+        try {
+            return ApplicationManager.getApplication().runReadAction(
+                (Computable<String>) () -> resolveAndFormatDeclaration(
+                    psiFile, document, editor, pathStr, targetLine, symbolName, declInfo));
+        } finally {
+            EdtUtil.invokeAndWait(() -> EditorFactory.getInstance().releaseEditor(editor));
+        }
+    }
+
+    private String resolveAndFormatDeclaration(PsiFile psiFile, Document document, Editor editor,
+                                               String pathStr, int targetLine, String symbolName,
+                                               String[] declInfo) {
         int lineStartOffset = document.getLineStartOffset(targetLine - 1);
         int lineEndOffset = document.getLineEndOffset(targetLine - 1);
 
         List<PsiElement> declarations = resolveDeclarationsOnLine(
-            psiFile, document, lineStartOffset, lineEndOffset, symbolName);
+            psiFile, document, editor, lineStartOffset, lineEndOffset, symbolName);
         if (declarations.isEmpty()) {
             return err("Could not resolve declaration for '" + symbolName + "' at line " + targetLine +
                 " in " + pathStr + ". The symbol may be unresolved or from an unindexed library.");
@@ -173,26 +192,35 @@ public final class GoToDeclarationTool extends RefactoringTool {
         return formatDeclarationResults(declarations, symbolName);
     }
 
+    private Editor createNavigationEditor(Document document, VirtualFile vf) {
+        Editor[] editor = new Editor[1];
+        EdtUtil.invokeAndWait(() -> {
+            PsiDocumentManager.getInstance(project).commitDocument(document);
+            editor[0] = EditorFactory.getInstance().createEditor(document, project, vf, true);
+        });
+        return editor[0];
+    }
+
     /**
      * Finds declarations for {@code symbolName} occurring anywhere on the target line.
      * <p>
-     * Uses three layered strategies, all of which delegate to the IDE's own
-     * reference-resolution infrastructure and are therefore language-agnostic:
+     * Uses the same provider-first order as the IDE's Go to Declaration action, followed by the
+     * existing language-agnostic PSI fallbacks:
      *
      * <ol>
-     *   <li>For each text occurrence of {@code symbolName} on the line, ask the IDE for the
-     *       reference at that offset via {@link PsiFile#findReferenceAt(int)} (uses every language
-     *       plugin's registered reference contributors — works for C/C++, Python, JS, Go, etc.).
-     *       Handles polyvariant references via {@link PsiPolyVariantReference#multiResolve}.</li>
-     *   <li>If no reference resolves, walk up the PSI tree from each occurrence — some language
-     *       plugins put the reference on a parent expression rather than the leaf identifier.</li>
-     *   <li>Finally, if the caret sits on a declaration itself, return the enclosing named element
-     *       (matches the IDE's behaviour of "go to declaration on a declaration" showing the
-     *       declaration itself).</li>
+     *   <li>Ask registered declaration providers first. Product plugins such as CLion Nova expose
+     *       semantic navigation through {@link GotoDeclarationUtil}, even when no leaf
+     *       {@link PsiReference} exists.</li>
+     *   <li>Ask {@link PsiFile#findReferenceAt(int)} and handle polyvariant references via
+     *       {@link PsiPolyVariantReference#multiResolve}.</li>
+     *   <li>If no reference resolves, walk up the PSI tree because some language plugins attach
+     *       the reference to a parent expression rather than the leaf identifier.</li>
+     *   <li>Finally, if the caret sits on a declaration itself, return the enclosing named element.</li>
      * </ol>
      */
     private List<PsiElement> resolveDeclarationsOnLine(
-        PsiFile psiFile, Document document, int lineStartOffset, int lineEndOffset, String symbolName) {
+        PsiFile psiFile, Document document, Editor editor, int lineStartOffset,
+        int lineEndOffset, String symbolName) {
         List<PsiElement> declarations = new ArrayList<>();
         if (symbolName.isEmpty()) return declarations;
         String lineText = document.getText(new TextRange(lineStartOffset, lineEndOffset));
@@ -203,6 +231,13 @@ public final class GoToDeclarationTool extends RefactoringTool {
             if (symIdx < 0) break;
             if (isWholeIdentifierMatch(lineText, symIdx, symbolName.length())) {
                 int rawOffset = lineStartOffset + symIdx;
+                PsiElement[] providerTargets =
+                    GotoDeclarationUtil.findTargetElementsFromProviders(editor, rawOffset, psiFile);
+                if (providerTargets != null && providerTargets.length > 0) {
+                    declarations.addAll(List.of(providerTargets));
+                    return declarations;
+                }
+
                 int offset = TargetElementUtil.adjustOffset(psiFile, document, rawOffset);
                 resolveAtOffset(psiFile, offset, declarations);
                 if (!declarations.isEmpty()) return declarations;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/IdeDeclarationNavigator.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/IdeDeclarationNavigator.java
@@ -1,0 +1,189 @@
+package com.github.catatafishen.agentbridge.psi.tools.refactoring;
+
+import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.EditorFactory;
+import com.intellij.openapi.editor.event.CaretEvent;
+import com.intellij.openapi.editor.event.CaretListener;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
+import com.intellij.openapi.fileEditor.FileEditorManagerListener;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.ActionCallback;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.Alarm;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Invokes the IDE's real {@code GotoDeclaration} action in a live project editor and captures the
+ * location selected by that action.
+ *
+ * <p>This is required for backend-driven products such as CLion Nova. Their declaration action is
+ * delegated to Rider.Backend and is intentionally not exposed through frontend PSI reference or
+ * {@code GotoDeclarationHandler} APIs.
+ */
+final class IdeDeclarationNavigator {
+
+    static final String GOTO_DECLARATION_ACTION_ID = "GotoDeclaration";
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(20);
+    private static final int ACTION_RETRY_DELAY_MILLIS = 250;
+    private static final Logger LOG = Logger.getInstance(IdeDeclarationNavigator.class);
+
+    private final Project project;
+    private final String actionId;
+    private final long timeoutMillis;
+
+    IdeDeclarationNavigator(@NotNull Project project) {
+        this(project, GOTO_DECLARATION_ACTION_ID, DEFAULT_TIMEOUT);
+    }
+
+    IdeDeclarationNavigator(@NotNull Project project, @NotNull String actionId,
+                            @NotNull Duration timeout) {
+        this.project = project;
+        this.actionId = actionId;
+        this.timeoutMillis = Math.max(1, timeout.toMillis());
+    }
+
+    @Nullable Location navigate(@NotNull VirtualFile sourceFile, int sourceOffset) {
+        AnAction action = ActionManager.getInstance().getAction(actionId);
+        if (action == null) return null;
+
+        Editor[] sourceEditor = new Editor[1];
+        int[] initialOffset = new int[1];
+        EdtUtil.invokeAndWait(() -> {
+            Editor editor = FileEditorManager.getInstance(project).openTextEditor(
+                new OpenFileDescriptor(project, sourceFile, sourceOffset), true);
+            if (editor == null) return;
+            int safeOffset = Math.max(0, Math.min(sourceOffset, editor.getDocument().getTextLength()));
+            editor.getCaretModel().moveToOffset(safeOffset);
+            sourceEditor[0] = editor;
+            initialOffset[0] = safeOffset;
+        });
+        if (sourceEditor[0] == null) return null;
+
+        CompletableFuture<Location> result = new CompletableFuture<>();
+        Disposable listeners = Disposer.newDisposable("AgentBridge go-to-declaration listener");
+        Alarm retryAlarm = new Alarm(Alarm.ThreadToUse.SWING_THREAD, listeners);
+        AtomicBoolean actionStarted = new AtomicBoolean(false);
+        subscribeToNavigation(
+            sourceFile, initialOffset[0], actionStarted, result, listeners);
+
+        EdtUtil.invokeLater(() -> invokeActionWhenReady(
+            action, sourceEditor[0], sourceFile, initialOffset[0], actionStarted, result,
+            retryAlarm));
+
+        try {
+            return result.get(timeoutMillis, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            result.complete(null);
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            result.complete(null);
+            return null;
+        } catch (ExecutionException e) {
+            LOG.warn("IDE go-to-declaration action failed", e.getCause());
+            return null;
+        } finally {
+            Disposer.dispose(listeners);
+        }
+    }
+
+    private void invokeActionWhenReady(
+        AnAction action, Editor sourceEditor, VirtualFile sourceFile, int sourceOffset,
+        AtomicBoolean actionStarted, CompletableFuture<Location> result, Alarm retryAlarm) {
+        if (result.isDone()) return;
+        if (project.isDisposed() || sourceEditor.isDisposed()) {
+            result.complete(null);
+            return;
+        }
+
+        try {
+            actionStarted.set(true);
+            ActionCallback callback = ActionManager.getInstance().tryToExecute(
+                action, null, sourceEditor.getContentComponent(), "AgentBridge", true);
+            callback.doWhenRejected(() -> {
+                if (!result.isDone()) {
+                    retryAlarm.addRequest(
+                        () -> invokeActionWhenReady(
+                            action, sourceEditor, sourceFile, sourceOffset, actionStarted, result,
+                            retryAlarm),
+                        ACTION_RETRY_DELAY_MILLIS);
+                }
+            });
+            captureSelectedEditorLater(sourceFile, sourceOffset, result);
+        } catch (RuntimeException e) {
+            LOG.warn("Failed to invoke IDE go-to-declaration action", e);
+            result.complete(null);
+        }
+    }
+
+    private void subscribeToNavigation(
+        VirtualFile sourceFile, int sourceOffset, AtomicBoolean actionStarted,
+        CompletableFuture<Location> result, Disposable listeners) {
+        EditorFactory.getInstance().getEventMulticaster().addCaretListener(
+            new CaretListener() {
+                @Override
+                public void caretPositionChanged(@NotNull CaretEvent event) {
+                    if (actionStarted.get()) {
+                        completeIfNavigated(
+                            event.getEditor(), sourceFile, sourceOffset, result);
+                    }
+                }
+            },
+            listeners);
+
+        project.getMessageBus().connect(listeners).subscribe(
+            FileEditorManagerListener.FILE_EDITOR_MANAGER,
+            new FileEditorManagerListener() {
+                @Override
+                public void selectionChanged(@NotNull FileEditorManagerEvent event) {
+                    if (actionStarted.get()) {
+                        captureSelectedEditorLater(sourceFile, sourceOffset, result);
+                    }
+                }
+            });
+    }
+
+    private void captureSelectedEditorLater(
+        VirtualFile sourceFile, int sourceOffset, CompletableFuture<Location> result) {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            Editor selected = FileEditorManager.getInstance(project).getSelectedTextEditor();
+            if (selected != null) {
+                completeIfNavigated(selected, sourceFile, sourceOffset, result);
+            }
+        });
+    }
+
+    private void completeIfNavigated(
+        Editor editor, VirtualFile sourceFile, int sourceOffset,
+        CompletableFuture<Location> result) {
+        if (result.isDone() || editor.getProject() != project) return;
+        VirtualFile selectedFile = FileDocumentManager.getInstance().getFile(editor.getDocument());
+        if (selectedFile == null) return;
+
+        int selectedOffset = editor.getCaretModel().getOffset();
+        if (!sourceFile.equals(selectedFile) || selectedOffset != sourceOffset) {
+            result.complete(new Location(selectedFile, selectedOffset));
+        }
+    }
+
+    record Location(@NotNull VirtualFile file, int offset) {
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/IdeDeclarationNavigator.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/IdeDeclarationNavigator.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Invokes the IDE's real {@code GotoDeclaration} action in a live project editor and captures the
@@ -64,87 +65,103 @@ final class IdeDeclarationNavigator {
         AnAction action = ActionManager.getInstance().getAction(actionId);
         if (action == null) return null;
 
-        Editor[] sourceEditor = new Editor[1];
-        int[] initialOffset = new int[1];
-        EdtUtil.invokeAndWait(() -> {
-            Editor editor = FileEditorManager.getInstance(project).openTextEditor(
-                new OpenFileDescriptor(project, sourceFile, sourceOffset), true);
-            if (editor == null) return;
-            int safeOffset = Math.max(0, Math.min(sourceOffset, editor.getDocument().getTextLength()));
-            editor.getCaretModel().moveToOffset(safeOffset);
-            sourceEditor[0] = editor;
-            initialOffset[0] = safeOffset;
-        });
-        if (sourceEditor[0] == null) return null;
-
-        CompletableFuture<Location> result = new CompletableFuture<>();
-        Disposable listeners = Disposer.newDisposable("AgentBridge go-to-declaration listener");
-        Alarm retryAlarm = new Alarm(Alarm.ThreadToUse.SWING_THREAD, listeners);
-        AtomicBoolean actionStarted = new AtomicBoolean(false);
-        subscribeToNavigation(
-            sourceFile, initialOffset[0], actionStarted, result, listeners);
-
-        EdtUtil.invokeLater(() -> invokeActionWhenReady(
-            action, sourceEditor[0], sourceFile, initialOffset[0], actionStarted, result,
-            retryAlarm));
-
+        EditorState previousEditor = captureEditorState(project);
         try {
-            return result.get(timeoutMillis, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-            result.complete(null);
-            return null;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            result.complete(null);
-            return null;
-        } catch (ExecutionException e) {
-            LOG.warn("IDE go-to-declaration action failed", e.getCause());
-            return null;
+            Editor[] sourceEditor = new Editor[1];
+            int[] initialOffset = new int[1];
+            EdtUtil.invokeAndWait(() -> {
+                Editor editor = FileEditorManager.getInstance(project).openTextEditor(
+                    new OpenFileDescriptor(project, sourceFile, sourceOffset), false);
+                if (editor == null) return;
+                int safeOffset =
+                    Math.max(0, Math.min(sourceOffset, editor.getDocument().getTextLength()));
+                editor.getCaretModel().moveToOffset(safeOffset);
+                sourceEditor[0] = editor;
+                initialOffset[0] = safeOffset;
+            });
+            if (sourceEditor[0] == null) return null;
+
+            CompletableFuture<Location> result = new CompletableFuture<>();
+            Disposable listeners = Disposer.newDisposable("AgentBridge go-to-declaration listener");
+            Alarm retryAlarm = new Alarm(Alarm.ThreadToUse.SWING_THREAD, listeners);
+            AtomicReference<NavigationAttempt> activeAttempt = new AtomicReference<>();
+            subscribeToNavigation(
+                sourceFile, initialOffset[0], activeAttempt, result, listeners);
+
+            EdtUtil.invokeLater(() -> invokeActionWhenReady(
+                action, sourceEditor[0], sourceFile, initialOffset[0], activeAttempt, result,
+                retryAlarm));
+
+            try {
+                return result.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException e) {
+                result.complete(null);
+                return null;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                result.complete(null);
+                return null;
+            } catch (ExecutionException e) {
+                LOG.warn("IDE go-to-declaration action failed", e.getCause());
+                return null;
+            } finally {
+                Disposer.dispose(listeners);
+            }
         } finally {
-            Disposer.dispose(listeners);
+            restoreEditorState(project, previousEditor);
         }
     }
 
     private void invokeActionWhenReady(
         AnAction action, Editor sourceEditor, VirtualFile sourceFile, int sourceOffset,
-        AtomicBoolean actionStarted, CompletableFuture<Location> result, Alarm retryAlarm) {
+        AtomicReference<NavigationAttempt> activeAttempt, CompletableFuture<Location> result,
+        Alarm retryAlarm) {
         if (result.isDone()) return;
         if (project.isDisposed() || sourceEditor.isDisposed()) {
             result.complete(null);
             return;
         }
 
+        NavigationAttempt attempt = new NavigationAttempt();
+        activeAttempt.set(attempt);
         try {
-            actionStarted.set(true);
             ActionCallback callback = ActionManager.getInstance().tryToExecute(
                 action, null, sourceEditor.getContentComponent(), "AgentBridge", true);
+            callback.doWhenDone(() -> {
+                if (activeAttempt.get() != attempt || result.isDone()) return;
+                attempt.accept(result);
+                captureSelectedEditorLater(
+                    sourceFile, sourceOffset, activeAttempt, attempt, result);
+            });
             callback.doWhenRejected(() -> {
+                attempt.reject();
+                activeAttempt.compareAndSet(attempt, null);
                 if (!result.isDone()) {
                     retryAlarm.addRequest(
                         () -> invokeActionWhenReady(
-                            action, sourceEditor, sourceFile, sourceOffset, actionStarted, result,
+                            action, sourceEditor, sourceFile, sourceOffset, activeAttempt, result,
                             retryAlarm),
                         ACTION_RETRY_DELAY_MILLIS);
                 }
             });
-            captureSelectedEditorLater(sourceFile, sourceOffset, result);
         } catch (RuntimeException e) {
+            attempt.reject();
+            activeAttempt.compareAndSet(attempt, null);
             LOG.warn("Failed to invoke IDE go-to-declaration action", e);
             result.complete(null);
         }
     }
 
     private void subscribeToNavigation(
-        VirtualFile sourceFile, int sourceOffset, AtomicBoolean actionStarted,
+        VirtualFile sourceFile, int sourceOffset,
+        AtomicReference<NavigationAttempt> activeAttempt,
         CompletableFuture<Location> result, Disposable listeners) {
         EditorFactory.getInstance().getEventMulticaster().addCaretListener(
             new CaretListener() {
                 @Override
                 public void caretPositionChanged(@NotNull CaretEvent event) {
-                    if (actionStarted.get()) {
-                        completeIfNavigated(
-                            event.getEditor(), sourceFile, sourceOffset, result);
-                    }
+                    completeIfNavigated(
+                        event.getEditor(), sourceFile, sourceOffset, activeAttempt, result);
                 }
             },
             listeners);
@@ -154,34 +171,133 @@ final class IdeDeclarationNavigator {
             new FileEditorManagerListener() {
                 @Override
                 public void selectionChanged(@NotNull FileEditorManagerEvent event) {
-                    if (actionStarted.get()) {
-                        captureSelectedEditorLater(sourceFile, sourceOffset, result);
+                    NavigationAttempt attempt = activeAttempt.get();
+                    if (attempt != null) {
+                        captureSelectedEditorLater(
+                            sourceFile, sourceOffset, activeAttempt, attempt, result);
                     }
                 }
             });
     }
 
     private void captureSelectedEditorLater(
-        VirtualFile sourceFile, int sourceOffset, CompletableFuture<Location> result) {
+        VirtualFile sourceFile, int sourceOffset,
+        AtomicReference<NavigationAttempt> activeAttempt, NavigationAttempt attempt,
+        CompletableFuture<Location> result) {
         ApplicationManager.getApplication().invokeLater(() -> {
+            if (activeAttempt.get() != attempt || attempt.isRejected() || result.isDone()) return;
             Editor selected = FileEditorManager.getInstance(project).getSelectedTextEditor();
             if (selected != null) {
-                completeIfNavigated(selected, sourceFile, sourceOffset, result);
+                completeIfNavigated(
+                    selected, sourceFile, sourceOffset, activeAttempt, result);
             }
         });
     }
 
     private void completeIfNavigated(
         Editor editor, VirtualFile sourceFile, int sourceOffset,
+        AtomicReference<NavigationAttempt> activeAttempt,
         CompletableFuture<Location> result) {
-        if (result.isDone() || editor.getProject() != project) return;
+        if (result.isDone() || editor.isDisposed() || editor.getProject() != project) return;
+
+        NavigationAttempt attempt = activeAttempt.get();
+        if (attempt == null || attempt.isRejected()) return;
+        if (FileEditorManager.getInstance(project).getSelectedTextEditor() != editor) return;
+
         VirtualFile selectedFile = FileDocumentManager.getInstance().getFile(editor.getDocument());
         if (selectedFile == null) return;
 
         int selectedOffset = editor.getCaretModel().getOffset();
         if (!sourceFile.equals(selectedFile) || selectedOffset != sourceOffset) {
-            result.complete(new Location(selectedFile, selectedOffset));
+            attempt.record(new Location(selectedFile, selectedOffset), result);
         }
+    }
+
+    static @Nullable EditorState captureEditorState(@NotNull Project project) {
+        if (project.isDisposed()) return null;
+
+        EditorState[] state = new EditorState[1];
+        EdtUtil.invokeAndWait(() -> {
+            if (project.isDisposed()) return;
+            FileEditorManager manager = FileEditorManager.getInstance(project);
+            VirtualFile[] selectedFiles = manager.getSelectedFiles();
+            if (selectedFiles.length == 0) return;
+
+            VirtualFile selectedFile = selectedFiles[0];
+            int caretOffset = -1;
+            Editor selectedEditor = manager.getSelectedTextEditor();
+            if (selectedEditor != null && !selectedEditor.isDisposed()
+                && selectedFile.equals(
+                FileDocumentManager.getInstance().getFile(selectedEditor.getDocument()))) {
+                caretOffset = selectedEditor.getCaretModel().getOffset();
+            }
+            state[0] = new EditorState(selectedFile, caretOffset);
+        });
+        return state[0];
+    }
+
+    static void restoreEditorState(@NotNull Project project, @Nullable EditorState state) {
+        if (state == null || project.isDisposed()) return;
+
+        EdtUtil.invokeAndWait(() -> {
+            if (project.isDisposed() || !state.file().isValid()) return;
+            FileEditorManager manager = FileEditorManager.getInstance(project);
+            if (state.caretOffset() < 0) {
+                manager.openFile(state.file(), false);
+                return;
+            }
+
+            Editor editor = manager.openTextEditor(
+                new OpenFileDescriptor(project, state.file(), state.caretOffset()), false);
+            if (editor != null && !editor.isDisposed()) {
+                int safeOffset = Math.max(
+                    0, Math.min(state.caretOffset(), editor.getDocument().getTextLength()));
+                editor.getCaretModel().moveToOffset(safeOffset);
+            }
+        });
+    }
+
+    private static final class NavigationAttempt {
+        private final AtomicBoolean accepted = new AtomicBoolean(false);
+        private final AtomicBoolean rejected = new AtomicBoolean(false);
+        private final AtomicReference<Location> candidate = new AtomicReference<>();
+
+        void accept(CompletableFuture<Location> result) {
+            if (rejected.get()) return;
+            accepted.set(true);
+            Location buffered = candidate.getAndSet(null);
+            if (buffered != null) {
+                result.complete(buffered);
+            }
+        }
+
+        void reject() {
+            rejected.set(true);
+            candidate.set(null);
+        }
+
+        boolean isRejected() {
+            return rejected.get();
+        }
+
+        void record(Location location, CompletableFuture<Location> result) {
+            if (rejected.get()) return;
+            if (accepted.get()) {
+                result.complete(location);
+                return;
+            }
+
+            candidate.compareAndSet(null, location);
+            if (accepted.get() && !rejected.get()) {
+                Location buffered = candidate.getAndSet(null);
+                if (buffered != null) {
+                    result.complete(buffered);
+                }
+            }
+        }
+    }
+
+    record EditorState(@NotNull VirtualFile file, int caretOffset) {
     }
 
     record Location(@NotNull VirtualFile file, int offset) {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/FileToolAutoFormatTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/FileToolAutoFormatTest.java
@@ -1,0 +1,122 @@
+package com.github.catatafishen.agentbridge.psi.tools.file;
+
+import com.github.catatafishen.agentbridge.session.db.ConversationDatabase;
+
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.EdtTestUtil;
+import com.intellij.testFramework.PsiTestUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Platform integration tests for the deferred auto-format pipeline.
+ */
+public class FileToolAutoFormatTest extends BasePlatformTestCase {
+
+    private Path sourceDir;
+
+    @Override
+    protected boolean runInDispatchThread() {
+        return false;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        String projectBasePath = getProject().getBasePath();
+        assertNotNull("Light project must have a base path", projectBasePath);
+        Path projectBaseDir = Files.createDirectories(Path.of(projectBasePath));
+        sourceDir = Files.createTempDirectory(projectBaseDir, "file-tool-auto-format-test");
+
+        VirtualFile sourceRoot =
+            LocalFileSystem.getInstance().refreshAndFindFileByPath(sourceDir.toString());
+        assertNotNull("Failed to register test source root in VFS", sourceRoot);
+        EdtTestUtil.runInEdtAndWait(() -> PsiTestUtil.addSourceRoot(getModule(), sourceRoot));
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            ConversationDatabase.getInstance(getProject()).dispose();
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    public void testFlushReturnsAfterFormattingHasCompletedAndSaved() throws Exception {
+        TestFile testFile = createTestFile("Sample.java", "class Sample{int value=1;}");
+
+        FileTool.queueAutoFormat(getProject(), testFile.file().getPath());
+
+        assertTrue("Deferred auto-format should complete successfully",
+            FileTool.flushPendingAutoFormat(getProject()));
+        assertFalse("The formatted document must be saved before flush returns",
+            FileDocumentManager.getInstance().isDocumentUnsaved(testFile.document()));
+
+        String formatted = Files.readString(Path.of(testFile.file().getPath()));
+        assertTrue("Expected class declaration to be reformatted: " + formatted,
+            formatted.contains("class Sample {"));
+        assertTrue("Expected field declaration to be reformatted: " + formatted,
+            formatted.contains("int value = 1;"));
+    }
+
+    public void testEdtFlushSchedulesBackgroundFormattingAndSave() throws Exception {
+        TestFile testFile = createTestFile(
+            "AsyncSample.java", "class AsyncSample{int value=1;}");
+        FileTool.queueAutoFormat(getProject(), testFile.file().getPath());
+        AtomicBoolean flushResult = new AtomicBoolean(true);
+
+        EdtTestUtil.runInEdtAndWait(() ->
+            flushResult.set(FileTool.flushPendingAutoFormat(getProject())));
+
+        assertFalse("EDT flush must hand work to a background thread", flushResult.get());
+        assertTrue("Background flush did not format and save the file",
+            waitForFormattedAndSaved(testFile));
+    }
+
+    private boolean waitForFormattedAndSaved(TestFile testFile) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+        Path path = Path.of(testFile.file().getPath());
+        while (System.nanoTime() < deadline) {
+            String content = Files.readString(path);
+            boolean saved = !FileDocumentManager.getInstance()
+                .isDocumentUnsaved(testFile.document());
+            if (saved
+                && content.contains("class AsyncSample {")
+                && content.contains("int value = 1;")) {
+                return true;
+            }
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(20));
+            if (Thread.interrupted()) throw new InterruptedException();
+        }
+        return false;
+    }
+
+    private TestFile createTestFile(String name, String content) throws IOException {
+        Path filePath = sourceDir.resolve(name);
+        Files.writeString(filePath, content);
+        VirtualFile file =
+            LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath.toString());
+        assertNotNull("Failed to register test file in VFS: " + filePath, file);
+
+        Document document = ReadAction.nonBlocking(
+                () -> FileDocumentManager.getInstance().getDocument(file))
+            .expireWith(getProject())
+            .executeSynchronously();
+        assertNotNull("Expected a document for the test file", document);
+        return new TestFile(file, document);
+    }
+
+    private record TestFile(VirtualFile file, Document document) {
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/FileToolAutoFormatTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/FileToolAutoFormatTest.java
@@ -6,9 +6,11 @@ import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.progress.util.ProgressIndicatorBase;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
 import com.intellij.testFramework.EdtTestUtil;
 import com.intellij.testFramework.PsiTestUtil;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
@@ -16,7 +18,9 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -201,6 +205,162 @@ public class FileToolAutoFormatTest extends BasePlatformTestCase {
         assertEquals(List.of("first.java", "new.java"), state.drain());
         state.requeueFirst(List.of());
         assertTrue(state.drain().isEmpty());
+    }
+
+    public void testEmptyAndIdleQueuesReturnImmediately() {
+        assertTrue("A project without a queue must be a no-op",
+            FileTool.flushPendingAutoFormat(getProject()));
+
+        FileTool.queueAutoFormat(getProject(), sourceDir.resolve("MissingIdle.java").toString());
+        assertTrue(FileTool.flushPendingAutoFormat(getProject()));
+        assertTrue("A drained queue must remain a no-op",
+            FileTool.flushPendingAutoFormat(getProject()));
+    }
+
+    public void testExpiredAndContendedFlushLockRetainQueuedWork() throws Exception {
+        Project activeProject = mock(Project.class);
+        when(activeProject.isDisposed()).thenReturn(false);
+
+        FileTool.AutoFormatState expiredState = new FileTool.AutoFormatState();
+        expiredState.add("expired.java");
+        assertFalse("A zero lock budget must time out immediately",
+            FileTool.flushOnBackgroundThread(activeProject, expiredState, 0));
+        assertEquals(List.of("expired.java"), expiredState.drain());
+        assertTrue(expiredState.isIdle());
+
+        FileTool.AutoFormatState contendedState = new FileTool.AutoFormatState();
+        contendedState.add("contended.java");
+        CountDownLatch locked = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        Thread holder = new Thread(() -> {
+            contendedState.flushLock.lock();
+            try {
+                locked.countDown();
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                contendedState.flushLock.unlock();
+            }
+        }, "file-tool-format-lock-holder");
+        holder.start();
+        assertTrue("Lock holder did not start", locked.await(5, TimeUnit.SECONDS));
+
+        try {
+            assertFalse("A locked state is not idle", contendedState.isIdle());
+            assertFalse("A contended lock must respect the supplied timeout",
+                FileTool.flushOnBackgroundThread(
+                    activeProject, contendedState, TimeUnit.MILLISECONDS.toNanos(20)));
+        } finally {
+            release.countDown();
+            holder.join(TimeUnit.SECONDS.toMillis(5));
+        }
+
+        assertFalse("Lock holder did not stop", holder.isAlive());
+        assertEquals("Timed-out work must remain queued",
+            List.of("contended.java"), contendedState.drain());
+        assertTrue(contendedState.isIdle());
+    }
+
+    public void testDeadlineCancellationAndRunnerResultAreReported() {
+        long generousDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        assertTrue(FileTool.runAutoFormatWithDeadline(generousDeadline, ignored -> true));
+        assertFalse(FileTool.runAutoFormatWithDeadline(generousDeadline, ignored -> false));
+
+        AtomicBoolean cancellationObserved = new AtomicBoolean(false);
+        long cancellationDeadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(50);
+        boolean result = FileTool.runAutoFormatWithDeadline(cancellationDeadline, indicator -> {
+            long guardDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (!indicator.isCanceled() && System.nanoTime() < guardDeadline) {
+                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+            }
+            cancellationObserved.set(indicator.isCanceled());
+            return true;
+        });
+
+        assertTrue("Scheduled deadline did not cancel the indicator", cancellationObserved.get());
+        assertFalse("A canceled formatting run must fail visibly", result);
+    }
+
+    public void testProcessorAndDocumentFailuresAbortPipeline() {
+        Project activeProject = mock(Project.class);
+        when(activeProject.isDisposed()).thenReturn(false);
+        ProgressIndicatorBase indicator = new ProgressIndicatorBase();
+        FileDocumentManager failedManager = mock(FileDocumentManager.class);
+
+        assertFalse("A formatter failure must abort before saving",
+            FileTool.runAutoFormatBatch(
+                activeProject, List.of(), indicator, (ignored, optimize) -> false, failedManager));
+
+        FileDocumentManager savedManager = mock(FileDocumentManager.class);
+        assertTrue("Successful empty processor groups must complete",
+            FileTool.runAutoFormatBatch(
+                activeProject, List.of(), new ProgressIndicatorBase(),
+                (ignored, optimize) -> true, savedManager));
+
+        List<PsiFile> files = List.of(mock(PsiFile.class));
+        AtomicInteger calls = new AtomicInteger();
+        assertFalse(FileTool.runFormatProcessors(files, files, (ignored, optimize) -> {
+            calls.incrementAndGet();
+            return false;
+        }));
+        assertEquals("Second formatter must not run after first-stage failure", 1, calls.get());
+
+        calls.set(0);
+        assertFalse(FileTool.runFormatProcessors(files, files, (ignored, optimize) -> {
+            calls.incrementAndGet();
+            return optimize;
+        }));
+        assertEquals("Both formatter stages must run before second-stage failure", 2, calls.get());
+        assertTrue(FileTool.runFormatProcessors(files, files, (ignored, optimize) -> true));
+
+        Document document = mock(Document.class);
+        FileDocumentManager unsavedManager = mock(FileDocumentManager.class);
+        when(unsavedManager.isDocumentUnsaved(document)).thenReturn(true);
+        assertFalse("An unsaved processed document must fail the flush",
+            FileTool.saveProcessedDocuments(unsavedManager, List.of(document), 1));
+
+        FileDocumentManager cleanManager = mock(FileDocumentManager.class);
+        when(cleanManager.isDocumentUnsaved(document)).thenReturn(false);
+        assertTrue(FileTool.saveProcessedDocuments(cleanManager, List.of(document), 1));
+        assertTrue("An empty document batch is already saved",
+            FileTool.saveProcessedDocuments(mock(FileDocumentManager.class), List.of(), 0));
+    }
+
+    public void testFormatPlanAndVirtualFileBoundaryDecisions() {
+        VirtualFile invalidFile = mock(VirtualFile.class);
+        when(invalidFile.isValid()).thenReturn(false);
+        VirtualFile validFile = mock(VirtualFile.class);
+        when(validFile.isValid()).thenReturn(true);
+
+        assertFalse(FileTool.isUsableFormatFile(null));
+        assertFalse(FileTool.isUsableFormatFile(invalidFile));
+        assertTrue(FileTool.isUsableFormatFile(validFile));
+
+        PsiFile psiFile = mock(PsiFile.class);
+        Document document = mock(Document.class);
+        List<PsiFile> optimize = new ArrayList<>();
+        List<PsiFile> reformat = new ArrayList<>();
+        List<Document> documents = new ArrayList<>();
+
+        FileTool.addToFormatPlan(
+            new FileTool.ResolvedFormatFile(psiFile, null, 1),
+            optimize, reformat, documents);
+        FileTool.addToFormatPlan(
+            new FileTool.ResolvedFormatFile(
+                psiFile, document, FileTool.MAX_BYTES_FOR_OPTIMIZE_IMPORTS + 1),
+            optimize, reformat, documents);
+
+        assertEquals(List.of(psiFile), optimize);
+        assertEquals(List.of(psiFile), reformat);
+        assertEquals(List.of(document), documents);
+    }
+
+    public void testDirectoryWithoutPsiFileIsIgnored() {
+        FileTool.queueAutoFormat(getProject(), sourceDir.toString());
+
+        assertTrue("A directory cannot produce a PsiFile and must be ignored",
+            FileTool.flushPendingAutoFormat(getProject()));
     }
 
     public void testMediumFileSkipsImportOptimizationButStillReformats() throws Exception {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/FileToolAutoFormatTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/FileToolAutoFormatTest.java
@@ -207,6 +207,64 @@ public class FileToolAutoFormatTest extends BasePlatformTestCase {
         assertTrue(state.drain().isEmpty());
     }
 
+    public void testSuccessfulChunksAreNotRetriedWhenLaterChunkFails() {
+        Project activeProject = mock(Project.class);
+        when(activeProject.isDisposed()).thenReturn(false);
+        FileTool.AutoFormatState state = new FileTool.AutoFormatState();
+        List<String> paths = new ArrayList<>();
+        for (int i = 0; i < FileTool.AUTO_FORMAT_BATCH_SIZE + 2; i++) {
+            String path = "File" + i + ".java";
+            paths.add(path);
+            state.add(path);
+        }
+
+        List<List<String>> attemptedChunks = new ArrayList<>();
+        AtomicInteger calls = new AtomicInteger();
+        assertFalse(FileTool.flushWhileLocked(
+            activeProject,
+            state,
+            Long.MAX_VALUE,
+            (chunk, ignoredDeadline) -> {
+                attemptedChunks.add(List.copyOf(chunk));
+                return calls.getAndIncrement() == 0;
+            }));
+
+        assertEquals(2, attemptedChunks.size());
+        assertEquals(paths.subList(0, FileTool.AUTO_FORMAT_BATCH_SIZE),
+            attemptedChunks.get(0));
+        assertEquals(paths.subList(FileTool.AUTO_FORMAT_BATCH_SIZE, paths.size()),
+            attemptedChunks.get(1));
+        assertEquals(
+            "Only the failed chunk must be retained after earlier chunks succeeded",
+            paths.subList(FileTool.AUTO_FORMAT_BATCH_SIZE, paths.size()),
+            state.drain());
+    }
+
+    public void testLargeQueueCompletesInBoundedChunks() {
+        Project activeProject = mock(Project.class);
+        when(activeProject.isDisposed()).thenReturn(false);
+        FileTool.AutoFormatState state = new FileTool.AutoFormatState();
+        int pathCount = FileTool.AUTO_FORMAT_BATCH_SIZE * 2 + 1;
+        for (int i = 0; i < pathCount; i++) {
+            state.add("File" + i + ".java");
+        }
+
+        List<Integer> chunkSizes = new ArrayList<>();
+        assertTrue(FileTool.flushWhileLocked(
+            activeProject,
+            state,
+            Long.MAX_VALUE,
+            (chunk, ignoredDeadline) -> {
+                chunkSizes.add(chunk.size());
+                return true;
+            }));
+
+        assertEquals(
+            List.of(FileTool.AUTO_FORMAT_BATCH_SIZE, FileTool.AUTO_FORMAT_BATCH_SIZE, 1),
+            chunkSizes);
+        assertTrue(state.drain().isEmpty());
+    }
+
     public void testEmptyAndIdleQueuesReturnImmediately() {
         assertTrue("A project without a queue must be a no-op",
             FileTool.flushPendingAutoFormat(getProject()));
@@ -330,12 +388,17 @@ public class FileToolAutoFormatTest extends BasePlatformTestCase {
     public void testFormatPlanAndVirtualFileBoundaryDecisions() {
         VirtualFile invalidFile = mock(VirtualFile.class);
         when(invalidFile.isValid()).thenReturn(false);
-        VirtualFile validFile = mock(VirtualFile.class);
-        when(validFile.isValid()).thenReturn(true);
+        VirtualFile readOnlyFile = mock(VirtualFile.class);
+        when(readOnlyFile.isValid()).thenReturn(true);
+        when(readOnlyFile.isWritable()).thenReturn(false);
+        VirtualFile writableFile = mock(VirtualFile.class);
+        when(writableFile.isValid()).thenReturn(true);
+        when(writableFile.isWritable()).thenReturn(true);
 
         assertFalse(FileTool.isUsableFormatFile(null));
         assertFalse(FileTool.isUsableFormatFile(invalidFile));
-        assertTrue(FileTool.isUsableFormatFile(validFile));
+        assertFalse(FileTool.isUsableFormatFile(readOnlyFile));
+        assertTrue(FileTool.isUsableFormatFile(writableFile));
 
         PsiFile psiFile = mock(PsiFile.class);
         Document document = mock(Document.class);

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/FileToolAutoFormatTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/FileToolAutoFormatTest.java
@@ -5,6 +5,8 @@ import com.github.catatafishen.agentbridge.session.db.ConversationDatabase;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.EdtTestUtil;
@@ -14,9 +16,14 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Platform integration tests for the deferred auto-format pipeline.
@@ -82,6 +89,154 @@ public class FileToolAutoFormatTest extends BasePlatformTestCase {
         assertFalse("EDT flush must hand work to a background thread", flushResult.get());
         assertTrue("Background flush did not format and save the file",
             waitForFormattedAndSaved(testFile));
+    }
+
+    public void testDisposedProjectRejectsQueueAndFlush() {
+        Project disposedProject = mock(Project.class);
+        when(disposedProject.isDisposed()).thenReturn(true);
+
+        FileTool.queueAutoFormat(disposedProject, "ignored.java");
+
+        assertFalse("Disposed projects cannot flush deferred formatting",
+            FileTool.flushPendingAutoFormat(disposedProject));
+    }
+
+    public void testInterruptedFlushRetainsWorkForRetry() throws Exception {
+        TestFile testFile = createTestFile(
+            "InterruptedSample.java", "class InterruptedSample{int value=1;}");
+        FileTool.queueAutoFormat(getProject(), testFile.file().getPath());
+
+        boolean flushResult;
+        boolean interruptRestored;
+        Thread.currentThread().interrupt();
+        try {
+            flushResult = FileTool.flushPendingAutoFormat(getProject());
+            interruptRestored = Thread.currentThread().isInterrupted();
+        } finally {
+            Thread.interrupted();
+        }
+
+        assertFalse("Interrupted flush must fail visibly", flushResult);
+        assertTrue("Interrupted status must be restored", interruptRestored);
+        assertTrue("Queued work must remain available for retry",
+            FileTool.flushPendingAutoFormat(getProject()));
+    }
+
+    public void testInterruptionAfterDrainRequeuesPendingPath() {
+        Project mockProject = mock(Project.class);
+        AtomicInteger disposalChecks = new AtomicInteger();
+        AtomicBoolean disposed = new AtomicBoolean(false);
+        when(mockProject.isDisposed()).thenAnswer(ignored -> {
+            if (disposed.get()) return true;
+            if (disposalChecks.incrementAndGet() == 3) {
+                Thread.currentThread().interrupt();
+            }
+            return false;
+        });
+        FileTool.queueAutoFormat(mockProject, "retained.java");
+
+        boolean flushResult;
+        try {
+            flushResult = FileTool.flushPendingAutoFormat(mockProject);
+        } finally {
+            Thread.interrupted();
+        }
+
+        assertFalse("Interrupted batch must fail visibly", flushResult);
+        disposed.set(true);
+        assertFalse("Cleanup flush must observe project disposal",
+            FileTool.flushPendingAutoFormat(mockProject));
+    }
+
+    public void testExpiredBatchRequeuesPathsInOriginalOrder() {
+        Project activeProject = mock(Project.class);
+        when(activeProject.isDisposed()).thenReturn(false);
+        FileTool.AutoFormatState state = new FileTool.AutoFormatState();
+        state.add("first.java");
+        state.add("second.java");
+
+        assertFalse("Expired batch must fail",
+            FileTool.flushWhileLocked(activeProject, state, System.nanoTime() - 1));
+        assertEquals("Expired work must be retained in order",
+            List.of("first.java", "second.java"), state.drain());
+    }
+
+    public void testProjectDisposalBeforeBatchRetainsQueue() {
+        Project disposedProject = mock(Project.class);
+        when(disposedProject.isDisposed()).thenReturn(true);
+        FileTool.AutoFormatState state = new FileTool.AutoFormatState();
+        state.add("retained.java");
+
+        assertFalse("Disposed project must stop a locked flush",
+            FileTool.flushWhileLocked(disposedProject, state, Long.MAX_VALUE));
+        assertEquals(List.of("retained.java"), state.drain());
+    }
+
+    public void testCancellationAndRuntimeFailureRetainQueue() {
+        Project cancelledProject = mock(Project.class);
+        when(cancelledProject.isDisposed()).thenThrow(new ProcessCanceledException());
+        FileTool.AutoFormatState cancelledState = new FileTool.AutoFormatState();
+        cancelledState.add("cancelled.java");
+
+        assertFalse("Cancellation must be reported as an incomplete flush",
+            FileTool.flushWhileLocked(cancelledProject, cancelledState, Long.MAX_VALUE));
+        assertEquals(List.of("cancelled.java"), cancelledState.drain());
+
+        Project failedProject = mock(Project.class);
+        when(failedProject.isDisposed()).thenThrow(new IllegalStateException("boom"));
+        FileTool.AutoFormatState failedState = new FileTool.AutoFormatState();
+        failedState.add("failed.java");
+
+        assertFalse("Runtime failure must be reported as an incomplete flush",
+            FileTool.flushWhileLocked(failedProject, failedState, Long.MAX_VALUE));
+        assertEquals(List.of("failed.java"), failedState.drain());
+    }
+
+    public void testRequeueFirstKeepsFailedBatchAheadOfNewPaths() {
+        FileTool.AutoFormatState state = new FileTool.AutoFormatState();
+        state.add("new.java");
+
+        state.requeueFirst(List.of("first.java", "new.java"));
+
+        assertEquals(List.of("first.java", "new.java"), state.drain());
+        state.requeueFirst(List.of());
+        assertTrue(state.drain().isEmpty());
+    }
+
+    public void testMediumFileSkipsImportOptimizationButStillReformats() throws Exception {
+        String content = "class MediumSample{int value=1;"
+            + " ".repeat((int) FileTool.MAX_BYTES_FOR_OPTIMIZE_IMPORTS + 1024)
+            + "}";
+        TestFile testFile = createTestFile("MediumSample.java", content);
+        assertTrue(testFile.file().getLength() > FileTool.MAX_BYTES_FOR_OPTIMIZE_IMPORTS);
+        assertTrue(testFile.file().getLength() <= FileTool.MAX_BYTES_FOR_REFORMAT);
+        FileTool.queueAutoFormat(getProject(), testFile.file().getPath());
+
+        assertTrue(FileTool.flushPendingAutoFormat(getProject()));
+
+        String formatted = Files.readString(Path.of(testFile.file().getPath()));
+        assertTrue(formatted.contains("class MediumSample {"));
+        assertTrue(formatted.contains("int value = 1;"));
+    }
+
+    public void testTooLargeFileIsSkippedWithoutModification() throws Exception {
+        String content = "class TooLargeSample{"
+            + " ".repeat((int) FileTool.MAX_BYTES_FOR_REFORMAT + 1024)
+            + "}";
+        TestFile testFile = createTestFile("TooLargeSample.java", content);
+        assertTrue(testFile.file().getLength() > FileTool.MAX_BYTES_FOR_REFORMAT);
+        FileTool.queueAutoFormat(getProject(), testFile.file().getPath());
+
+        assertTrue(FileTool.flushPendingAutoFormat(getProject()));
+        assertEquals(content, Files.readString(Path.of(testFile.file().getPath())));
+    }
+
+    public void testMissingPathDoesNotFailFlush() {
+        Path missingPath = sourceDir.resolve("Missing.java");
+        FileTool.queueAutoFormat(getProject(), missingPath.toString());
+
+        assertTrue("Missing queued files should be ignored",
+            FileTool.flushPendingAutoFormat(getProject()));
     }
 
     private boolean waitForFormattedAndSaved(TestFile testFile) throws Exception {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitDocumentSaveIntegrationTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitDocumentSaveIntegrationTest.java
@@ -1,0 +1,182 @@
+package com.github.catatafishen.agentbridge.psi.tools.git;
+
+import com.github.catatafishen.agentbridge.session.db.ConversationDatabase;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.application.impl.ApplicationImpl;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.EdtTestUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Threading integration tests for document saves initiated by Git tools.
+ */
+public class GitDocumentSaveIntegrationTest extends BasePlatformTestCase {
+
+    @Override
+    protected boolean runInDispatchThread() {
+        return false;
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            ConversationDatabase.getInstance(getProject()).dispose();
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    public void testBackgroundSaveKeepsGitWriteWaitOffEdt() throws Exception {
+        TestFile testFile = createUnsavedTestFile();
+        ApplicationImpl application = (ApplicationImpl) ApplicationManager.getApplication();
+        CountDownLatch readStarted = new CountDownLatch(1);
+        CountDownLatch releaseRead = new CountDownLatch(1);
+
+        CompletableFuture<Void> readFuture = runOnPooledThread(() ->
+            application.runReadAction(() -> {
+                readStarted.countDown();
+                awaitRelease(releaseRead, "read action");
+            }));
+        assertTrue("Background read action did not start",
+            readStarted.await(5, TimeUnit.SECONDS));
+
+        CompletableFuture<Void> saveFuture =
+            runOnPooledThread(GitTool::saveAllDocuments);
+
+        EdtSnapshot edtSnapshot;
+        try {
+            assertTrue("Document save never requested a write action",
+                waitForPendingWriteAction(application, saveFuture));
+            edtSnapshot = captureEdtSnapshot();
+        } finally {
+            releaseRead.countDown();
+        }
+
+        readFuture.get(10, TimeUnit.SECONDS);
+        saveFuture.get(10, TimeUnit.SECONDS);
+        assertFalse("Git save was waiting for the write lock on EDT: " + edtSnapshot,
+            edtSnapshot.containsClass(GitTool.class.getName()));
+        assertFalse("Document must be saved when saveAllDocuments() returns",
+            FileDocumentManager.getInstance().isDocumentUnsaved(testFile.document()));
+        assertEquals("changed", Files.readString(testFile.path()));
+    }
+
+    public void testReadOnlyGitStatusDoesNotSaveEditorDocuments() throws Exception {
+        TestFile testFile = createUnsavedTestFile();
+
+        try {
+            new GitStatusTool(getProject()).execute(new JsonObject());
+
+            assertTrue("Read-only git_status must not save editor documents",
+                FileDocumentManager.getInstance().isDocumentUnsaved(testFile.document()));
+        } finally {
+            EdtTestUtil.runInEdtAndWait(() ->
+                FileDocumentManager.getInstance().reloadFromDisk(testFile.document()));
+        }
+    }
+
+    private TestFile createUnsavedTestFile() throws Exception {
+        String basePath = getProject().getBasePath();
+        assertNotNull("Light project must have a base path", basePath);
+        Path projectDir = Path.of(basePath);
+        Files.createDirectories(projectDir);
+        Path path = Files.createTempFile(projectDir, "git-document-save-", ".txt");
+        Files.writeString(path, "original");
+
+        VirtualFile file =
+            LocalFileSystem.getInstance().refreshAndFindFileByPath(path.toString());
+        assertNotNull("Failed to register test file in VFS", file);
+        Document document = ReadAction.nonBlocking(
+                () -> FileDocumentManager.getInstance().getDocument(file))
+            .expireWith(getProject())
+            .executeSynchronously();
+        assertNotNull("Expected a document for the test file", document);
+
+        EdtTestUtil.runInEdtAndWait(() ->
+            WriteCommandAction.runWriteCommandAction(getProject(),
+                () -> document.setText("changed")));
+        assertTrue("Test precondition: document must be unsaved",
+            FileDocumentManager.getInstance().isDocumentUnsaved(document));
+        return new TestFile(path, document);
+    }
+
+    private static boolean waitForPendingWriteAction(
+        ApplicationImpl application,
+        CompletableFuture<?> saveFuture
+    ) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (!application.isWriteActionPending()
+            && !saveFuture.isDone()
+            && System.nanoTime() < deadline) {
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10));
+            if (Thread.interrupted()) throw new InterruptedException();
+        }
+        return application.isWriteActionPending();
+    }
+
+    private static EdtSnapshot captureEdtSnapshot() {
+        for (Map.Entry<Thread, StackTraceElement[]> entry
+            : Thread.getAllStackTraces().entrySet()) {
+            if (entry.getKey().getName().startsWith("AWT-EventQueue")) {
+                return new EdtSnapshot(entry.getKey().getState(), entry.getValue());
+            }
+        }
+        throw new AssertionError("AWT event dispatch thread was not found");
+    }
+
+    private static CompletableFuture<Void> runOnPooledThread(Runnable action) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                action.run();
+                future.complete(null);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+        return future;
+    }
+
+    private static void awaitRelease(CountDownLatch latch, String operation) {
+        try {
+            if (!latch.await(10, TimeUnit.SECONDS)) {
+                throw new AssertionError("Timed out waiting to release " + operation);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(operation + " was interrupted", e);
+        }
+    }
+
+    private record EdtSnapshot(Thread.State state, StackTraceElement[] stack) {
+        private boolean containsClass(String className) {
+            return Arrays.stream(stack)
+                .anyMatch(frame -> frame.getClassName().startsWith(className));
+        }
+
+        @Override
+        public String toString() {
+            String separator = System.lineSeparator();
+            return state + separator + String.join(separator,
+                Arrays.stream(stack).map(StackTraceElement::toString).toList());
+        }
+    }
+
+    private record TestFile(Path path, Document document) {
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitDocumentSaveIntegrationTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitDocumentSaveIntegrationTest.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.application.impl.ApplicationImpl;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.EdtTestUtil;
@@ -21,6 +22,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Threading integration tests for document saves initiated by Git tools.
@@ -87,6 +91,21 @@ public class GitDocumentSaveIntegrationTest extends BasePlatformTestCase {
         } finally {
             EdtTestUtil.runInEdtAndWait(() ->
                 FileDocumentManager.getInstance().reloadFromDisk(testFile.document()));
+        }
+    }
+
+    public void testGitWriteAbortsWhenDeferredFormatCannotComplete() {
+        Project disposedProject = mock(Project.class);
+        when(disposedProject.isDisposed()).thenReturn(true);
+        GitStatusTool tool = new GitStatusTool(disposedProject);
+
+        try {
+            tool.flushAndSave();
+            fail("Git write must abort when deferred formatting cannot complete");
+        } catch (IllegalStateException e) {
+            assertEquals(
+                "Git operation aborted: deferred auto-format did not complete. Retry the operation.",
+                e.getMessage());
         }
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolsTest.java
@@ -45,6 +45,12 @@ public class GitToolsTest extends BasePlatformTestCase {
     // ── Test lifecycle ────────────────────────────────────────────────────────────
 
     @Override
+    protected boolean runInDispatchThread() {
+        // MCP tool calls are dispatched by McpProtocolHandler on a worker thread.
+        return false;
+    }
+
+    @Override
     protected void setUp() throws Exception {
         super.setUp();
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsExtendedTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsExtendedTest.java
@@ -2,12 +2,18 @@ package com.github.catatafishen.agentbridge.psi.tools.refactoring;
 
 import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
 import com.github.catatafishen.agentbridge.psi.ToolUtils;
+import com.github.catatafishen.agentbridge.session.db.ConversationDatabase;
 import com.google.gson.JsonObject;
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import com.intellij.util.ui.UIUtil;
 
@@ -16,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 /**
@@ -81,6 +88,7 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
             for (VirtualFile openFile : fem.getOpenFiles()) {
                 fem.closeFile(openFile);
             }
+            ConversationDatabase.getInstance(getProject()).dispose();
             deleteDir(tempDir);
         } finally {
             super.tearDown();
@@ -414,6 +422,50 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
                 && result.contains("Line: 2"));
         assertFalse("Should not return the not-resolved error, got: " + result,
             result.contains("Could not resolve"));
+    }
+
+    /**
+     * Regression test for product-specific declaration providers. CLion Nova exposes semantic
+     * navigation through a {@link GotoDeclarationHandler} even when the PSI leaf has no reference.
+     */
+    public void testGoToDeclarationUsesRegisteredProviderBeforePsiFallbacks() throws Exception {
+        VirtualFile usageFile = createTestFile("ProviderUsage.txt", "Widget value;\n");
+        VirtualFile declarationFile = createTestFile("Widget.java", String.join("\n",
+            "public class Widget { }",
+            ""));
+
+        PsiElement declaration = ApplicationManager.getApplication().runReadAction(
+            (Computable<PsiElement>) () -> {
+                PsiFile psiFile = PsiManager.getInstance(getProject()).findFile(declarationFile);
+                if (psiFile == null) return null;
+                int offset = psiFile.getText().indexOf("Widget");
+                return ToolUtils.findNearestNamedAncestor(psiFile.findElementAt(offset));
+            });
+        assertNotNull("Expected a declaration element in Widget.java", declaration);
+
+        AtomicBoolean providerInvoked = new AtomicBoolean(false);
+        GotoDeclarationHandler handler = (sourceElement, offset, editor) -> {
+            if (sourceElement == null
+                || !usageFile.equals(sourceElement.getContainingFile().getVirtualFile())) {
+                return null;
+            }
+            providerInvoked.set(true);
+            assertSame("Provider must receive an editor associated with the active project",
+                getProject(), editor.getProject());
+            return new PsiElement[]{declaration};
+        };
+        GotoDeclarationHandler.EP_NAME.getPoint()
+            .registerExtension(handler, getTestRootDisposable());
+
+        String result = goToDeclarationTool.execute(
+            args("path", usageFile.getPath(), "line", "1", "symbol", "Widget"));
+
+        assertTrue("Registered declaration provider was not invoked", providerInvoked.get());
+        assertTrue("Provider target should win over the plain-text PSI fallback, got: " + result,
+            result.contains("Declaration of 'Widget'") && result.contains("Widget.java")
+                && result.contains("Line: 1"));
+        assertFalse("The usage file must not be reported as its own declaration, got: " + result,
+            result.contains("ProviderUsage.txt"));
     }
 
     public void testGoToDeclarationRejectsSubstringMatch() throws Exception {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsExtendedTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsExtendedTest.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
@@ -118,6 +119,23 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
         VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByPath(file.toString());
         assertNotNull("Failed to register test file in VFS: " + file, vf);
         return vf;
+    }
+
+    private Editor openEditorAt(VirtualFile file, int offset) {
+        Editor editor = FileEditorManager.getInstance(getProject()).openTextEditor(
+            new OpenFileDescriptor(getProject(), file, offset), false);
+        assertNotNull("Failed to open test editor for " + file.getPath(), editor);
+        editor.getCaretModel().moveToOffset(offset);
+        return editor;
+    }
+
+    private void assertSelectedEditorAt(VirtualFile expectedFile, int expectedOffset) {
+        Editor selected = FileEditorManager.getInstance(getProject()).getSelectedTextEditor();
+        assertNotNull("Expected a selected text editor", selected);
+        assertSame("The tool must restore the previously selected file",
+            expectedFile, FileDocumentManager.getInstance().getFile(selected.getDocument()));
+        assertEquals("The tool must restore the previous caret offset",
+            expectedOffset, selected.getCaretModel().getOffset());
     }
 
     /**
@@ -441,6 +459,10 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
         VirtualFile declarationFile = createTestFile("Widget.java", String.join("\n",
             "public class Widget { }",
             ""));
+        VirtualFile previousFile =
+            createTestFile("ProviderPreviouslySelected.txt", "keep this editor selected\n");
+        int previousOffset = 5;
+        openEditorAt(previousFile, previousOffset);
 
         PsiElement declaration = ApplicationManager.getApplication().runReadAction(
             (Computable<PsiElement>) () -> {
@@ -478,6 +500,7 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
                 && result.contains("Line: 1"));
         assertFalse("The usage file must not be reported as its own declaration, got: " + result,
             result.contains("ProviderUsage.txt"));
+        assertSelectedEditorAt(previousFile, previousOffset);
     }
 
     public void testGoToDeclarationFallsBackToIdeActionResult() throws Exception {
@@ -517,6 +540,10 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
         VirtualFile declarationFile = createTestFile("ActionTarget.java", declarationText);
         int usageOffset = usageText.indexOf("Widget");
         int declarationOffset = declarationText.indexOf("Widget");
+        VirtualFile previousFile =
+            createTestFile("ActionPreviouslySelected.txt", "keep this editor selected\n");
+        int previousOffset = 7;
+        openEditorAt(previousFile, previousOffset);
         AtomicBoolean actionInvoked = new AtomicBoolean(false);
         String actionId = "AgentBridge.TestGotoDeclaration." + System.identityHashCode(this);
 
@@ -548,6 +575,7 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
             assertNotNull("The action navigation target was not captured", location);
             assertSame(declarationFile, location.file());
             assertEquals(declarationOffset, location.offset());
+            assertSelectedEditorAt(previousFile, previousOffset);
         } finally {
             actionManager.unregisterAction(actionId);
         }
@@ -558,10 +586,14 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
         VirtualFile usageFile = createTestFile("RetryActionUsage.txt", usageText);
         String declarationText = "class Widget { }\n";
         VirtualFile declarationFile = createTestFile("RetryActionTarget.java", declarationText);
+        String decoyText = "unrelated caret movement\n";
+        VirtualFile decoyFile = createTestFile("RetryActionDecoy.txt", decoyText);
         int usageOffset = usageText.indexOf("Widget");
         int declarationOffset = declarationText.indexOf("Widget");
+        int decoyOffset = decoyText.indexOf("caret");
         AtomicBoolean enabled = new AtomicBoolean(false);
         AtomicBoolean enableQueued = new AtomicBoolean(false);
+        AtomicBoolean decoyMoved = new AtomicBoolean(false);
         AtomicInteger updateCalls = new AtomicInteger();
         String actionId = "AgentBridge.TestRetryGotoDeclaration." + System.identityHashCode(this);
 
@@ -571,7 +603,17 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
             public void update(@NotNull AnActionEvent event) {
                 updateCalls.incrementAndGet();
                 if (enableQueued.compareAndSet(false, true)) {
-                    ApplicationManager.getApplication().invokeLater(() -> enabled.set(true));
+                    ApplicationManager.getApplication().invokeLater(() -> {
+                        Editor decoyEditor = FileEditorManager.getInstance(getProject())
+                            .openTextEditor(
+                                new OpenFileDescriptor(getProject(), decoyFile, decoyOffset),
+                                false);
+                        if (decoyEditor != null) {
+                            decoyEditor.getCaretModel().moveToOffset(decoyOffset);
+                            decoyMoved.set(true);
+                        }
+                        enabled.set(true);
+                    });
                 }
                 event.getPresentation().setEnabled(enabled.get());
             }
@@ -592,8 +634,10 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
                     .navigate(usageFile, usageOffset));
 
             assertTrue("The rejected action must be updated again", updateCalls.get() > 1);
+            assertTrue("The regression setup must move an unrelated caret", decoyMoved.get());
             assertNotNull("Navigation must succeed after the action becomes enabled", location);
-            assertSame(declarationFile, location.file());
+            assertSame("A rejected attempt must not capture the unrelated editor",
+                declarationFile, location.file());
             assertEquals(declarationOffset, location.offset());
         } finally {
             actionManager.unregisterAction(actionId);

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsExtendedTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsExtendedTest.java
@@ -413,8 +413,8 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
             ""));
 
         // Line 3 contains the usage `this.bar()` — resolve 'bar' to its declaration on line 2.
-        String result = goToDeclarationTool.execute(
-            args("path", vf.getPath(), "line", "3", "symbol", "bar"));
+        String result = executeSync(() -> goToDeclarationTool.execute(
+            args("path", vf.getPath(), "line", "3", "symbol", "bar")));
 
         assertNotNull("Result must not be null", result);
         assertTrue("Resolution should succeed for 'bar' usage, got: " + result,
@@ -450,6 +450,8 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
                 return null;
             }
             providerInvoked.set(true);
+            assertTrue("Provider must run under a platform read action",
+                ApplicationManager.getApplication().isReadAccessAllowed());
             assertSame("Provider must receive an editor associated with the active project",
                 getProject(), editor.getProject());
             return new PsiElement[]{declaration};
@@ -457,8 +459,8 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
         GotoDeclarationHandler.EP_NAME.getPoint()
             .registerExtension(handler, getTestRootDisposable());
 
-        String result = goToDeclarationTool.execute(
-            args("path", usageFile.getPath(), "line", "1", "symbol", "Widget"));
+        String result = executeSync(() -> goToDeclarationTool.execute(
+            args("path", usageFile.getPath(), "line", "1", "symbol", "Widget")));
 
         assertTrue("Registered declaration provider was not invoked", providerInvoked.get());
         assertTrue("Provider target should win over the plain-text PSI fallback, got: " + result,

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsExtendedTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsExtendedTest.java
@@ -6,8 +6,14 @@ import com.github.catatafishen.agentbridge.session.db.ConversationDatabase;
 import com.google.gson.JsonObject;
 import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler;
 import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -16,13 +22,16 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import com.intellij.util.ui.UIUtil;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 /**
@@ -149,12 +158,12 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
      * {@code EdtUtil.invokeLater}: calling {@code execute()} directly from the EDT would
      * deadlock because the EDT queue is blocked by {@code future.get()}.
      */
-    private String executeSync(ThrowingSupplier<String> action) throws Exception {
-        CompletableFuture<String> future = new CompletableFuture<>();
+    private <T> T executeSync(ThrowingSupplier<T> action) throws Exception {
+        CompletableFuture<T> future = new CompletableFuture<>();
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
             try {
                 future.complete(action.get());
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 future.completeExceptionally(e);
             }
         });
@@ -398,11 +407,10 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
      * End-to-end resolution: a Java file contains both a method declaration and a usage of that
      * method; asks {@code go_to_declaration} to navigate from the usage to the declaration.
      * <p>
-     * Exercises the language-agnostic path that resolves via
-     * {@code psiFile.findReferenceAt(offset)} — the same path that allows the tool to work for
-     * C/C++ in CLion Nova, Python in PyCharm, JS in WebStorm, etc. without per-language code.
-     * Java is used here because we have a stable PSI for it in tests; the resolution path itself
-     * is language-agnostic.
+     * Exercises the language-agnostic frontend path that resolves via
+     * {@code psiFile.findReferenceAt(offset)}. Java is used here because it has stable PSI in the
+     * test platform. Backend-driven products such as CLion Nova are covered separately by the
+     * live-editor action tests below.
      */
     public void testGoToDeclarationResolvesUsageToDeclaration() throws Exception {
         VirtualFile vf = createTestFile("Foo.java", String.join("\n",
@@ -425,8 +433,8 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
     }
 
     /**
-     * Regression test for product-specific declaration providers. CLion Nova exposes semantic
-     * navigation through a {@link GotoDeclarationHandler} even when the PSI leaf has no reference.
+     * Regression test for frontend declaration providers that can resolve a symbol even when the
+     * PSI leaf has no reference.
      */
     public void testGoToDeclarationUsesRegisteredProviderBeforePsiFallbacks() throws Exception {
         VirtualFile usageFile = createTestFile("ProviderUsage.txt", "Widget value;\n");
@@ -454,6 +462,8 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
                 ApplicationManager.getApplication().isReadAccessAllowed());
             assertSame("Provider must receive an editor associated with the active project",
                 getProject(), editor.getProject());
+            assertSame("Provider must use the live project editor",
+                FileEditorManager.getInstance(getProject()).getSelectedTextEditor(), editor);
             return new PsiElement[]{declaration};
         };
         GotoDeclarationHandler.EP_NAME.getPoint()
@@ -468,6 +478,163 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
                 && result.contains("Line: 1"));
         assertFalse("The usage file must not be reported as its own declaration, got: " + result,
             result.contains("ProviderUsage.txt"));
+    }
+
+    public void testGoToDeclarationFallsBackToIdeActionResult() throws Exception {
+        VirtualFile usageFile = createTestFile(
+            "BackendUsage.java",
+            "class BackendUsage { Object value = Missing; }\n");
+        String declarationText = "class Missing { }\n";
+        VirtualFile declarationFile = createTestFile("Missing.java", declarationText);
+        int declarationOffset = declarationText.indexOf("Missing");
+        AtomicBoolean navigatorInvoked = new AtomicBoolean(false);
+
+        GoToDeclarationTool backendTool = new GoToDeclarationTool(
+            getProject(),
+            (sourceFile, sourceOffset) -> {
+                assertEquals("Fallback must use the requested source path",
+                    usageFile.getPath(), sourceFile.getPath());
+                assertTrue("Fallback must use the matched symbol offset", sourceOffset > 0);
+                navigatorInvoked.set(true);
+                return new IdeDeclarationNavigator.Location(
+                    declarationFile, declarationOffset);
+            });
+
+        String result = executeSync(() -> backendTool.execute(
+            args("path", usageFile.getPath(), "line", "1", "symbol", "Missing")));
+
+        assertTrue("The IDE action fallback was not invoked", navigatorInvoked.get());
+        assertTrue("Expected the backend-selected declaration, got: " + result,
+            result.contains("Declaration of 'Missing'")
+                && result.contains("Missing.java")
+                && result.contains("Line: 1"));
+    }
+
+    public void testIdeDeclarationNavigatorUsesLiveEditorAction() throws Exception {
+        String usageText = "Widget value;\n";
+        VirtualFile usageFile = createTestFile("ActionUsage.txt", usageText);
+        String declarationText = "class Widget { }\n";
+        VirtualFile declarationFile = createTestFile("ActionTarget.java", declarationText);
+        int usageOffset = usageText.indexOf("Widget");
+        int declarationOffset = declarationText.indexOf("Widget");
+        AtomicBoolean actionInvoked = new AtomicBoolean(false);
+        String actionId = "AgentBridge.TestGotoDeclaration." + System.identityHashCode(this);
+
+        ActionManager actionManager = ActionManager.getInstance();
+        actionManager.registerAction(actionId, new AnAction() {
+            @Override
+            public void actionPerformed(@NotNull AnActionEvent event) {
+                com.intellij.openapi.editor.Editor editor =
+                    event.getData(CommonDataKeys.EDITOR);
+                assertNotNull("The real editor must be present in the action data context", editor);
+                assertSame("The action must receive the source file's editor",
+                    usageFile,
+                    FileDocumentManager.getInstance().getFile(editor.getDocument()));
+                actionInvoked.set(true);
+                FileEditorManager.getInstance(getProject()).openTextEditor(
+                    new OpenFileDescriptor(
+                        getProject(), declarationFile, declarationOffset),
+                    false);
+            }
+        });
+
+        try {
+            IdeDeclarationNavigator.Location location = executeSync(
+                () -> new IdeDeclarationNavigator(
+                    getProject(), actionId, Duration.ofSeconds(5))
+                    .navigate(usageFile, usageOffset));
+
+            assertTrue("The registered IDE action was not invoked", actionInvoked.get());
+            assertNotNull("The action navigation target was not captured", location);
+            assertSame(declarationFile, location.file());
+            assertEquals(declarationOffset, location.offset());
+        } finally {
+            actionManager.unregisterAction(actionId);
+        }
+    }
+
+    public void testIdeDeclarationNavigatorRetriesRejectedAction() throws Exception {
+        String usageText = "Widget value;\n";
+        VirtualFile usageFile = createTestFile("RetryActionUsage.txt", usageText);
+        String declarationText = "class Widget { }\n";
+        VirtualFile declarationFile = createTestFile("RetryActionTarget.java", declarationText);
+        int usageOffset = usageText.indexOf("Widget");
+        int declarationOffset = declarationText.indexOf("Widget");
+        AtomicBoolean enabled = new AtomicBoolean(false);
+        AtomicBoolean enableQueued = new AtomicBoolean(false);
+        AtomicInteger updateCalls = new AtomicInteger();
+        String actionId = "AgentBridge.TestRetryGotoDeclaration." + System.identityHashCode(this);
+
+        ActionManager actionManager = ActionManager.getInstance();
+        actionManager.registerAction(actionId, new AnAction() {
+            @Override
+            public void update(@NotNull AnActionEvent event) {
+                updateCalls.incrementAndGet();
+                if (enableQueued.compareAndSet(false, true)) {
+                    ApplicationManager.getApplication().invokeLater(() -> enabled.set(true));
+                }
+                event.getPresentation().setEnabled(enabled.get());
+            }
+
+            @Override
+            public void actionPerformed(@NotNull AnActionEvent event) {
+                FileEditorManager.getInstance(getProject()).openTextEditor(
+                    new OpenFileDescriptor(
+                        getProject(), declarationFile, declarationOffset),
+                    false);
+            }
+        });
+
+        try {
+            IdeDeclarationNavigator.Location location = executeSync(
+                () -> new IdeDeclarationNavigator(
+                    getProject(), actionId, Duration.ofSeconds(5))
+                    .navigate(usageFile, usageOffset));
+
+            assertTrue("The rejected action must be updated again", updateCalls.get() > 1);
+            assertNotNull("Navigation must succeed after the action becomes enabled", location);
+            assertSame(declarationFile, location.file());
+            assertEquals(declarationOffset, location.offset());
+        } finally {
+            actionManager.unregisterAction(actionId);
+        }
+    }
+
+    public void testIdeDeclarationNavigatorReturnsNullForMissingAction() throws Exception {
+        VirtualFile usageFile = createTestFile("MissingAction.txt", "Widget value;\n");
+
+        IdeDeclarationNavigator.Location location = new IdeDeclarationNavigator(
+            getProject(),
+            "AgentBridge.ActionThatDoesNotExist." + System.identityHashCode(this),
+            Duration.ofMillis(10))
+            .navigate(usageFile, 0);
+
+        assertNull(location);
+    }
+
+    public void testIdeDeclarationNavigatorTimesOutWhenActionDoesNotNavigate() throws Exception {
+        VirtualFile usageFile = createTestFile("NoNavigation.txt", "Widget value;\n");
+        AtomicBoolean actionInvoked = new AtomicBoolean(false);
+        String actionId = "AgentBridge.TestNoNavigation." + System.identityHashCode(this);
+        ActionManager actionManager = ActionManager.getInstance();
+        actionManager.registerAction(actionId, new AnAction() {
+            @Override
+            public void actionPerformed(@NotNull AnActionEvent event) {
+                actionInvoked.set(true);
+            }
+        });
+
+        try {
+            IdeDeclarationNavigator.Location location = executeSync(
+                () -> new IdeDeclarationNavigator(
+                    getProject(), actionId, Duration.ofMillis(500))
+                    .navigate(usageFile, 0));
+
+            assertTrue("The no-op action was not invoked", actionInvoked.get());
+            assertNull("A no-op action must not fabricate a declaration location", location);
+        } finally {
+            actionManager.unregisterAction(actionId);
+        }
     }
 
     public void testGoToDeclarationRejectsSubstringMatch() throws Exception {

--- a/plugin-experimental/build.gradle.kts
+++ b/plugin-experimental/build.gradle.kts
@@ -173,7 +173,9 @@ intellijPlatform {
         ides {
             // Use explicit stable versions only — recommended() also pulls in EAP builds
             // which cause ClosedByInterruptException from resource exhaustion.
-            create(IntelliJPlatformType.IntellijIdeaCommunity, "2025.3")
+            // IntelliJ IDEA Community (IC) is no longer published as a separate artifact
+            // since 2025.3 — JetBrains unified the distribution. Use Ultimate (IU) instead.
+            create(IntelliJPlatformType.IntellijIdeaUltimate, "2025.3")
         }
     }
 }


### PR DESCRIPTION
## Summary

- Run deferred reformat and import processors synchronously on a background progress indicator instead of wrapping single-file processor calls in an EDT write action.
- Serialize per-project flushes, use an atomic idle check, process bounded chunks without retrying successful prefixes, retain failed work, and skip non-writable files before IntelliJ can open an unlock modal.
- Remove the outer EDT and write-action wrapper from VCS saves while keeping read-only status and diff operations side-effect free.
- Capture CLion and Rider backend declaration navigation through the live IDE action with attempt-scoped events, ignore rejected attempts, avoid focus requests, and restore the previously selected editor and caret.
- Use the unified IntelliJ IDEA 2025.3 (IU) distribution for experimental-plugin verification because the separate Community (IC) artifact is no longer published.

## Root cause

For a single file, AbstractLayoutCodeProcessor.run schedules a background task and returns. The previous pipeline invoked it inside an EDT write command while the background import optimizer needed a read action. VCS writes independently used invokeAndWait around an outer write action. Under load, those paths formed the read and write inversion captured in the freeze reports.

Backend declaration navigation had a separate race: listeners stayed globally armed after a rejected action attempt, so unrelated caret movement could be accepted as the declaration target. Both navigation entry points also requested editor focus and left the user selection changed.

The formatter now follows the JetBrains format-on-save pattern: construct a multi-file processor chain and call processFilesUnderProgress off EDT, letting the platform own its narrow write actions. Navigation events are tied to one accepted action attempt and editor state is restored in finally.

The experimental verifier still requested IntelliJIdeaCommunity 2025.3. JetBrains unified IntelliJ IDEA distributions starting with 2025.3, so that artifact cannot resolve and the missing SDK produces a cascade of unresolved IDE symbols. The fix preserves the intentionally pinned stable verifier version and changes only its distribution type to IntelliJIdeaUltimate.

## Verification

- IDEA build_project: 0 errors.
- plugin-core buildPlugin: successful.
- FileToolAutoFormatTest: 20 of 20 passed.
- RefactoringToolsExtendedTest: 25 of 25 passed.
- Document-save integration tests: 3 of 3 passed.
- ToolDefinitionContractTest: 1560 of 1560 passed.
- Real CLion 2026.1 Starter GoToDeclarationIntegrationTest: 1 of 1 passed.
- Full local plugin-core test task: 10,197 executed, 36 known Windows or environment-specific failures, 3 skipped; none of the failures are in the changed formatter, VCS flush, or declaration-navigation classes.
- plugin-experimental verifyPlugin: successful; IntelliJ Plugin Verifier loaded idea-2025.3-win.
- IDEA build after the verifier-target change: 0 errors, 23 warnings.
- Commits 7c27b2abd and 4577af8eb use the repository bot identity.

References:

- https://plugins.jetbrains.com/docs/intellij/threading-model.html
- https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
- https://blog.jetbrains.com/platform/2025/11/intellij-platform-2025-3-what-plugin-developers-should-know/