### PR TITLE
fix: resolve local Gradle build against IntelliJ IDEA 2026.2

### DIFF
--- a/plugin-core/build.gradle.kts
+++ b/plugin-core/build.gradle.kts
@@ -35,7 +35,10 @@ repositories {
 
 dependencies {
     intellijPlatform {
-        val localPath = providers.gradleProperty("intellijPlatform.localPath").orNull
+        // A blank value (e.g. `-PintellijPlatform.localPath=` passed on the command line to opt
+        // out of a broken local IDE without editing ~/.gradle/gradle.properties) must be treated
+        // as unset, not as a literal empty path passed to local().
+        val localPath = providers.gradleProperty("intellijPlatform.localPath").orNull?.takeIf { it.isNotBlank() }
         if (localPath != null) {
             local(localPath)
         } else {
@@ -49,9 +52,26 @@ dependencies {
         bundledPlugin("com.intellij.java")
         bundledPlugin("Git4Idea")
         bundledPlugin("org.jetbrains.plugins.terminal")
+        // JCEF (com.intellij.ui.jcef.*, org.cef.*) shipped on the auto-included boot classpath
+        // through IU 2026.1. Starting with build 262 (2026.2) it moved into a separately
+        // class-loaded bundled plugin (id com.intellij.modules.jcef), so it must be requested
+        // explicitly to stay resolvable on the compile classpath. Harmless no-op on older versions.
+        bundledPlugin("com.intellij.modules.jcef")
+        // com.intellij.dvcs.repo.Repository / AbstractRepositoryManager (supertypes of
+        // GitRepository) and com.intellij.vcs.log.impl.VcsProjectLog live in these product
+        // modules. IU 262 (2026.2) stopped auto-including every lib/*.jar product module on the
+        // compile classpath, so request them explicitly. Harmless no-op on older versions where
+        // they were already auto-included.
+        bundledModule("intellij.platform.vcs.dvcs")
+        bundledModule("intellij.platform.vcs.dvcs.impl")
+        bundledModule("intellij.platform.vcs.log.impl")
         // In IU-2026.1+, intellij.libraries.lucene.common.jar moved from lib/modules/ (auto-included)
         // to lib/ (not auto-included). Add it explicitly so Lucene packages resolve in both versions.
-        bundledLibrary("lib/intellij.libraries.lucene.common.jar")
+        // IU 2026.2 removed the jar from lib/ entirely, so only request it when we know it exists —
+        // an unconditional bundledLibrary() call here would break every local 2026.2 build outright.
+        if (localPath == null || file("$localPath/lib/intellij.libraries.lucene.common.jar").exists()) {
+            bundledLibrary("lib/intellij.libraries.lucene.common.jar")
+        }
     }
 
     // Kotlin stdlib for UI layer

--- a/plugin-experimental/build.gradle.kts
+++ b/plugin-experimental/build.gradle.kts
@@ -18,7 +18,10 @@ repositories {
 
 dependencies {
     intellijPlatform {
-        val localPath = providers.gradleProperty("intellijPlatform.localPath").orNull
+        // A blank value (e.g. `-PintellijPlatform.localPath=` passed on the command line to opt
+        // out of a broken local IDE without editing ~/.gradle/gradle.properties) must be treated
+        // as unset, not as a literal empty path passed to local().
+        val localPath = providers.gradleProperty("intellijPlatform.localPath").orNull?.takeIf { it.isNotBlank() }
         if (localPath != null) {
             local(localPath)
         } else {
@@ -32,8 +35,12 @@ dependencies {
         bundledPlugin("Git4Idea")
         bundledPlugin("org.jetbrains.plugins.terminal")
         bundledPlugin("com.intellij.database")
-        // Required in IU 2026.1+ (moved from lib/modules/ to lib/).
-        bundledLibrary("lib/intellij.libraries.lucene.common.jar")
+        // Required in IU 2026.1+ (moved from lib/modules/ to lib/). IU 2026.2 removed the jar
+        // entirely, so only request it when we know it exists — see plugin-core/build.gradle.kts
+        // for the matching guard and rationale.
+        if (localPath == null || file("$localPath/lib/intellij.libraries.lucene.common.jar").exists()) {
+            bundledLibrary("lib/intellij.libraries.lucene.common.jar")
+        }
     }
 
     compileOnly(project(":plugin-core"))


### PR DESCRIPTION
Fixes #968.

## Problem
A local Gradle compile of `plugin-core` (`:plugin-core:compileKotlin`) fails with ~108 unresolved-reference errors when `intellijPlatform.localPath` points at an IU 2026.2 (build 262+) installation:
- `com.intellij.ui.jcef.*` / `org.cef.*` (JCEF) — `JBCefBrowser`, `JBCefJSQuery`, `JBCefApp`, etc.
- `com.intellij.dvcs.repo.Repository` / `AbstractRepositoryManager` (supertypes of Git4Idea's `GitRepository`)
- `com.intellij.vcs.log.impl.VcsProjectLog`

Reproduced locally against an actual IU 2026.2.0.1 (262.8665.337) install.

## Root cause
Build 262 (2026.2) reorganized the platform layout further:
- JCEF moved from the auto-included boot classpath into a separately class-loaded bundled plugin (`com.intellij.modules.jcef`).
- `intellij.platform.vcs.dvcs`, `intellij.platform.vcs.dvcs.impl`, and `intellij.platform.vcs.log.impl` are `productModuleV2` jars in `lib/` that IntelliJ Platform Gradle Plugin 2.18.1 no longer puts on the compile classpath automatically.
- `lib/intellij.libraries.lucene.common.jar` (added explicitly for the 2026.1 move) no longer exists at all in 2026.2 — the previously-unconditional `bundledLibrary(...)` call for it would itself break every local 2026.2 build.

## Fix
In `plugin-core/build.gradle.kts` and `plugin-experimental/build.gradle.kts`:
1. Explicitly declare `bundledPlugin("com.intellij.modules.jcef")` and `bundledModule("intellij.platform.vcs.dvcs")` / `...vcs.dvcs.impl` / `...vcs.log.impl` so these resolve on the compile classpath. These calls are no-ops on 2025.3/2026.1 where the classes were already auto-included.
2. Guard the `lucene.common.jar` `bundledLibrary` call to only fire when the jar exists on disk (mirrors the existing guard used for the test-only `compileOnly(files(jar))` a few lines below).
3. Treat a blank `intellijPlatform.localPath` (e.g. `-PintellijPlatform.localPath=`) as unset rather than passing an empty string to `local()`, so it can be used to opt out of a broken local IDE per-invocation without editing `~/.gradle/gradle.properties`.

## Verification
- `./gradlew :plugin-core:compileKotlin` against the local IU 2026.2.0.1 install: previously ~108 errors → now `BUILD SUCCESSFUL`.
- `./gradlew :plugin-core:compileTestJava :plugin-core:compileTestKotlin :plugin-experimental:compileKotlin :plugin-experimental:compileTestJava :mcp-server:compileJava`: `BUILD SUCCESSFUL`.
- Confirmed (via `git stash`) that `:integration-tests:compileTestJava` fails against the same 2026.2 local install both before and after this change, due to an unrelated JVM-toolchain metadata mismatch (project declares Java 21, 2026.2 requires 25) — a distinct, pre-existing problem not touched by this PR.
- CI is unaffected: it downloads `intellijPlatformVersion=2026.1.3` (no `localPath`), and the added `bundledPlugin`/`bundledModule` calls are no-ops there since those classes were already auto-included.

## Out of scope (from the issue's suggested work list)
- **Bumping the IntelliJ Platform Gradle Plugin**: 2.18.1 is still the latest published release — there is no newer version to bump to.
- **Adding a 262 CI compatibility job**: blocked by the separate JVM 21 vs 25 toolchain issue in `integration-tests` noted above; tracking that as follow-up work rather than bundling an unrelated fix into this PR.