### PR TITLE
fix: use custom startup instructions from settings in MCP initialize

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/claude/InstructionsManager.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/claude/InstructionsManager.java
@@ -1,5 +1,7 @@
 package com.github.catatafishen.agentbridge.client.claude;
 
+import com.github.catatafishen.agentbridge.settings.StartupInstructionsSettings;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -113,8 +115,26 @@ public final class InstructionsManager {
 
     @NotNull
     private static String buildInstructions(@NotNull String additionalInstructions, boolean sandboxEnabled) {
+        var application = ApplicationManager.getApplication();
+        var settings = application == null
+            ? null
+            : application.getService(StartupInstructionsSettings.class);
+        String startupInstructions = settings == null ? null : settings.getInstructions();
+        return buildInstructions(additionalInstructions, sandboxEnabled, startupInstructions);
+    }
+
+    @NotNull
+    static String buildInstructions(
+        @NotNull String additionalInstructions,
+        boolean sandboxEnabled,
+        @Nullable String startupInstructions
+    ) {
         StringBuilder sb = new StringBuilder(INSTRUCTIONS_SENTINEL).append("\n\n");
-        appendResource(sb, "/default-startup-instructions.md");
+        if (startupInstructions != null) {
+            sb.append(startupInstructions);
+        } else {
+            appendResource(sb, "/default-startup-instructions.md");
+        }
         if (sandboxEnabled) {
             sb.append("\n\n");
             appendResource(sb, "/bwrap-sandbox-instructions.md");

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpProtocolHandler.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/McpProtocolHandler.java
@@ -23,6 +23,7 @@ import com.github.catatafishen.agentbridge.session.db.ConversationService;
 import com.github.catatafishen.agentbridge.session.db.ToolCallStatsEnrichment;
 import com.github.catatafishen.agentbridge.settings.McpServerSettings;
 import com.github.catatafishen.agentbridge.settings.McpToolFilter;
+import com.github.catatafishen.agentbridge.settings.StartupInstructionsSettings;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -31,6 +32,7 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
@@ -195,11 +197,12 @@ public final class McpProtocolHandler {
     }
 
     private @NotNull String buildInstructions() {
+        String startupInstructions = getStartupInstructions();
         String memoryContext = buildMemoryContext();
         if (memoryContext.isEmpty()) {
-            return STARTUP_INSTRUCTIONS;
+            return startupInstructions;
         }
-        return STARTUP_INSTRUCTIONS + "\n\n" + memoryContext;
+        return startupInstructions + "\n\n" + memoryContext;
     }
 
     private @NotNull String buildMemoryContext() {
@@ -241,6 +244,15 @@ public final class McpProtocolHandler {
             LOG.warn("Failed to build memory context for MCP init", e);
             return "";
         }
+    }
+
+    private static @NotNull String getStartupInstructions() {
+        var application = ApplicationManager.getApplication();
+        if (application == null) {
+            return STARTUP_INSTRUCTIONS;
+        }
+        var settings = application.getService(StartupInstructionsSettings.class);
+        return settings == null ? STARTUP_INSTRUCTIONS : settings.getInstructions();
     }
 
     private static String loadInstructions() {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/claude/InstructionsManagerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/claude/InstructionsManagerTest.java
@@ -154,6 +154,25 @@ class InstructionsManagerTest {
     // ── additional instructions ───────────────────────────────────────────────
 
     @Test
+    void usesCustomStartupInstructionsWhenEnabled() {
+        String custom = "CUSTOM_STARTUP_INSTRUCTIONS";
+
+        String content = InstructionsManager.buildInstructions("", false, custom);
+
+        assertTrue(content.contains(custom), "custom startup instructions must be included");
+        assertFalse(content.contains("TRUST TOOL OUTPUTS"),
+            "default instructions must not be included when custom instructions are enabled");
+    }
+
+    @Test
+    void usesDefaultStartupInstructionsWhenCustomIsDisabled() {
+        String content = InstructionsManager.buildInstructions("", false, null);
+
+        assertTrue(content.contains("TRUST TOOL OUTPUTS"),
+            "default startup instructions must be included when custom instructions are disabled");
+    }
+
+    @Test
     void blankAdditionalInstructionsNotAppended() {
         InstructionsManager.ensureInstructions(projectRoot.toString(), "CLAUDE.md", "   ");
 


### PR DESCRIPTION
McpProtocolHandler.buildInstructions() and InstructionsManager.buildInstructions() both hardcoded the static classpath default template, ignoring StartupInstructionsSettings. Custom startup instructions configured in Settings → Tools → AgentBridge were never delivered to external MCP clients or file-based agents.