### PR TITLE
fix: declare JCEF plugin dependency for IDE build 262+

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,6 +18,7 @@ ignore:
   - "**/AgentEditHighlighter.java"
   - "**/AgentEditNotificationProvider.java"
   - "**/RevertReasonDialog.java"
+  - "**/JcefCompat.java"
 
 coverage:
   status:

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
@@ -431,47 +431,6 @@ public final class PlatformApiCompat {
     }
 
     /**
-     *
-     * <p><b>Why extracted:</b> {@code CefLoadHandlerAdapter} provides default implementations for all
-     * {@code CefLoadHandler} methods, but the JCEF version bundled with the dev IDE may declare
-     * {@code onLoadError} with a different {@code ErrorCode} enum type than the target platform SDK.
-     * In Kotlin, the compiler flags the anonymous subclass as "not implementing abstract member"
-     * because of this signature mismatch. In Java, the adapter's default implementation satisfies
-     * the contract and no error is reported.</p>
-     */
-    public static org.cef.handler.CefLoadHandler createMainFrameLoadEndHandler(@NotNull Runnable onMainFrameLoaded) {
-        return new org.cef.handler.CefLoadHandlerAdapter() {
-            @Override
-            public void onLoadEnd(org.cef.browser.CefBrowser browser, org.cef.browser.CefFrame frame, int httpStatusCode) {
-                if (frame != null && frame.isMain()) {
-                    onMainFrameLoaded.run();
-                }
-            }
-        };
-    }
-
-    /**
-     * Creates a JCEF display handler that logs console messages to the given logger.
-     *
-     * <p><b>Why extracted:</b> In newer JCEF versions, {@code LogSeverity} was moved from
-     * {@code org.cef.CefSettings.LogSeverity} to a top-level {@code org.cef.LogSeverity} enum.
-     * Kotlin's strict override checking flags the old import path as "overrides nothing" because
-     * the parameter type doesn't match the parent's signature. In Java, the method resolution
-     * handles both paths via the compiled class hierarchy without flagging an error.</p>
-     */
-    public static org.cef.handler.CefDisplayHandler createConsoleLogHandler(@NotNull Logger logger) {
-        return new org.cef.handler.CefDisplayHandlerAdapter() {
-            @Override
-            public boolean onConsoleMessage(org.cef.browser.CefBrowser browser,
-                                            org.cef.CefSettings.LogSeverity level,
-                                            String message, String source, int line) {
-                logger.info("JCEF Console [" + level + "]: " + message);
-                return false;
-            }
-        };
-    }
-
-    /**
      * Subscribes a callback to Look-and-Feel change events on the application message bus.
      *
      * <p><b>Why extracted:</b> {@code LafManagerListener.TOPIC} is typed as
@@ -2085,20 +2044,6 @@ public final class PlatformApiCompat {
     public static @Nullable com.intellij.openapi.ui.popup.ListPopupStep<Object> getListStep(
         @NotNull com.intellij.ui.popup.list.ListPopupImpl popup) {
         return popup.getListStep();
-    }
-
-    /**
-     * Creates a {@link com.intellij.ui.jcef.JBCefJSQuery} for the given JCEF browser.
-     *
-     * <p><b>Why extracted:</b> {@code JBCefJSQuery.create(JBCefBrowser)} is scheduled for
-     * removal in favour of {@code create(JBCefBrowserBase)}. {@code JBCefBrowser} extends
-     * {@code JBCefBrowserBase} in all supported IDE SDK versions (verified in 2024.3–2026.2),
-     * so passing a {@code JBCefBrowserBase} reference here is safe. This wrapper keeps the
-     * call site clean and confines any future API change to one place.</p>
-     */
-    public static @NotNull com.intellij.ui.jcef.JBCefJSQuery createJSQuery(
-        @NotNull com.intellij.ui.jcef.JBCefBrowserBase browser) {
-        return com.intellij.ui.jcef.JBCefJSQuery.create(browser);
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/JcefCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/JcefCompat.java
@@ -1,0 +1,38 @@
+package com.github.catatafishen.agentbridge.ui;
+
+import com.intellij.ui.jcef.JBCefBrowserBase;
+import com.intellij.ui.jcef.JBCefJSQuery;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Version-compatibility wrappers for JetBrains JCEF ({@code com.intellij.ui.jcef}) APIs.
+ *
+ * <p><b>Why this is separate from {@link com.github.catatafishen.agentbridge.psi.PlatformApiCompat}:</b>
+ * JCEF ships in a separately class-loaded bundled plugin ({@code com.intellij.modules.jcef}) as of
+ * IDE build 262. Any class that references {@code com.intellij.ui.jcef.*} or {@code org.cef.*} in a
+ * method signature forces the JVM verifier to load those types when the class itself is loaded. If
+ * such references lived in {@code PlatformApiCompat} — which is touched on the startup path — the
+ * whole plugin would fail to load with {@code NoClassDefFoundError} in environments where JCEF is
+ * absent (alternative JDK, thin client, remote-dev backend).
+ *
+ * <p>Keeping all JCEF-typed helpers here means this class is only loaded once JCEF UI is actually
+ * used (guarded by {@code JBCefApp.isSupported()}), so the headless code paths stay JCEF-free.
+ */
+public final class JcefCompat {
+
+    private JcefCompat() {
+    }
+
+    /**
+     * Creates a {@link JBCefJSQuery} for the given JCEF browser.
+     *
+     * <p><b>Why extracted:</b> {@code JBCefJSQuery.create(JBCefBrowser)} is scheduled for
+     * removal in favour of {@code create(JBCefBrowserBase)}. {@code JBCefBrowser} extends
+     * {@code JBCefBrowserBase} in all supported IDE SDK versions (verified in 2024.3–2026.2),
+     * so passing a {@code JBCefBrowserBase} reference here is safe. This wrapper keeps the
+     * call site clean and confines any future API change to one place.
+     */
+    public static @NotNull JBCefJSQuery createJSQuery(@NotNull JBCefBrowserBase browser) {
+        return JBCefJSQuery.create(browser);
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/graph/KnowledgeGraphDiagramPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/graph/KnowledgeGraphDiagramPanel.kt
@@ -1,6 +1,6 @@
 package com.github.catatafishen.agentbridge.ui.graph
 
-import com.github.catatafishen.agentbridge.psi.PlatformApiCompat
+import com.github.catatafishen.agentbridge.ui.JcefCompat
 import com.github.catatafishen.agentbridge.psi.graph.CodeGraphStore
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
@@ -66,7 +66,7 @@ class KnowledgeGraphDiagramPanel(private val project: Project) : Disposable {
             Disposer.register(this, b)
             browser = b
 
-            val q = PlatformApiCompat.createJSQuery(b as com.intellij.ui.jcef.JBCefBrowserBase)
+            val q = JcefCompat.createJSQuery(b as com.intellij.ui.jcef.JBCefBrowserBase)
             q.addHandler { path -> navigateToFile(path); null }
             Disposer.register(this, q)
             navigateQuery = q

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ToolCallsWebPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ToolCallsWebPanel.kt
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.ui.side
 
 import com.github.catatafishen.agentbridge.psi.PlatformApiCompat
+import com.github.catatafishen.agentbridge.ui.JcefCompat
 import com.github.catatafishen.agentbridge.services.LiveToolCallEntry
 import com.github.catatafishen.agentbridge.services.LiveToolCallService
 import com.github.catatafishen.agentbridge.services.ToolRegistry
@@ -42,7 +43,7 @@ class ToolCallsWebPanel(private val project: Project) : JPanel(BorderLayout()), 
             browser.setPageBackgroundColor("rgb(${panelBg.red},${panelBg.green},${panelBg.blue})")
             Disposer.register(this, browser)
 
-            val query = PlatformApiCompat.createJSQuery(browser)
+            val query = JcefCompat.createJSQuery(browser)
             query.addHandler { request ->
                 try {
                     val parsed = com.google.gson.JsonParser.parseString(request).asJsonObject
@@ -62,7 +63,7 @@ class ToolCallsWebPanel(private val project: Project) : JPanel(BorderLayout()), 
             Disposer.register(this, query)
             diffQuery = query
 
-            val loadMore = PlatformApiCompat.createJSQuery(browser)
+            val loadMore = JcefCompat.createJSQuery(browser)
             loadMore.addHandler { beforeEventId ->
                 loadHistoryPage(if (beforeEventId.isNullOrBlank()) null else beforeEventId)
                 null

--- a/plugin-core/src/main/resources/META-INF/jcef-features.xml
+++ b/plugin-core/src/main/resources/META-INF/jcef-features.xml
@@ -1,0 +1,17 @@
+<idea-plugin>
+    <!-- Features requiring the JCEF plugin (com.intellij.modules.jcef).
+
+         In IDE builds up to 2026.1 the JCEF classes (org.cef.* and
+         com.intellij.ui.jcef.*) shipped on the boot classpath as the module
+         intellij.libraries.jcef, so they were always resolvable. Starting with
+         build 262 (2026.2) JCEF moved into a separately class-loaded bundled
+         plugin (id com.intellij.modules.jcef). Without declaring this optional
+         dependency the plugin classloader can no longer see org.cef.* /
+         com.intellij.ui.jcef.*, which crashed startup with
+         NoClassDefFoundError: org/cef/handler/CefLoadHandler.
+
+         The dependency is optional so the plugin still loads (MCP tools, PSI
+         bridge, headless features) in environments where JCEF is unavailable
+         (alternative JDK without JCEF, thin client, remote-dev backend). JCEF
+         UI is guarded at runtime by JBCefApp.isSupported(). -->
+</idea-plugin>

--- a/plugin-core/src/main/resources/META-INF/plugin.xml
+++ b/plugin-core/src/main/resources/META-INF/plugin.xml
@@ -57,6 +57,11 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, OpenCod
   <depends optional="true" config-file="java-features.xml">com.intellij.modules.java</depends>
   <depends optional="true" config-file="git-features.xml">Git4Idea</depends>
   <depends optional="true" config-file="terminal-features.xml">org.jetbrains.plugins.terminal</depends>
+  <!-- JCEF moved from the boot classpath into a separately class-loaded bundled plugin in build 262.
+       Declaring this dependency wires the JCEF classloader so org.cef.* / com.intellij.ui.jcef.*
+       resolve at runtime. Optional so the plugin still loads (headless MCP/PSI features) when JCEF
+       is unavailable; JCEF UI is guarded by JBCefApp.isSupported(). -->
+  <depends optional="true" config-file="jcef-features.xml">com.intellij.modules.jcef</depends>
   <!-- Optional plugins accessed via reflection for enhanced tool support -->
   <depends optional="true" config-file="gradle-features.xml">org.jetbrains.plugins.gradle</depends>
   <depends optional="true" config-file="maven-features.xml">org.jetbrains.idea.maven</depends>

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/JcefCompatTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/JcefCompatTest.java
@@ -1,0 +1,53 @@
+package com.github.catatafishen.agentbridge.ui;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link JcefCompat}.
+ *
+ * <p>The {@code createJSQuery} method delegates directly to {@code JBCefJSQuery.create(browser)}
+ * and cannot be exercised without a live IntelliJ JCEF environment (covered by integration tests).
+ * This test verifies the structural contract: the class is a non-instantiable utility class and
+ * that the factory method is declared with the expected signature.
+ */
+@DisplayName("JcefCompat")
+class JcefCompatTest {
+
+    @Nested
+    @DisplayName("utility class contract")
+    class UtilityClassContract {
+
+        @Test
+        @DisplayName("class is final")
+        void classIsFinal() {
+            assertTrue(Modifier.isFinal(JcefCompat.class.getModifiers()),
+                "JcefCompat should be a final utility class");
+        }
+
+        @Test
+        @DisplayName("private constructor prevents instantiation")
+        void privateConstructorPreventsInstantiation() throws NoSuchMethodException {
+            Constructor<JcefCompat> ctor = JcefCompat.class.getDeclaredConstructor();
+            assertFalse(ctor.canAccess(null),
+                "JcefCompat constructor should be private");
+        }
+
+        @Test
+        @DisplayName("createJSQuery method is declared public and static")
+        void createJsQueryIsPublicStatic() throws NoSuchMethodException {
+            var method = JcefCompat.class.getDeclaredMethod(
+                "createJSQuery", com.intellij.ui.jcef.JBCefBrowserBase.class);
+            int mods = method.getModifiers();
+            assertTrue(Modifier.isPublic(mods), "createJSQuery should be public");
+            assertTrue(Modifier.isStatic(mods), "createJSQuery should be static");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The plugin crashes on startup in GoLand/IDEA **build 262** (2026.2) with:

```
NoClassDefFoundError: org/cef/handler/CefLoadHandler
    at PsiBridgeStartup.execute(PsiBridgeStartup.kt:20)
```

## Root cause

Build 262 moved JCEF into a **separately class-loaded bundled plugin** (`com.intellij.modules.jcef`). In builds up to 2026.1 the JCEF classes (`org.cef.*` and `com.intellij.ui.jcef.*`) shipped on the **boot classpath** (module `intellij.libraries.jcef` in `lib/`), so they were always resolvable — the plugin never needed to declare a dependency.

Under build 262 the plugin's classloader can no longer see `org.cef.*`. The crash surfaces on the startup path because `PsiBridgeStartup` calls `PlatformApiCompat.isJetBrainsClient()`, and `PlatformApiCompat` declared methods whose **signatures** referenced `org.cef.*` / `com.intellij.ui.jcef.*`. Loading that class forces the JVM verifier to resolve those types, so a missing JCEF took down the **entire** plugin — including the headless MCP/PSI features that don't use JCEF at all.

This mirrors the `intellij.libraries.lucene.common.jar` relocation already handled in `build.gradle.kts`.

## Fix

1. **Declare an optional dependency on `com.intellij.modules.jcef`** (`plugin.xml` + new `jcef-features.xml`). This is a valid module id in 253–2026.1 and the bundled-plugin id in 262+, so it wires the JCEF classloader across all supported versions. Optional, so the plugin still loads where JCEF is unavailable (alternative JDK, thin client, remote-dev backend); JCEF UI stays guarded by `JBCefApp.isSupported()`.
2. **Remove all JCEF references from the startup-critical `PlatformApiCompat`** — moved the `createJSQuery` helper into a new JCEF-only `JcefCompat` class and deleted two dead `org.cef` handler factory methods (`createMainFrameLoadEndHandler`, `createConsoleLogHandler` — no callers). `PlatformApiCompat` now verifies and loads even when JCEF is absent, so headless features degrade gracefully instead of crashing.

## Verification

- `compileKotlin` / `compileJava` succeed (only pre-existing deprecation warnings).
- `verifyPluginProjectConfiguration` passes.
- Patched `plugin.xml` contains the new dependency; `jcef-features.xml` bundles into resources.
- The two `createJSQuery` call sites (`KnowledgeGraphDiagramPanel`, `ToolCallsWebPanel`) repointed to `JcefCompat`.

> Note: unrelated pre-existing unit-test failures on the dev machine are locale-specific (comma decimal separator, e.g. `2,0 KB`) and MIME-registry differences — none touch JCEF or `PlatformApiCompat`.