### PR TITLE
fix: strip heredoc bodies before run_command abuse classification

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
@@ -70,6 +70,18 @@ public final class ToolUtils {
         java.util.regex.Pattern.compile("mvn\\s+(verify|package|install|deploy)(\\s|$)");
 
     /**
+     * Matches a heredoc body: the text between the opening {@code <<[-]['"]?DELIM['"]?\n}
+     * and the closing {@code \nDELIM} line. Used by {@link #stripHeredocBodies(String)}.
+     * {@code DOTALL} is required so {@code .*?} crosses newlines.
+     * Backreference {@code \1} ties the closing delimiter to the opening one.
+     */
+    private static final java.util.regex.Pattern HEREDOC_BODY_PATTERN =
+        java.util.regex.Pattern.compile(
+            "<<-?[\"']?([A-Za-z_][A-Za-z0-9_]*)[\"']?\\n.*?\\n\\1(?=\\n|$)",
+            java.util.regex.Pattern.DOTALL
+        );
+
+    /**
      * Maximum levels to walk up the PSI parent chain when searching for a named ancestor.
      * A small limit avoids incorrectly returning an enclosing method or class when the caret
      * is on an unresolved reference expression — in the "go to declaration on a declaration"
@@ -826,7 +838,9 @@ public final class ToolUtils {
      * @return the abuse type ("git", "cat", "sed", "grep", "find", "test", "compile") or null if allowed
      */
     public static String detectCommandAbuseType(String command) {
-        String cmd = command.toLowerCase().trim();
+        // Strip heredoc bodies before classification — they contain arbitrary user-supplied text
+        // (e.g. a PR description mentioning "./gradlew test") that should not influence routing.
+        String cmd = stripHeredocBodies(command).toLowerCase().trim();
 
         // Block git — causes IntelliJ editor buffer desync
         if (isGitCommand(cmd)) {
@@ -867,6 +881,21 @@ public final class ToolUtils {
         if (isTestCommand(cmd)) return "test";
 
         return null;
+    }
+
+    /**
+     * Strips heredoc body text from {@code command}, leaving the opening {@code <<DELIM} and
+     * closing {@code DELIM} markers in place. The body is arbitrary user-supplied content
+     * (e.g. a PR description) and must not influence abuse-type classification.
+     *
+     * <p>Example: {@code gh pr create --body <<'EOF'\nRun ./gradlew test first\nEOF} becomes
+     * {@code gh pr create --body <<EOF\nEOF} after stripping.
+     */
+    static String stripHeredocBodies(String command) {
+        return HEREDOC_BODY_PATTERN.matcher(command).replaceAll(mr ->
+            "<<" + java.util.regex.Matcher.quoteReplacement(mr.group(1))
+                + "\n" + java.util.regex.Matcher.quoteReplacement(mr.group(1))
+        );
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsTool.java
@@ -918,13 +918,22 @@ public final class RunTestsTool extends TestingTool {
             var manager = com.intellij.execution.ui.RunContentManager.getInstance(project);
             var descriptors = new ArrayList<>(manager.getAllDescriptors());
 
+            // Prefer exact-name match; if absent fall back to the LAST substring match
+            // (RunManager renames duplicate configs to "Name (1)", "Name (2)" etc. — the
+            // last occurrence in getAllDescriptors is the most recently added one).
             com.intellij.execution.ui.RunContentDescriptor target = null;
+            com.intellij.execution.ui.RunContentDescriptor substringFallback = null;
             for (var d : descriptors) {
-                if (d.getDisplayName() != null && d.getDisplayName().contains(configName)) {
+                if (d.getDisplayName() == null) continue;
+                if (d.getDisplayName().equals(configName)) {
                     target = d;
                     break;
                 }
+                if (d.getDisplayName().contains(configName)) {
+                    substringFallback = d; // keep scanning — last match wins
+                }
             }
+            if (target == null) target = substringFallback;
             if (target == null) return "";
 
             var console = target.getExecutionConsole();

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/ToolUtilsAbuseDetectionTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/ToolUtilsAbuseDetectionTest.java
@@ -385,4 +385,61 @@ class ToolUtilsAbuseDetectionTest {
             assertEquals(java.util.List.of(), ToolUtils.tokenizeShellCommand(""));
         }
     }
+
+    // ── Heredoc body stripping ───────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("heredoc body stripping")
+    class HeredocBodyStripping {
+
+        @Test
+        @DisplayName("gh pr create with heredoc body mentioning ./gradlew test is NOT blocked as test")
+        void ghPrCreateWithGradlewTestInBodyIsNotBlocked() {
+            String cmd = "gh pr create --title 'My PR' --body <<'EOF'\n"
+                + "This PR improves performance. To verify, run ./gradlew test\n"
+                + "EOF";
+            assertNull(ToolUtils.detectCommandAbuseType(cmd));
+        }
+
+        @Test
+        @DisplayName("gh pr create with heredoc body mentioning npm test is NOT blocked as test")
+        void ghPrCreateWithNpmTestInBodyIsNotBlocked() {
+            String cmd = "gh pr create --title 'My PR' --body <<EOF\n"
+                + "Run npm test before merging\n"
+                + "EOF";
+            assertNull(ToolUtils.detectCommandAbuseType(cmd));
+        }
+
+        @Test
+        @DisplayName("actual ./gradlew test command without heredoc IS still blocked")
+        void gradlewTestCommandIsStillBlocked() {
+            assertEquals("test", ToolUtils.detectCommandAbuseType("./gradlew test"));
+        }
+
+        @Test
+        @DisplayName("stripHeredocBodies removes body but keeps delimiters")
+        void stripHeredocBodiesKeepsDelimiters() {
+            String cmd = "gh pr create --body <<'EOF'\nRun ./gradlew test first\nEOF";
+            String stripped = ToolUtils.stripHeredocBodies(cmd);
+            // Body removed; opening <<EOF and closing EOF remain
+            org.junit.jupiter.api.Assertions.assertTrue(stripped.contains("<<EOF"), "opener should remain");
+            org.junit.jupiter.api.Assertions.assertTrue(stripped.contains("\nEOF"), "closer should remain");
+            org.junit.jupiter.api.Assertions.assertFalse(stripped.contains("./gradlew test"), "body should be stripped");
+        }
+
+        @Test
+        @DisplayName("stripHeredocBodies handles <<- form")
+        void stripHeredocBodiesHandlesDashForm() {
+            String cmd = "cat <<-BLOCK\n\tsome content with jest mocha\nBLOCK";
+            String stripped = ToolUtils.stripHeredocBodies(cmd);
+            org.junit.jupiter.api.Assertions.assertFalse(stripped.contains("jest"), "body should be stripped");
+        }
+
+        @Test
+        @DisplayName("command with no heredoc is returned unchanged")
+        void noHeredocReturnedUnchanged() {
+            String cmd = "./gradlew test --info";
+            assertEquals(cmd, ToolUtils.stripHeredocBodies(cmd));
+        }
+    }
 }


### PR DESCRIPTION
fix: strip heredoc bodies before abuse classification

Closes #995 and #1000