### PR TITLE
feat: prepare Kiro agent-engine v3 migration + extra CLI args in sandbox preview

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/bridge/ProfileBasedAgentConfig.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/bridge/ProfileBasedAgentConfig.java
@@ -213,6 +213,9 @@ public class ProfileBasedAgentConfig implements AgentConfig {
             addPermissionCliFlags(cmd);
         }
 
+        // Append user-configured extra CLI args last so they win in "last-wins" flag conflicts.
+        cmd.addAll(profile.parsedExtraCliArgs());
+
         ProcessBuilder pb = new ProcessBuilder(cmd);
 
         // Inject captured shell environment (includes nvm, sdkman, etc.)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/CopilotClient.java
@@ -199,6 +199,10 @@ public final class CopilotClient extends AcpClient {
         //     standard AcpClient fallback enables conversation-history injection and notifies
         //     the user that resume was unavailable.
 
+        AgentProfile profile = AgentProfileManager.getInstance().getProfile(AGENT_ID);
+        if (profile != null) {
+            cmd.addAll(profile.parsedExtraCliArgs());
+        }
         return cmd;
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/HermesClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/HermesClient.java
@@ -2,6 +2,8 @@ package com.github.catatafishen.agentbridge.client.acp;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.github.catatafishen.agentbridge.services.AgentProfile;
+import com.github.catatafishen.agentbridge.services.AgentProfileManager;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
@@ -54,7 +56,13 @@ public final class HermesClient extends AcpClient {
     protected List<String> buildCommand(String cwd, int mcpPort) {
         // --accept-hooks auto-approves shell hooks that would otherwise prompt
         // on a TTY we don't have when launched from the IDE plugin.
-        return List.of(AGENT_ID, "acp", "--accept-hooks");
+        List<String> cmd = new java.util.ArrayList<>(List.of(AGENT_ID, "acp", "--accept-hooks"));
+        AgentProfile profile =
+            AgentProfileManager.getInstance().getProfile(AGENT_ID);
+        if (profile != null) {
+            cmd.addAll(profile.parsedExtraCliArgs());
+        }
+        return cmd;
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/JunieClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/JunieClient.java
@@ -5,6 +5,8 @@ import com.github.catatafishen.agentbridge.model.SessionUpdate;
 import com.github.catatafishen.agentbridge.client.ClientSessionException;
 import com.github.catatafishen.agentbridge.client.ClientStartException;
 import com.github.catatafishen.agentbridge.client.acp.junie.JunieKeyStore;
+import com.github.catatafishen.agentbridge.services.AgentProfile;
+import com.github.catatafishen.agentbridge.services.AgentProfileManager;
 import com.github.catatafishen.agentbridge.settings.StartupInstructionsSettings;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -140,6 +142,11 @@ public final class JunieClient extends AcpClient {
             LOG.info("Junie: using CLI credentials (no token configured in plugin settings)");
         }
 
+        AgentProfile profile =
+            AgentProfileManager.getInstance().getProfile(AgentProfileManager.JUNIE_PROFILE_ID);
+        if (profile != null) {
+            cmd.addAll(profile.parsedExtraCliArgs());
+        }
         return cmd;
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 public final class KiroClient extends AcpClient {
@@ -93,6 +94,185 @@ public final class KiroClient extends AcpClient {
         });
     }
 
+    /**
+     * Handles Kiro v3's {@code _kiro/auth/getAccessToken} reverse callback by reading the
+     * OIDC access token from the Kiro CLI's local SQLite database and returning it.
+     * <p>
+     * In v3, the harness no longer holds its own auth state — instead it calls back to the
+     * host (IDE extension or, in our case, this plugin) to obtain a fresh token whenever
+     * the underlying API credentials need renewal. This mirrors how the Kiro VS Code extension
+     * works: the extension holds the OIDC session and hands tokens to the CLI on demand.
+     * <p>
+     * We read the token from the same SQLite DB the CLI itself populated during {@code kiro login}
+     * ({@code ~/Library/Application Support/kiro-cli/data.sqlite3}, table {@code auth_kv},
+     * key {@code kirocli:odic:token}). We return {@code accessToken} and {@code expiresAt}, plus the
+     * {@code profileArn} of the selected Q Developer profile (from the {@code state} table, key
+     * {@code api.codewhisperer.profile}). The harness forwards {@code profileArn} to the backend,
+     * which rejects requests without it ({@code "profileArn is required for this request"}).
+     * <p>
+     * All other requests are delegated to the parent {@link AcpClient#handleAgentRequest}.
+     */
+    @Override
+    protected void handleAgentRequest(com.google.gson.JsonElement id,
+                                      com.github.catatafishen.agentbridge.client.acp.transport.JsonRpcTransport.IncomingRequest request) {
+        switch (request.method()) {
+            case "_kiro/auth/getAccessToken" -> handleGetAccessToken(id);
+            case "_kiro/terminal/shell_type" -> handleShellType(id);
+            default -> super.handleAgentRequest(id, request);
+        }
+    }
+
+    /**
+     * Handles Kiro v3's {@code _kiro/terminal/shell_type} reverse callback.
+     * Returns the name of the user's default shell (e.g. {@code "zsh"}, {@code "bash"}).
+     * Reads {@code $SHELL} env var and returns its basename; falls back to {@code "cmd"}
+     * on Windows and {@code "bash"} elsewhere.
+     */
+    private void handleShellType(com.google.gson.JsonElement id) {
+        String shellType = resolveShellType();
+        JsonObject result = new JsonObject();
+        result.addProperty("shellType", shellType);
+        transport.sendResponse(id, result);
+        LOG.debug("Kiro v3: _kiro/terminal/shell_type — returned " + shellType);
+    }
+
+    static String resolveShellType() {
+        String shell = System.getenv("SHELL");
+        if (shell != null && !shell.isBlank()) {
+            // /bin/zsh → "zsh", /usr/bin/fish → "fish", etc.
+            return java.nio.file.Path.of(shell).getFileName().toString();
+        }
+        // Windows: SHELL is not set; COMSPEC points to cmd or powershell
+        String comspec = System.getenv("COMSPEC");
+        if (comspec != null && !comspec.isBlank()) {
+            String name = java.nio.file.Path.of(comspec).getFileName().toString().toLowerCase();
+            if (name.endsWith(".exe")) name = name.substring(0, name.length() - 4);
+            return name; // "cmd" or "powershell"
+        }
+        return com.intellij.openapi.util.SystemInfo.isWindows ? "cmd" : "bash";
+    }
+
+    private void handleGetAccessToken(com.google.gson.JsonElement id) {
+        try {
+            KiroTokenRecord token = readKiroToken();
+            if (token == null) {
+                LOG.warn("Kiro v3: _kiro/auth/getAccessToken — no token found in local DB; " +
+                    "run 'kiro login' to authenticate");
+                transport.sendError(id, -32000, "No Kiro access token found — run 'kiro login'");
+                return;
+            }
+            JsonObject result = new JsonObject();
+            result.addProperty("accessToken", token.accessToken());
+            result.addProperty("expiresAt", token.expiresAt());
+            if (token.profileArn() != null && !token.profileArn().isBlank()) {
+                result.addProperty("profileArn", token.profileArn());
+            } else {
+                LOG.warn("Kiro v3: _kiro/auth/getAccessToken — no profileArn found in local DB; " +
+                    "backend requests requiring a Q Developer profile will fail with " +
+                    "'profileArn is required'. Run 'kiro login' to (re)select a profile.");
+            }
+            transport.sendResponse(id, result);
+            LOG.debug("Kiro v3: _kiro/auth/getAccessToken — returned token (expires " + token.expiresAt()
+                + ", profileArn " + (token.profileArn() != null ? "present" : "absent") + ")");
+        } catch (Exception e) {
+            LOG.warn("Kiro v3: _kiro/auth/getAccessToken — failed to read token: " + e.getMessage(), e);
+            transport.sendError(id, -32000, "Auth refresh callback failed: " + e.getMessage());
+        }
+    }
+
+    record KiroTokenRecord(String accessToken, String expiresAt, @org.jetbrains.annotations.Nullable String profileArn) {}
+
+    /**
+     * Reads the Kiro CLI OIDC token from its local SQLite database.
+     * Returns {@code null} if the DB or token row does not exist.
+     */
+    @org.jetbrains.annotations.Nullable
+    static KiroTokenRecord readKiroToken() throws Exception {
+        java.nio.file.Path dbPath = resolveKiroDbPath();
+        if (!java.nio.file.Files.exists(dbPath)) {
+            return null;
+        }
+        // Use sqlite3 subprocess to avoid a JDBC dependency. The DB is small and
+        // this is called at most once per auth refresh cycle.
+        // Returns two tab-separated columns: access_token<TAB>expires_at
+        ProcessBuilder pb = new ProcessBuilder(
+            "sqlite3", dbPath.toString(),
+            "SELECT json_extract(value,'$.access_token') || char(9) || " +
+                "json_extract(value,'$.expires_at') " +
+                "FROM auth_kv WHERE key='kirocli:odic:token';"
+        );
+        pb.redirectErrorStream(true);
+        Process proc = pb.start();
+        String output;
+        try (java.io.BufferedReader reader = new java.io.BufferedReader(
+            new java.io.InputStreamReader(proc.getInputStream(), java.nio.charset.StandardCharsets.UTF_8))) {
+            output = reader.lines().collect(java.util.stream.Collectors.joining()).trim();
+        }
+        proc.waitFor(5, TimeUnit.SECONDS);
+        if (output.isBlank()) return null;
+        String[] parts = output.split("\t", 2);
+        if (parts.length < 2 || parts[0].isBlank()) return null;
+        return new KiroTokenRecord(parts[0], parts[1], readKiroProfileArn(dbPath));
+    }
+
+    /**
+     * Reads the Q Developer profile ARN the Kiro CLI selected during {@code kiro login}.
+     * <p>
+     * v3 backend requests require a {@code profileArn} to identify the user's Q Developer
+     * profile — without it the service returns {@code "profileArn is required for this request"}.
+     * The CLI stores the selected profile in its {@code state} table under key
+     * {@code api.codewhisperer.profile} as JSON ({@code {"arn":"arn:aws:codewhisperer:...",
+     * "profile_name":"..."}}); we extract the {@code arn} field.
+     * <p>
+     * Returns {@code null} if the row is absent (e.g. Builder ID / free-tier accounts that
+     * don't use a profile), in which case the callback omits {@code profileArn}.
+     */
+    @org.jetbrains.annotations.Nullable
+    static String readKiroProfileArn(java.nio.file.Path dbPath) throws Exception {
+        // The state table stores value as a BLOB, so CAST to TEXT before json_extract.
+        ProcessBuilder pb = new ProcessBuilder(
+            "sqlite3", dbPath.toString(),
+            "SELECT json_extract(CAST(value AS TEXT),'$.arn') " +
+                "FROM state WHERE key='api.codewhisperer.profile';"
+        );
+        pb.redirectErrorStream(true);
+        Process proc = pb.start();
+        String output;
+        try (java.io.BufferedReader reader = new java.io.BufferedReader(
+            new java.io.InputStreamReader(proc.getInputStream(), java.nio.charset.StandardCharsets.UTF_8))) {
+            output = reader.lines().collect(java.util.stream.Collectors.joining()).trim();
+        }
+        proc.waitFor(5, TimeUnit.SECONDS);
+        return output.isBlank() ? null : output;
+    }
+
+    /**
+     * Returns the OS-appropriate path to the Kiro CLI SQLite database.
+     * <ul>
+     *   <li>macOS: {@code ~/Library/Application Support/kiro-cli/data.sqlite3}</li>
+     *   <li>Linux: {@code ~/.local/share/kiro-cli/data.sqlite3}</li>
+     *   <li>Windows: {@code %APPDATA%\kiro-cli\data.sqlite3}</li>
+     * </ul>
+     */
+    static java.nio.file.Path resolveKiroDbPath() {
+        String home = SystemProperties.getUserHome();
+        if (com.intellij.openapi.util.SystemInfo.isMac) {
+            return java.nio.file.Path.of(home, "Library", "Application Support", "kiro-cli", "data.sqlite3");
+        } else if (com.intellij.openapi.util.SystemInfo.isWindows) {
+            String appData = System.getenv("APPDATA");
+            if (appData != null && !appData.isBlank()) {
+                return java.nio.file.Path.of(appData, "kiro-cli", "data.sqlite3");
+            }
+            return java.nio.file.Path.of(home, "AppData", "Roaming", "kiro-cli", "data.sqlite3");
+        } else {
+            // Linux: XDG_DATA_HOME or ~/.local/share
+            String xdgData = System.getenv("XDG_DATA_HOME");
+            if (xdgData != null && !xdgData.isBlank()) {
+                return java.nio.file.Path.of(xdgData, "kiro-cli", "data.sqlite3");
+            }
+            return java.nio.file.Path.of(home, ".local", "share", "kiro-cli", "data.sqlite3");
+        }
+    }
     private void handleKiroNotification(String method, JsonObject params) {
         switch (method) {
             case "_kiro.dev/commands/available" -> handleCommandsAvailable(params);
@@ -222,9 +402,10 @@ public final class KiroClient extends AcpClient {
 
     @Override
     protected List<String> buildCommand(String cwd, int mcpPort) {
-        List<String> cmd = new java.util.ArrayList<>(buildCommandStatic());
         AgentProfile profile = AgentProfileManager
             .getInstance().getProfile(AgentProfileManager.KIRO_PROFILE_ID);
+        String engine = profile != null ? profile.getKiroAgentEngine() : "v2";
+        List<String> cmd = new java.util.ArrayList<>(buildCommandStatic(engine));
         if (profile != null) {
             cmd.addAll(profile.parsedExtraCliArgs());
         }
@@ -232,13 +413,32 @@ public final class KiroClient extends AcpClient {
     }
 
     /**
-     * Returns the Kiro CLI command with the correct argument order.
-     * {@code --agent} must come AFTER {@code acp} subcommand (as a global flag it starts a chat
-     * session). {@code --trust-all-tools} bypasses per-tool TTY permission prompts that would
-     * block forever since stdin/stdout are wired to JSON-RPC.
+     * Returns the Kiro CLI command for the given engine version.
+     * <ul>
+     *   <li><b>v2</b>: {@code kiro-cli acp --agent intellij-task --trust-all-tools}
+     *       — agent and trust are both CLI flags.</li>
+     *   <li><b>v3</b>: {@code kiro-cli acp --agent-engine v3}
+     *       — neither {@code --agent} nor {@code --trust-all-tools} are supported as flags.
+     *       Trust is set via {@code autopilot:true} in {@code session/new} params
+     *       (see {@link #customizeNewSession}).
+     *       Agent selection is sent as {@code session/set_mode} after session creation
+     *       (see {@link #onSessionCreated}).</li>
+     * </ul>
      */
-    static List<String> buildCommandStatic() {
+    static List<String> buildCommandStatic(String engine) {
+        if ("v3".equals(engine)) {
+            // V3 does not support --agent or --trust-all-tools as CLI flags.
+            // Trust is handled via "autopilot: true" in session/new (see customizeNewSession).
+            // Agent selection is handled via session/set_mode after session/new (see onSessionCreated).
+            return List.of("kiro-cli", "acp", "--agent-engine", "v3");
+        }
         return List.of("kiro-cli", "acp", "--agent", "intellij-task", "--trust-all-tools");
+    }
+
+    /** @deprecated Use {@link #buildCommandStatic(String)} with an explicit engine. */
+    @Deprecated
+    static List<String> buildCommandStatic() {
+        return buildCommandStatic("v2");
     }
 
     @Override
@@ -312,6 +512,41 @@ public final class KiroClient extends AcpClient {
         JsonArray servers = new JsonArray();
         servers.add(server);
         params.add("mcpServers", servers);
+
+        // V3 does not support --trust-all-tools as a CLI flag.
+        // Pass autopilot:true in session/new instead — equivalent to the IDE's "auto-approve all
+        // tools" setting — so tool calls are never blocked waiting for TTY permission prompts.
+        AgentProfile profile = AgentProfileManager
+            .getInstance().getProfile(AgentProfileManager.KIRO_PROFILE_ID);
+        if (profile != null && "v3".equals(profile.getKiroAgentEngine())) {
+            params.addProperty("autopilot", true);
+        }
+    }
+
+    /**
+     * For v3, sends {@code session/set_mode} with {@code "intellij-task"} immediately after
+     * session creation. This is the v3 replacement for the {@code --agent intellij-task} CLI flag
+     * (which is not supported in v3).
+     */
+    @Override
+    protected void onSessionCreated(String sessionId) {
+        AgentProfile profile = AgentProfileManager
+            .getInstance().getProfile(AgentProfileManager.KIRO_PROFILE_ID);
+        if (profile == null || !"v3".equals(profile.getKiroAgentEngine())) {
+            return;
+        }
+        JsonObject params = new JsonObject();
+        params.addProperty("sessionId", sessionId);
+        params.addProperty("mode", "intellij-task");
+        transport.sendRequest("session/set_mode", params)
+            .orTimeout(10, TimeUnit.SECONDS)
+            .whenComplete((result, ex) -> {
+                if (ex != null) {
+                    LOG.warn("Kiro v3: session/set_mode failed for intellij-task: " + ex.getMessage());
+                } else {
+                    LOG.info("Kiro v3: session/set_mode intellij-task applied for session " + sessionId);
+                }
+            });
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
@@ -3,6 +3,8 @@ package com.github.catatafishen.agentbridge.client.acp;
 import com.github.catatafishen.agentbridge.model.ContentBlock;
 import com.github.catatafishen.agentbridge.model.PromptResponse;
 import com.github.catatafishen.agentbridge.model.SessionUpdate;
+import com.github.catatafishen.agentbridge.services.AgentProfile;
+import com.github.catatafishen.agentbridge.services.AgentProfileManager;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
@@ -220,7 +222,13 @@ public final class KiroClient extends AcpClient {
 
     @Override
     protected List<String> buildCommand(String cwd, int mcpPort) {
-        return buildCommandStatic();
+        List<String> cmd = new java.util.ArrayList<>(buildCommandStatic());
+        AgentProfile profile = AgentProfileManager
+            .getInstance().getProfile(AgentProfileManager.KIRO_PROFILE_ID);
+        if (profile != null) {
+            cmd.addAll(profile.parsedExtraCliArgs());
+        }
+        return cmd;
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/OpenCodeClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/OpenCodeClient.java
@@ -1,6 +1,8 @@
 package com.github.catatafishen.agentbridge.client.acp;
 
 import com.github.catatafishen.agentbridge.client.AbstractClient;
+import com.github.catatafishen.agentbridge.services.AgentProfile;
+import com.github.catatafishen.agentbridge.services.AgentProfileManager;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -103,7 +105,12 @@ public final class OpenCodeClient extends AcpClient {
         // On Windows, opencode is installed via npm and the native binary is not on PATH.
         // Probe the project-local node_modules path as a fallback.
         String windowsPath = resolveWindowsOpenCodePath(cwd);
-        return List.of(windowsPath != null ? windowsPath : AGENT_ID, "acp");
+        List<String> cmd = new java.util.ArrayList<>(List.of(windowsPath != null ? windowsPath : AGENT_ID, "acp"));
+        AgentProfile profile = AgentProfileManager.getInstance().getProfile(AGENT_ID);
+        if (profile != null) {
+            cmd.addAll(profile.parsedExtraCliArgs());
+        }
+        return cmd;
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/VibeClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/VibeClient.java
@@ -1,6 +1,8 @@
 package com.github.catatafishen.agentbridge.client.acp;
 
 import com.github.catatafishen.agentbridge.bridge.NudgeSource;
+import com.github.catatafishen.agentbridge.services.AgentProfile;
+import com.github.catatafishen.agentbridge.services.AgentProfileManager;
 import com.github.catatafishen.agentbridge.services.AgentNudgeService;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -56,7 +58,13 @@ public final class VibeClient extends AcpClient {
 
     @Override
     protected List<String> buildCommand(String cwd, int mcpPort) {
-        return List.of("vibe-acp");
+        List<String> cmd = new java.util.ArrayList<>(List.of("vibe-acp"));
+        AgentProfile profile =
+            AgentProfileManager.getInstance().getProfile(AGENT_ID);
+        if (profile != null) {
+            cmd.addAll(profile.parsedExtraCliArgs());
+        }
+        return cmd;
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfile.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfile.java
@@ -118,6 +118,12 @@ public final class AgentProfile {
     private String extraCliArgs = "";
 
     /**
+     * Kiro agent engine version. Either {@code "v2"} (default, uses {@code --agent} CLI flag)
+     * or {@code "v3"} (uses {@code session/set_mode} ACP method after {@code session/new}).
+     */
+    private String kiroAgentEngine = "v2";
+
+    /**
      * Whether this agent supports {@code session/message} JSON-RPC notifications.
      * When {@code true}, startup instructions are sent via {@code session/message}.
      * When {@code false}, instructions must come from config files or MCP prompt field.
@@ -215,6 +221,7 @@ public final class AgentProfile {
         this.additionalInstructions = other.additionalInstructions;
         this.customCliModels = new ArrayList<>(other.customCliModels);
         this.extraCliArgs = other.extraCliArgs;
+        this.kiroAgentEngine = other.kiroAgentEngine;
     }
 
     // ── Getters / Setters ────────────────────────────────────────────────────
@@ -507,6 +514,18 @@ public final class AgentProfile {
 
     public void setExtraCliArgs(@NotNull String extraCliArgs) {
         this.extraCliArgs = extraCliArgs;
+    }
+
+    /**
+     * Returns the Kiro agent engine version: {@code "v2"} (default) or {@code "v3"}.
+     */
+    @NotNull
+    public String getKiroAgentEngine() {
+        return kiroAgentEngine != null && !kiroAgentEngine.isBlank() ? kiroAgentEngine : "v2";
+    }
+
+    public void setKiroAgentEngine(@NotNull String kiroAgentEngine) {
+        this.kiroAgentEngine = kiroAgentEngine;
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfile.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfile.java
@@ -108,6 +108,16 @@ public final class AgentProfile {
     private String excludedBuiltInTools = "";
 
     /**
+     * Free-text extra CLI arguments appended after all plugin-managed flags when launching
+     * this agent. Tokenized at launch time via {@link com.intellij.util.execution.ParametersListUtil#parse}
+     * (same quoting rules as IntelliJ's own VM-options field). Empty string means no extra args.
+     *
+     * <p>Args are appended <em>after</em> all plugin-managed flags so they win in
+     * &quot;last-wins&quot; flag-conflict scenarios, though this is not guaranteed for every CLI.</p>
+     */
+    private String extraCliArgs = "";
+
+    /**
      * Whether this agent supports {@code session/message} JSON-RPC notifications.
      * When {@code true}, startup instructions are sent via {@code session/message}.
      * When {@code false}, instructions must come from config files or MCP prompt field.
@@ -204,6 +214,7 @@ public final class AgentProfile {
         this.bundledAgentFiles = new ArrayList<>(other.bundledAgentFiles);
         this.additionalInstructions = other.additionalInstructions;
         this.customCliModels = new ArrayList<>(other.customCliModels);
+        this.extraCliArgs = other.extraCliArgs;
     }
 
     // ── Getters / Setters ────────────────────────────────────────────────────
@@ -487,6 +498,27 @@ public final class AgentProfile {
 
     public void setCustomCliModels(@NotNull List<String> customCliModels) {
         this.customCliModels = new ArrayList<>(customCliModels);
+    }
+
+    @NotNull
+    public String getExtraCliArgs() {
+        return extraCliArgs != null ? extraCliArgs : "";
+    }
+
+    public void setExtraCliArgs(@NotNull String extraCliArgs) {
+        this.extraCliArgs = extraCliArgs;
+    }
+
+    /**
+     * Tokenizes {@link #extraCliArgs} via {@link com.intellij.util.execution.ParametersListUtil#parse}
+     * and returns the resulting tokens. Returns an empty list when {@link #extraCliArgs} is blank,
+     * avoiding a {@code ParametersListUtil} call in the common (no extra args) case.
+     */
+    @NotNull
+    public List<String> parsedExtraCliArgs() {
+        String raw = getExtraCliArgs();
+        if (raw.isBlank()) return List.of();
+        return com.intellij.util.execution.ParametersListUtil.parse(raw);
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfileManager.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfileManager.java
@@ -71,6 +71,7 @@ public final class AgentProfileManager implements PersistentStateComponent<Agent
         public List<String> customCliModels = new ArrayList<>(); // NOSONAR - IntelliJ XmlSerializer persists public state fields directly.
         public boolean stripNonEssentialPath; // NOSONAR - IntelliJ XmlSerializer persists public state fields directly.
         public String excludedBuiltInTools = ""; // NOSONAR - IntelliJ XmlSerializer persists public state fields directly.
+        public String extraCliArgs = ""; // NOSONAR - IntelliJ XmlSerializer persists public state fields directly.
     }
 
     /**
@@ -145,6 +146,9 @@ public final class AgentProfileManager implements PersistentStateComponent<Agent
         if (isSet(o.excludedBuiltInTools)) {
             profile.setExcludedBuiltInTools(o.excludedBuiltInTools);
         }
+        if (isSet(o.extraCliArgs)) {
+            profile.setExtraCliArgs(o.extraCliArgs);
+        }
     }
 
     private static boolean isSet(@Nullable String s) {
@@ -164,6 +168,8 @@ public final class AgentProfileManager implements PersistentStateComponent<Agent
             && current.isStripNonEssentialPath();
         String ebt = current.getExcludedBuiltInTools();
         o.excludedBuiltInTools = ebt.equals(defaults.getExcludedBuiltInTools()) ? "" : ebt;
+        String eca = current.getExtraCliArgs();
+        o.extraCliArgs = eca.equals(defaults.getExtraCliArgs()) ? "" : eca;
         return o;
     }
 
@@ -172,7 +178,8 @@ public final class AgentProfileManager implements PersistentStateComponent<Agent
             || !o.prependInstructionsTo.isEmpty()
             || !o.customCliModels.isEmpty()
             || o.stripNonEssentialPath
-            || !o.excludedBuiltInTools.isEmpty();
+            || !o.excludedBuiltInTools.isEmpty()
+            || !o.extraCliArgs.isEmpty();
     }
 
     private static String nullToEmpty(@Nullable String s) {
@@ -202,6 +209,29 @@ public final class AgentProfileManager implements PersistentStateComponent<Agent
         AgentProfile profile = profiles.get(agentId);
         if (profile == null) return;
         profile.setCustomBinaryPath(path != null ? path.trim() : "");
+    }
+
+    /**
+     * Returns the user-configured extra CLI arguments for the given agent, or an empty string
+     * if not set. Use {@link AgentProfile#parsedExtraCliArgs()} on the returned profile to get
+     * the tokenized list; this method returns the raw text for binding to a UI text field.
+     */
+    @NotNull
+    public synchronized String loadExtraCliArgs(@NotNull String agentId) {
+        ensureDefaults();
+        AgentProfile profile = profiles.get(agentId);
+        return profile != null ? profile.getExtraCliArgs() : "";
+    }
+
+    /**
+     * Persists extra CLI arguments for the given agent.
+     * Pass {@code null} or blank to clear the override (no extra args).
+     */
+    public synchronized void saveExtraCliArgs(@NotNull String agentId, @Nullable String args) {
+        ensureDefaults();
+        AgentProfile profile = profiles.get(agentId);
+        if (profile == null) return;
+        profile.setExtraCliArgs(args != null ? args.trim() : "");
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfileManager.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentProfileManager.java
@@ -235,6 +235,26 @@ public final class AgentProfileManager implements PersistentStateComponent<Agent
     }
 
     /**
+     * Returns the Kiro agent engine version: {@code "v2"} (default) or {@code "v3"}.
+     */
+    @NotNull
+    public synchronized String loadKiroAgentEngine() {
+        ensureDefaults();
+        AgentProfile profile = profiles.get(KIRO_PROFILE_ID);
+        return profile != null ? profile.getKiroAgentEngine() : "v2";
+    }
+
+    /**
+     * Persists the Kiro agent engine version. Pass {@code "v2"} or {@code "v3"}.
+     */
+    public synchronized void saveKiroAgentEngine(@NotNull String engine) {
+        ensureDefaults();
+        AgentProfile profile = profiles.get(KIRO_PROFILE_ID);
+        if (profile == null) return;
+        profile.setKiroAgentEngine(engine);
+    }
+
+    /**
      * One-time migration: reads binary paths stored in the legacy
      * {@code PropertiesComponent} keys ({@code agentbridge.<id>.customBinary})
      * and copies them into the corresponding {@link AgentProfile}.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ClaudeCliClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ClaudeCliClientConfigurable.kt
@@ -62,6 +62,21 @@ class ClaudeCliClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project
                     { profile()?.customBinaryPath = it.trim() }
                 )
         }
+        row("Additional arguments:") {
+            textField()
+                .align(AlignX.FILL)
+                .resizableColumn()
+                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .comment(
+                    "Extra CLI flags appended after all plugin-managed arguments when launching Claude CLI. " +
+                        "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +
+                        "Args are appended last, so they win for flags that take the last-wins value."
+                )
+                .bindText(
+                    { AgentProfileManager.getInstance().loadExtraCliArgs(AgentProfileManager.CLAUDE_CLI_PROFILE_ID) },
+                    { AgentProfileManager.getInstance().saveExtraCliArgs(AgentProfileManager.CLAUDE_CLI_PROFILE_ID, it.trim()) }
+                )
+        }
         row("Instructions file:") {
             textField()
                 .align(AlignX.FILL)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ClaudeCliClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ClaudeCliClientConfigurable.kt
@@ -25,6 +25,7 @@ class ClaudeCliClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project
     }
 
     private var binaryPathField: javax.swing.JTextField? = null
+    private var extraArgsField: javax.swing.JTextField? = null
     private val sandboxSection = SandboxSettingsSection(
         agentId = AgentProfileManager.CLAUDE_CLI_PROFILE_ID,
         displayName = "Claude CLI",
@@ -33,6 +34,11 @@ class ClaudeCliClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project
                 ?: profile()?.customBinaryPath
         },
         binaryNameProvider = { "claude" },
+        extraArgsProvider = {
+            com.intellij.util.execution.ParametersListUtil.parse(
+                extraArgsField?.text?.trim().orEmpty()
+            )
+        },
     )
 
     override fun getId(): String = ID
@@ -66,7 +72,11 @@ class ClaudeCliClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project
             textField()
                 .align(AlignX.FILL)
                 .resizableColumn()
-                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .applyToComponent {
+                    emptyText.text = "e.g. --debug (leave empty for none)"
+                    extraArgsField = this
+                    sandboxSection.wireExtraArgsField(this)
+                }
                 .comment(
                     "Extra CLI flags appended after all plugin-managed arguments when launching Claude CLI. " +
                         "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +
@@ -103,11 +113,11 @@ class ClaudeCliClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project
         }
         separator()
         row {
-            label("Custom models (one per line):")
-                .comment(
+            label(
+                "Custom models (one per line). " +
                     "Format: <code>&lt;model-id&gt;=&lt;Display Name&gt;</code>. " +
-                        "Leave empty to use the built-in model list."
-                )
+                    "Leave empty to use the built-in model list."
+            ).applyToComponent { foreground = UIUtil.getContextHelpForeground() }
         }
         row {
             cell(JBScrollPane(customModelsArea))
@@ -121,7 +131,7 @@ class ClaudeCliClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project
                         (profile()?.customCliModels ?: emptyList()).joinToString("\n")
                     customModelsArea.caretPosition = 0
                 }
-        }.layout(RowLayout.PARENT_GRID).resizableRow()
+        }.resizableRow()
         sandboxSection.render(this@panel)
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/CodexClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/CodexClientConfigurable.kt
@@ -69,6 +69,21 @@ class CodexClientConfigurable(private val project: Project) :
                     { AgentProfileManager.getInstance().saveBinaryPath(PROFILE_ID, it.trim()) }
                 )
         }
+        row("Additional arguments:") {
+            textField()
+                .align(AlignX.FILL)
+                .resizableColumn()
+                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .comment(
+                    "Extra CLI flags appended after all plugin-managed arguments when launching Codex. " +
+                        "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +
+                        "Args are appended last, so they win for flags that take the last-wins value."
+                )
+                .bindText(
+                    { AgentProfileManager.getInstance().loadExtraCliArgs(PROFILE_ID) },
+                    { AgentProfileManager.getInstance().saveExtraCliArgs(PROFILE_ID, it.trim()) }
+                )
+        }
         row("Bubble color:") {
             cell(ThemeColorComboBox())
                 .comment("Choose a theme-aware accent color for message bubbles when using Codex.")

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/CodexClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/CodexClientConfigurable.kt
@@ -24,6 +24,8 @@ class CodexClientConfigurable(private val project: Project) :
     SearchableConfigurable {
 
     private val statusLabel = JBLabel(CHECKING)
+    private var binaryPathField: javax.swing.JTextField? = null
+    private var extraArgsField: javax.swing.JTextField? = null
     private val sandboxSection = SandboxSettingsSection(
         agentId = PROFILE_ID,
         displayName = "Codex",
@@ -32,8 +34,12 @@ class CodexClientConfigurable(private val project: Project) :
                 ?: AgentProfileManager.getInstance().loadBinaryPath(PROFILE_ID)
         },
         binaryNameProvider = { "codex" },
+        extraArgsProvider = {
+            com.intellij.util.execution.ParametersListUtil.parse(
+                extraArgsField?.text?.trim().orEmpty()
+            )
+        },
     )
-    private var binaryPathField: javax.swing.JTextField? = null
 
     override fun getId(): String = ID
 
@@ -73,7 +79,11 @@ class CodexClientConfigurable(private val project: Project) :
             textField()
                 .align(AlignX.FILL)
                 .resizableColumn()
-                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .applyToComponent {
+                    emptyText.text = "e.g. --debug (leave empty for none)"
+                    extraArgsField = this
+                    sandboxSection.wireExtraArgsField(this)
+                }
                 .comment(
                     "Extra CLI flags appended after all plugin-managed arguments when launching Codex. " +
                         "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/CopilotClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/CopilotClientConfigurable.kt
@@ -121,6 +121,21 @@ class CopilotClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) 
                     }
                 )
         }
+        row("Additional arguments:") {
+            textField()
+                .align(AlignX.FILL)
+                .resizableColumn()
+                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .comment(
+                    "Extra CLI flags appended after all plugin-managed arguments when launching Copilot. " +
+                        "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +
+                        "Args are appended last, so they win for flags that take the last-wins value."
+                )
+                .bindText(
+                    { AgentProfileManager.getInstance().loadExtraCliArgs(AGENT_ID) },
+                    { AgentProfileManager.getInstance().saveExtraCliArgs(AGENT_ID, it.trim()) }
+                )
+        }
         row("Bubble color:") {
             cell(ThemeColorComboBox())
                 .comment(

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/CopilotClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/CopilotClientConfigurable.kt
@@ -27,6 +27,7 @@ class CopilotClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) 
     private var configPanel: com.intellij.openapi.ui.DialogPanel? = null
 
     private var liveBinaryFieldText: () -> String = { "" }
+    private var extraArgsField: javax.swing.JTextField? = null
 
     private val sandboxSection = SandboxSettingsSection(
         agentId = AGENT_ID,
@@ -36,6 +37,11 @@ class CopilotClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) 
                 ?: AgentProfileManager.getInstance().loadBinaryPath(AGENT_ID)
         },
         binaryNameProvider = { "copilot" },
+        extraArgsProvider = {
+            com.intellij.util.execution.ParametersListUtil.parse(
+                extraArgsField?.text?.trim().orEmpty()
+            )
+        },
     )
 
     override fun getDisplayName(): String = "GitHub Copilot"
@@ -125,7 +131,11 @@ class CopilotClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) 
             textField()
                 .align(AlignX.FILL)
                 .resizableColumn()
-                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .applyToComponent {
+                    emptyText.text = "e.g. --debug (leave empty for none)"
+                    extraArgsField = this
+                    sandboxSection.wireExtraArgsField(this)
+                }
                 .comment(
                     "Extra CLI flags appended after all plugin-managed arguments when launching Copilot. " +
                         "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/HermesClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/HermesClientConfigurable.kt
@@ -67,6 +67,21 @@ class HermesClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
                     { AgentProfileManager.getInstance().saveBinaryPath(AGENT_ID, it.trim()) }
                 )
         }
+        row("Additional arguments:") {
+            textField()
+                .align(AlignX.FILL)
+                .resizableColumn()
+                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .comment(
+                    "Extra CLI flags appended after all plugin-managed arguments when launching Hermes. " +
+                        "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +
+                        "Args are appended last, so they win for flags that take the last-wins value."
+                )
+                .bindText(
+                    { AgentProfileManager.getInstance().loadExtraCliArgs(AGENT_ID) },
+                    { AgentProfileManager.getInstance().saveExtraCliArgs(AGENT_ID, it.trim()) }
+                )
+        }
         row("Bubble color:") {
             cell(ThemeColorComboBox())
                 .comment("Choose a theme-aware accent color for Hermes message bubbles.")

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/HermesClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/HermesClientConfigurable.kt
@@ -24,6 +24,7 @@ class HermesClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
 
     private val statusLabel = JBLabel()
     private var binaryPathField: javax.swing.JTextField? = null
+    private var extraArgsField: javax.swing.JTextField? = null
     private val sandboxSection = SandboxSettingsSection(
         agentId = AGENT_ID,
         displayName = "Hermes",
@@ -32,6 +33,11 @@ class HermesClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
                 ?: AgentProfileManager.getInstance().loadBinaryPath(AGENT_ID)
         },
         binaryNameProvider = { "hermes" },
+        extraArgsProvider = {
+            com.intellij.util.execution.ParametersListUtil.parse(
+                extraArgsField?.text?.trim().orEmpty()
+            )
+        },
     )
 
     override fun getId(): String = ID
@@ -71,7 +77,11 @@ class HermesClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
             textField()
                 .align(AlignX.FILL)
                 .resizableColumn()
-                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .applyToComponent {
+                    emptyText.text = "e.g. --debug (leave empty for none)"
+                    extraArgsField = this
+                    sandboxSection.wireExtraArgsField(this)
+                }
                 .comment(
                     "Extra CLI flags appended after all plugin-managed arguments when launching Hermes. " +
                         "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/JunieClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/JunieClientConfigurable.kt
@@ -108,6 +108,21 @@ class JunieClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
                     { AgentProfileManager.getInstance().saveBinaryPath(AGENT_ID, it.trim()) }
                 )
         }
+        row("Additional arguments:") {
+            textField()
+                .align(AlignX.FILL)
+                .resizableColumn()
+                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .comment(
+                    "Extra CLI flags appended after all plugin-managed arguments when launching Junie. " +
+                        "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +
+                        "Args are appended last, so they win for flags that take the last-wins value."
+                )
+                .bindText(
+                    { AgentProfileManager.getInstance().loadExtraCliArgs(AGENT_ID) },
+                    { AgentProfileManager.getInstance().saveExtraCliArgs(AGENT_ID, it.trim()) }
+                )
+        }
         row("Bubble color:") {
             cell(ThemeColorComboBox())
                 .comment("Choose a theme-aware accent color for message bubbles when using Junie.")

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/JunieClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/JunieClientConfigurable.kt
@@ -32,6 +32,7 @@ class JunieClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
     }
     private val genericSettings = GenericSettings(AGENT_ID)
     private var binaryPathField: javax.swing.JTextField? = null
+    private var extraArgsField: javax.swing.JTextField? = null
     private val sandboxSection = SandboxSettingsSection(
         agentId = AGENT_ID,
         displayName = "Junie",
@@ -40,6 +41,11 @@ class JunieClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
                 ?: AgentProfileManager.getInstance().loadBinaryPath(AGENT_ID)
         },
         binaryNameProvider = { "junie" },
+        extraArgsProvider = {
+            com.intellij.util.execution.ParametersListUtil.parse(
+                extraArgsField?.text?.trim().orEmpty()
+            )
+        },
     )
 
     override fun getId(): String = ID
@@ -112,7 +118,11 @@ class JunieClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
             textField()
                 .align(AlignX.FILL)
                 .resizableColumn()
-                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .applyToComponent {
+                    emptyText.text = "e.g. --debug (leave empty for none)"
+                    extraArgsField = this
+                    sandboxSection.wireExtraArgsField(this)
+                }
                 .comment(
                     "Extra CLI flags appended after all plugin-managed arguments when launching Junie. " +
                         "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/KiroClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/KiroClientConfigurable.kt
@@ -64,6 +64,21 @@ class KiroClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
                     { AgentProfileManager.getInstance().saveBinaryPath(AGENT_ID, it.trim()) }
                 )
         }
+        row("Additional arguments:") {
+            textField()
+                .align(AlignX.FILL)
+                .resizableColumn()
+                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .comment(
+                    "Extra CLI flags appended after all plugin-managed arguments when launching Kiro. " +
+                        "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +
+                        "Args are appended last, so they win for flags that take the last-wins value."
+                )
+                .bindText(
+                    { AgentProfileManager.getInstance().loadExtraCliArgs(AGENT_ID) },
+                    { AgentProfileManager.getInstance().saveExtraCliArgs(AGENT_ID, it.trim()) }
+                )
+        }
         row("Bubble color:") {
             cell(ThemeColorComboBox())
                 .comment("Choose a theme-aware accent color for message bubbles when using Kiro.")

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/KiroClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/KiroClientConfigurable.kt
@@ -22,6 +22,8 @@ class KiroClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
     private val statusLabel = JBLabel()
     private val genericSettings = GenericSettings(AGENT_ID)
     private var binaryPathField: javax.swing.JTextField? = null
+    private var extraArgsField: javax.swing.JTextField? = null
+    private var engineComboBox: javax.swing.JComboBox<String>? = null
     private val sandboxSection = SandboxSettingsSection(
         agentId = AGENT_ID,
         displayName = "Kiro",
@@ -30,6 +32,17 @@ class KiroClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
                 ?: AgentProfileManager.getInstance().loadBinaryPath(AGENT_ID)
         },
         binaryNameProvider = { "kiro-cli" },
+        extraArgsProvider = {
+            val engine = engineComboBox?.selectedItem as? String
+                ?: AgentProfileManager.getInstance().loadKiroAgentEngine()
+            val baseArgs = if (engine == "v3")
+                listOf("acp", "--agent-engine", "v3")
+            else
+                listOf("acp", "--agent", "intellij-task", "--trust-all-tools")
+            baseArgs + com.intellij.util.execution.ParametersListUtil.parse(
+                extraArgsField?.text?.trim().orEmpty()
+            )
+        },
     )
 
     override fun getId(): String = ID
@@ -49,6 +62,23 @@ class KiroClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
             cell(link)
         }
         separator()
+        row("Agent engine:") {
+            comboBox(listOf("v2", "v3"))
+                .comment(
+                    "V2 (default): uses <code>--agent intellij-task</code> at launch. " +
+                        "V3: uses <code>--agent-engine v3</code> — agent selection and auth " +
+                        "happen via ACP after connection."
+                )
+                .applyToComponent {
+                    @Suppress("UNCHECKED_CAST")
+                    engineComboBox = this as javax.swing.JComboBox<String>
+                    sandboxSection.wireComboBoxForPreview(this)
+                }
+                .bindItem(
+                    { AgentProfileManager.getInstance().loadKiroAgentEngine() },
+                    { AgentProfileManager.getInstance().saveKiroAgentEngine(it ?: "v2") }
+                )
+        }
         row("Kiro binary:") {
             textField()
                 .align(AlignX.FILL)
@@ -68,7 +98,11 @@ class KiroClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
             textField()
                 .align(AlignX.FILL)
                 .resizableColumn()
-                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .applyToComponent {
+                    emptyText.text = "e.g. --debug (leave empty for none)"
+                    extraArgsField = this
+                    sandboxSection.wireExtraArgsField(this)
+                }
                 .comment(
                     "Extra CLI flags appended after all plugin-managed arguments when launching Kiro. " +
                         "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/OpenCodeClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/OpenCodeClientConfigurable.kt
@@ -71,6 +71,21 @@ class OpenCodeClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project)
                     { AgentProfileManager.getInstance().saveBinaryPath(AGENT_ID, it.trim()) }
                 )
         }
+        row("Additional arguments:") {
+            textField()
+                .align(AlignX.FILL)
+                .resizableColumn()
+                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .comment(
+                    "Extra CLI flags appended after all plugin-managed arguments when launching OpenCode. " +
+                        "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +
+                        "Args are appended last, so they win for flags that take the last-wins value."
+                )
+                .bindText(
+                    { AgentProfileManager.getInstance().loadExtraCliArgs(AGENT_ID) },
+                    { AgentProfileManager.getInstance().saveExtraCliArgs(AGENT_ID, it.trim()) }
+                )
+        }
         row("Bubble color:") {
             cell(ThemeColorComboBox())
                 .comment(

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/OpenCodeClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/OpenCodeClientConfigurable.kt
@@ -26,6 +26,7 @@ class OpenCodeClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project)
     private val refreshResultLabel = JBLabel()
     private val genericSettings = GenericSettings(AGENT_ID)
     private var binaryPathField: javax.swing.JTextField? = null
+    private var extraArgsField: javax.swing.JTextField? = null
     private val sandboxSection = SandboxSettingsSection(
         agentId = AGENT_ID,
         displayName = "OpenCode",
@@ -34,6 +35,11 @@ class OpenCodeClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project)
                 ?: AgentProfileManager.getInstance().loadBinaryPath(AGENT_ID)
         },
         binaryNameProvider = { "opencode" },
+        extraArgsProvider = {
+            com.intellij.util.execution.ParametersListUtil.parse(
+                extraArgsField?.text?.trim().orEmpty()
+            )
+        },
     )
 
     override fun getId(): String = ID
@@ -75,7 +81,11 @@ class OpenCodeClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project)
             textField()
                 .align(AlignX.FILL)
                 .resizableColumn()
-                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .applyToComponent {
+                    emptyText.text = "e.g. --debug (leave empty for none)"
+                    extraArgsField = this
+                    sandboxSection.wireExtraArgsField(this)
+                }
                 .comment(
                     "Extra CLI flags appended after all plugin-managed arguments when launching OpenCode. " +
                         "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/SandboxSettingsSection.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/SandboxSettingsSection.kt
@@ -136,11 +136,33 @@ internal class SandboxSettingsSection(
      * changing the path immediately in the sandbox preview.
      */
     fun wireBinaryPathField(field: javax.swing.text.JTextComponent) {
+        wireFieldForPreview(field)
+    }
+
+    /**
+     * Attaches a {@link javax.swing.event.DocumentListener} to the given text field so the
+     * command preview refreshes live as the user edits the additional arguments. Each client
+     * configurable calls this on its extra-args text field so users see the impact of
+     * changing arguments immediately in the sandbox preview.
+     */
+    fun wireExtraArgsField(field: javax.swing.text.JTextComponent) {
+        wireFieldForPreview(field)
+    }
+
+    private fun wireFieldForPreview(field: javax.swing.text.JTextComponent) {
         field.document.addDocumentListener(object : javax.swing.event.DocumentListener {
             override fun insertUpdate(e: javax.swing.event.DocumentEvent?) = refreshCommandPreview()
             override fun removeUpdate(e: javax.swing.event.DocumentEvent?) = refreshCommandPreview()
             override fun changedUpdate(e: javax.swing.event.DocumentEvent?) = refreshCommandPreview()
         })
+    }
+
+    /**
+     * Attaches an {@link java.awt.event.ItemListener} to the given combo box so the
+     * command preview refreshes live when the selection changes.
+     */
+    fun wireComboBoxForPreview(comboBox: javax.swing.JComboBox<*>) {
+        comboBox.addItemListener { refreshCommandPreview() }
     }
 
     /** Called by the configurable's {@code reset()} to refresh status + preview. */

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/VibeClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/VibeClientConfigurable.kt
@@ -24,6 +24,7 @@ class VibeClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
 
     private val statusLabel = JBLabel()
     private var binaryPathField: javax.swing.JTextField? = null
+    private var extraArgsField: javax.swing.JTextField? = null
     private val sandboxSection = SandboxSettingsSection(
         agentId = AGENT_ID,
         displayName = "Vibe",
@@ -32,6 +33,11 @@ class VibeClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
                 ?: AgentProfileManager.getInstance().loadBinaryPath(AGENT_ID)
         },
         binaryNameProvider = { "vibe-acp" },
+        extraArgsProvider = {
+            com.intellij.util.execution.ParametersListUtil.parse(
+                extraArgsField?.text?.trim().orEmpty()
+            )
+        },
     )
 
     override fun getId(): String = ID
@@ -73,7 +79,11 @@ class VibeClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
             textField()
                 .align(AlignX.FILL)
                 .resizableColumn()
-                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .applyToComponent {
+                    emptyText.text = "e.g. --debug (leave empty for none)"
+                    extraArgsField = this
+                    sandboxSection.wireExtraArgsField(this)
+                }
                 .comment(
                     "Extra CLI flags appended after all plugin-managed arguments when launching Vibe. " +
                         "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/VibeClientConfigurable.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/VibeClientConfigurable.kt
@@ -69,6 +69,21 @@ class VibeClientConfigurable(@Suppress("UNUSED_PARAMETER") project: Project) :
                     { AgentProfileManager.getInstance().saveBinaryPath(AGENT_ID, it.trim()) }
                 )
         }
+        row("Additional arguments:") {
+            textField()
+                .align(AlignX.FILL)
+                .resizableColumn()
+                .applyToComponent { emptyText.text = "e.g. --debug (leave empty for none)" }
+                .comment(
+                    "Extra CLI flags appended after all plugin-managed arguments when launching Vibe. " +
+                        "Quoted values are supported (e.g. <code>--flag \"value with spaces\"</code>). " +
+                        "Args are appended last, so they win for flags that take the last-wins value."
+                )
+                .bindText(
+                    { AgentProfileManager.getInstance().loadExtraCliArgs(AGENT_ID) },
+                    { AgentProfileManager.getInstance().saveExtraCliArgs(AGENT_ID, it.trim()) }
+                )
+        }
         row("Bubble color:") {
             cell(ThemeColorComboBox())
                 .comment("Choose a theme-aware accent color for Vibe message bubbles.")

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
@@ -92,7 +92,10 @@ class PromptOrchestrator(
         get() = agentManager.client.activeSessionId
         set(value) {
             require(value == null) { "currentSessionId can only be cleared (set to null), not assigned." }
-            agentManager.client.dropCurrentSession()
+            // Use clientIfRunning (not client) to avoid triggering a fresh agent start here.
+            // If the agent isn't running (e.g. it failed to start), there is no session to drop —
+            // the session state on a not-yet-started client is already empty.
+            agentManager.clientIfRunning?.dropCurrentSession()
             lastInitialisedSessionId = null
         }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientTest.java
@@ -277,4 +277,99 @@ class KiroClientTest {
         m.setAccessible(true);
         return (boolean) m.invoke(null, line);
     }
+
+    // ── resolveShellType ────────────────────────────────────────────────
+
+    @Test
+    void resolveShellType_returnsBasenameOfShellEnvVar() {
+        // SHELL is likely set in the test environment; just verify it returns something non-blank
+        String result = KiroClient.resolveShellType();
+        assertNotNull(result);
+        assertFalse(result.isBlank());
+        // Should not contain path separators
+        assertFalse(result.contains("/"), "Expected basename only, got: " + result);
+    }
+
+    // ── resolveKiroDbPath ───────────────────────────────────────────────
+
+    @Test
+    void resolveKiroDbPath_returnsNonNullPath() {
+        java.nio.file.Path path = KiroClient.resolveKiroDbPath();
+        assertNotNull(path);
+        assertTrue(path.toString().contains("kiro-cli"), "Path should contain kiro-cli, got: " + path);
+        assertTrue(path.toString().endsWith("data.sqlite3"), "Path should end with data.sqlite3, got: " + path);
+    }
+
+    @Test
+    void resolveKiroDbPath_containsUserHome() {
+        java.nio.file.Path path = KiroClient.resolveKiroDbPath();
+        String userHome = System.getProperty("user.home");
+        assertTrue(path.toString().startsWith(userHome) ||
+            path.toString().contains("kiro-cli"),
+            "Expected path under user home or APPDATA/XDG, got: " + path);
+    }
+
+    // ── convertThinkingToThought ────────────────────────────────────────
+
+    @Test
+    void convertThinkingToThought_convertsChunkWithThinkingBlock() {
+        var thinking = new com.github.catatafishen.agentbridge.model.ContentBlock.Thinking("some thought");
+        var update = new com.github.catatafishen.agentbridge.model.SessionUpdate.AgentMessageChunk(
+            List.of(thinking));
+        var result = KiroClient.convertThinkingToThought(update);
+        assertInstanceOf(com.github.catatafishen.agentbridge.model.SessionUpdate.AgentThoughtChunk.class,
+            result, "Expected AgentThoughtChunk, got: " + result.getClass().getSimpleName());
+    }
+
+    @Test
+    void convertThinkingToThought_passesThruTextChunkUnchanged() {
+        var text = new com.github.catatafishen.agentbridge.model.ContentBlock.Text("hello");
+        var update = new com.github.catatafishen.agentbridge.model.SessionUpdate.AgentMessageChunk(
+            List.of(text));
+        var result = KiroClient.convertThinkingToThought(update);
+        assertSame(update, result, "Non-thinking chunk should pass through unchanged");
+    }
+
+    @Test
+    void convertThinkingToThought_nonMessageChunkPassesThru() {
+        var update = new com.github.catatafishen.agentbridge.model.SessionUpdate.SessionInfoChanged("title");
+        var result = KiroClient.convertThinkingToThought(update);
+        assertSame(update, result);
+    }
+
+    // ── extractPurposeFromArgs ──────────────────────────────────────────
+
+    @Test
+    void extractPurposeFromArgs_extractsPurposeFromJson() {
+        String args = "{\"path\":\"src/Foo.java\",\"__tool_use_purpose\":\"Read the file\",\"start_line\":1}";
+        assertEquals("Read the file", KiroClient.extractPurposeFromArgs(args));
+    }
+
+    @Test
+    void extractPurposeFromArgs_returnsNullWhenKeyAbsent() {
+        String args = "{\"path\":\"src/Foo.java\"}";
+        assertNull(KiroClient.extractPurposeFromArgs(args));
+    }
+
+    @Test
+    void extractPurposeFromArgs_returnsNullForNull() {
+        assertNull(KiroClient.extractPurposeFromArgs(null));
+    }
+
+    @Test
+    void extractPurposeFromArgs_returnsNullForEmptyString() {
+        assertNull(KiroClient.extractPurposeFromArgs(""));
+    }
+
+    @Test
+    void extractPurposeFromArgs_handlesKeyAtEnd() {
+        String args = "{\"a\":1,\"__tool_use_purpose\":\"last\"}";
+        assertEquals("last", KiroClient.extractPurposeFromArgs(args));
+    }
+
+    @Test
+    void extractPurposeFromArgs_handlesKeyAtStart() {
+        String args = "{\"__tool_use_purpose\":\"first\",\"a\":1}";
+        assertEquals("first", KiroClient.extractPurposeFromArgs(args));
+    }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientTest.java
@@ -79,17 +79,34 @@ class KiroClientTest {
     // ── buildCommandStatic ──────────────────────────────────────────────
 
     @Test
-    void buildCommand_returnsCorrectArgOrder() {
-        List<String> cmd = KiroClient.buildCommandStatic();
+    void buildCommand_v2_returnsCorrectArgOrder() {
+        List<String> cmd = KiroClient.buildCommandStatic("v2");
         assertEquals(List.of("kiro-cli", "acp", "--agent", "intellij-task", "--trust-all-tools"), cmd);
     }
 
     @Test
-    void buildCommand_agentAfterAcp() {
-        List<String> cmd = KiroClient.buildCommandStatic();
+    void buildCommand_v2_agentAfterAcp() {
+        List<String> cmd = KiroClient.buildCommandStatic("v2");
         int acpIdx = cmd.indexOf("acp");
         int agentIdx = cmd.indexOf("--agent");
         assertTrue(agentIdx > acpIdx, "--agent must come after acp subcommand");
+    }
+
+    @Test
+    void buildCommand_v3_usesAgentEngine() {
+        List<String> cmd = KiroClient.buildCommandStatic("v3");
+        assertEquals(List.of("kiro-cli", "acp", "--agent-engine", "v3"), cmd);
+        assertFalse(cmd.contains("--agent"), "--agent must not be present in v3 command");
+        assertFalse(cmd.contains("--trust-all-tools"),
+            "--trust-all-tools not supported in v3; trust is set via autopilot:true in session/new");
+    }
+
+    @Test
+    void buildCommand_defaultFallback_isV2() {
+        // The deprecated no-arg overload must still return the v2 command.
+        @SuppressWarnings("deprecation")
+        List<String> cmd = KiroClient.buildCommandStatic();
+        assertEquals(KiroClient.buildCommandStatic("v2"), cmd);
     }
 
     // ── supportsHttpMcp (version gating) ────────────────────────────────
@@ -201,6 +218,56 @@ class KiroClientTest {
     @Test
     void stripAnsi_boldAndReset() {
         assertEquals("bold text", KiroClient.stripAnsi("\u001b[1mbold text\u001b[0m"));
+    }
+
+    // ── readKiroProfileArn ──────────────────────────────────────────────
+
+    @Test
+    void readKiroProfileArn_extractsArnFromStateTable() throws Exception {
+        org.junit.jupiter.api.Assumptions.assumeTrue(sqlite3Available(),
+            "sqlite3 CLI not available on this machine");
+        java.nio.file.Path db = java.nio.file.Files.createTempFile("kiro-test", ".sqlite3");
+        try {
+            runSqlite(db,
+                "CREATE TABLE state (key TEXT PRIMARY KEY, value BLOB);",
+                "INSERT INTO state(key,value) VALUES('api.codewhisperer.profile'," +
+                    "'{\"arn\":\"arn:aws:codewhisperer:us-east-1:123456789012:profile/ABCDEFGH\"," +
+                    "\"profile_name\":\"my-profile\"}');");
+            assertEquals("arn:aws:codewhisperer:us-east-1:123456789012:profile/ABCDEFGH",
+                KiroClient.readKiroProfileArn(db));
+        } finally {
+            java.nio.file.Files.deleteIfExists(db);
+        }
+    }
+
+    @Test
+    void readKiroProfileArn_returnsNullWhenProfileRowAbsent() throws Exception {
+        org.junit.jupiter.api.Assumptions.assumeTrue(sqlite3Available(),
+            "sqlite3 CLI not available on this machine");
+        java.nio.file.Path db = java.nio.file.Files.createTempFile("kiro-test", ".sqlite3");
+        try {
+            runSqlite(db, "CREATE TABLE state (key TEXT PRIMARY KEY, value BLOB);");
+            assertNull(KiroClient.readKiroProfileArn(db));
+        } finally {
+            java.nio.file.Files.deleteIfExists(db);
+        }
+    }
+
+    private static boolean sqlite3Available() {
+        try {
+            Process p = new ProcessBuilder("sqlite3", "-version").redirectErrorStream(true).start();
+            return p.waitFor(5, java.util.concurrent.TimeUnit.SECONDS) && p.exitValue() == 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static void runSqlite(java.nio.file.Path db, String... statements) throws Exception {
+        for (String sql : statements) {
+            Process p = new ProcessBuilder("sqlite3", db.toString(), sql)
+                .redirectErrorStream(true).start();
+            p.waitFor(5, java.util.concurrent.TimeUnit.SECONDS);
+        }
     }
 
     // ── Reflection helpers ──────────────────────────────────────────────

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/VibeClientStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/VibeClientStaticMethodsTest.java
@@ -125,4 +125,77 @@ class VibeClientStaticMethodsTest {
             assertEquals("http://127.0.0.1:8080/mcp", server.get("url").getAsString());
         }
     }
+
+    // ── buildReprimandText ───────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("buildReprimandText")
+    class BuildReprimandText {
+
+        @Test
+        @DisplayName("write tool → mentions agentbridge_write_file and 'path' param")
+        void writeTool() {
+            String msg = VibeClient.buildReprimandText("write");
+            assertTrue(msg.contains("agentbridge_write_file"));
+            assertTrue(msg.contains("'path'"));
+        }
+
+        @Test
+        @DisplayName("edit tool → same as write (write/edit/create share a branch)")
+        void editTool() {
+            String msg = VibeClient.buildReprimandText("edit");
+            assertTrue(msg.contains("agentbridge_write_file"));
+        }
+
+        @Test
+        @DisplayName("create tool → same as write")
+        void createTool() {
+            String msg = VibeClient.buildReprimandText("create");
+            assertTrue(msg.contains("agentbridge_write_file"));
+        }
+
+        @Test
+        @DisplayName("read tool → mentions agentbridge_read_file and 'path' param")
+        void readTool() {
+            String msg = VibeClient.buildReprimandText("read");
+            assertTrue(msg.contains("agentbridge_read_file"));
+            assertTrue(msg.contains("'path'"));
+        }
+
+        @Test
+        @DisplayName("view tool → same as read")
+        void viewTool() {
+            String msg = VibeClient.buildReprimandText("view");
+            assertTrue(msg.contains("agentbridge_read_file"));
+        }
+
+        @Test
+        @DisplayName("bash tool → mentions agentbridge_run_command")
+        void bashTool() {
+            String msg = VibeClient.buildReprimandText("bash");
+            assertTrue(msg.contains("agentbridge_run_command"));
+        }
+
+        @Test
+        @DisplayName("grep tool → mentions agentbridge_search_text")
+        void grepTool() {
+            String msg = VibeClient.buildReprimandText("grep");
+            assertTrue(msg.contains("agentbridge_search_text"));
+        }
+
+        @Test
+        @DisplayName("glob tool → mentions agentbridge_list_project_files")
+        void globTool() {
+            String msg = VibeClient.buildReprimandText("glob");
+            assertTrue(msg.contains("agentbridge_list_project_files"));
+        }
+
+        @Test
+        @DisplayName("unknown tool → generic message mentioning agentbridge_* prefix")
+        void unknownTool() {
+            String msg = VibeClient.buildReprimandText("some_tool");
+            assertTrue(msg.contains("some_tool"));
+            assertTrue(msg.contains("agentbridge_*"));
+        }
+    }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentProfileManagerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentProfileManagerTest.java
@@ -137,6 +137,73 @@ class AgentProfileManagerTest {
         assertNull(manager.loadBinaryPath("unknown-agent"));
     }
 
+    // ── Extra CLI args CRUD ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("loadExtraCliArgs returns empty string for default profile (no custom args)")
+    void loadExtraCliArgsDefaultEmpty() {
+        assertEquals("", manager.loadExtraCliArgs(AgentProfileManager.KIRO_PROFILE_ID));
+    }
+
+    @Test
+    @DisplayName("saveExtraCliArgs + loadExtraCliArgs roundtrip")
+    void saveExtraCliArgsRoundtrip() {
+        manager.saveExtraCliArgs(AgentProfileManager.KIRO_PROFILE_ID, "--v3");
+        assertEquals("--v3", manager.loadExtraCliArgs(AgentProfileManager.KIRO_PROFILE_ID));
+    }
+
+    @Test
+    @DisplayName("saveExtraCliArgs with null clears the override")
+    void saveExtraCliArgsNullClears() {
+        manager.saveExtraCliArgs(AgentProfileManager.KIRO_PROFILE_ID, "--v3");
+        manager.saveExtraCliArgs(AgentProfileManager.KIRO_PROFILE_ID, null);
+        assertEquals("", manager.loadExtraCliArgs(AgentProfileManager.KIRO_PROFILE_ID));
+    }
+
+    @Test
+    @DisplayName("saveExtraCliArgs with blank clears the override")
+    void saveExtraCliArgsBlankClears() {
+        manager.saveExtraCliArgs(AgentProfileManager.KIRO_PROFILE_ID, "--v3");
+        manager.saveExtraCliArgs(AgentProfileManager.KIRO_PROFILE_ID, "   ");
+        assertEquals("", manager.loadExtraCliArgs(AgentProfileManager.KIRO_PROFILE_ID));
+    }
+
+    @Test
+    @DisplayName("saveExtraCliArgs for unknown agentId does nothing")
+    void saveExtraCliArgsUnknownId() {
+        assertDoesNotThrow(() -> manager.saveExtraCliArgs("unknown-agent", "--foo"));
+    }
+
+    @Test
+    @DisplayName("loadExtraCliArgs for unknown agentId returns empty string")
+    void loadExtraCliArgsUnknownId() {
+        assertEquals("", manager.loadExtraCliArgs("unknown-agent"));
+    }
+
+    @Test
+    @DisplayName("getState persists customised extraCliArgs as override")
+    void getStatePersistsExtraCliArgs() {
+        manager.saveExtraCliArgs(AgentProfileManager.KIRO_PROFILE_ID, "--v3 --debug");
+        AgentProfileManager.PersistedState state = manager.getState();
+        AgentProfileManager.ProfileOverride saved = state.overrides.stream()
+            .filter(o -> AgentProfileManager.KIRO_PROFILE_ID.equals(o.profileId))
+            .findFirst()
+            .orElse(null);
+        assertNotNull(saved, "Expected override for kiro");
+        assertEquals("--v3 --debug", saved.extraCliArgs);
+    }
+
+    @Test
+    @DisplayName("getState does NOT persist extraCliArgs when it equals the default (empty)")
+    void getStateDoesNotPersistDefaultExtraCliArgs() {
+        // Default is "" so saveExtraCliArgs("") should produce no override
+        manager.saveExtraCliArgs(AgentProfileManager.KIRO_PROFILE_ID, "");
+        AgentProfileManager.PersistedState state = manager.getState();
+        boolean hasKiroOverride = state.overrides.stream()
+            .anyMatch(o -> AgentProfileManager.KIRO_PROFILE_ID.equals(o.profileId));
+        assertFalse(hasKiroOverride, "No override should be persisted when extraCliArgs matches default");
+    }
+
     // ── Snapshot / override persistence ─────────────────────────────────────
 
     @Test
@@ -258,6 +325,14 @@ class AgentProfileManagerTest {
             o.excludedBuiltInTools = "view,edit,rg";
             assertTrue(invoke(o));
         }
+
+        @Test
+        @DisplayName("only extraCliArgs set → true")
+        void extraCliArgsReturnsTrue() throws Exception {
+            AgentProfileManager.ProfileOverride o = new AgentProfileManager.ProfileOverride();
+            o.extraCliArgs = "--v3";
+            assertTrue(invoke(o));
+        }
     }
 
     // ── Private helper: toDelta ──────────────────────────────────────────────
@@ -347,6 +422,30 @@ class AgentProfileManagerTest {
             assertEquals("/my/agent", delta.customBinaryPath);
             assertEquals("MY.md", delta.prependInstructionsTo);
             assertEquals(List.of("m1"), delta.customCliModels);
+        }
+
+        @Test
+        @DisplayName("different extraCliArgs → override has the value")
+        void differentExtraCliArgs() throws Exception {
+            AgentProfile current = makeProfile("test", "", null, new ArrayList<>());
+            current.setExtraCliArgs("--v3 --debug");
+            AgentProfile defaults = makeProfile("test", "", null, new ArrayList<>());
+            AgentProfileManager.ProfileOverride delta = invoke(current, defaults);
+
+            assertEquals("--v3 --debug", delta.extraCliArgs);
+            assertEquals("", delta.customBinaryPath);
+        }
+
+        @Test
+        @DisplayName("identical extraCliArgs → override field is empty")
+        void identicalExtraCliArgsProduceEmptyDelta() throws Exception {
+            AgentProfile current = makeProfile("test", "", null, new ArrayList<>());
+            current.setExtraCliArgs("--foo");
+            AgentProfile defaults = makeProfile("test", "", null, new ArrayList<>());
+            defaults.setExtraCliArgs("--foo");
+            AgentProfileManager.ProfileOverride delta = invoke(current, defaults);
+
+            assertEquals("", delta.extraCliArgs);
         }
 
     }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentProfileManagerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentProfileManagerTest.java
@@ -449,4 +449,138 @@ class AgentProfileManagerTest {
         }
 
     }
+
+    // ── Kiro agent engine CRUD ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("loadKiroAgentEngine returns 'v2' by default")
+    void loadKiroAgentEngineDefaultV2() {
+        assertEquals("v2", manager.loadKiroAgentEngine());
+    }
+
+    @Test
+    @DisplayName("saveKiroAgentEngine + loadKiroAgentEngine roundtrip")
+    void saveKiroAgentEngineRoundtrip() {
+        manager.saveKiroAgentEngine("v3");
+        assertEquals("v3", manager.loadKiroAgentEngine());
+    }
+
+    @Test
+    @DisplayName("saveKiroAgentEngine back to v2 roundtrip")
+    void saveKiroAgentEngineBackToV2() {
+        manager.saveKiroAgentEngine("v3");
+        manager.saveKiroAgentEngine("v2");
+        assertEquals("v2", manager.loadKiroAgentEngine());
+    }
+
+    // ── applyOverride — stripNonEssentialPath ────────────────────────────────
+
+    @Test
+    @DisplayName("loadState applies stripNonEssentialPath override when true")
+    void loadStateAppliesStripNonEssentialPath() {
+        AgentProfileManager.PersistedState state = new AgentProfileManager.PersistedState();
+        AgentProfileManager.ProfileOverride o = new AgentProfileManager.ProfileOverride();
+        o.profileId = AgentProfileManager.COPILOT_PROFILE_ID;
+        o.stripNonEssentialPath = true;
+        state.overrides.add(o);
+
+        AgentProfileManager fresh = new AgentProfileManager();
+        fresh.loadState(state);
+
+        AgentProfile copilot = fresh.getProfile(AgentProfileManager.COPILOT_PROFILE_ID);
+        assertNotNull(copilot);
+        assertTrue(copilot.isStripNonEssentialPath());
+    }
+
+    @Test
+    @DisplayName("loadState applies extraCliArgs override")
+    void loadStateAppliesExtraCliArgs() {
+        AgentProfileManager.PersistedState state = new AgentProfileManager.PersistedState();
+        AgentProfileManager.ProfileOverride o = new AgentProfileManager.ProfileOverride();
+        o.profileId = AgentProfileManager.KIRO_PROFILE_ID;
+        o.extraCliArgs = "--v3 --debug";
+        state.overrides.add(o);
+
+        AgentProfileManager fresh = new AgentProfileManager();
+        fresh.loadState(state);
+
+        AgentProfile kiro = fresh.getProfile(AgentProfileManager.KIRO_PROFILE_ID);
+        assertNotNull(kiro);
+        assertEquals("--v3 --debug", kiro.getExtraCliArgs());
+    }
+
+    @Test
+    @DisplayName("loadState applies excludedBuiltInTools override")
+    void loadStateAppliesExcludedBuiltInTools() {
+        AgentProfileManager.PersistedState state = new AgentProfileManager.PersistedState();
+        AgentProfileManager.ProfileOverride o = new AgentProfileManager.ProfileOverride();
+        o.profileId = AgentProfileManager.COPILOT_PROFILE_ID;
+        o.excludedBuiltInTools = "view,edit,rg";
+        state.overrides.add(o);
+
+        AgentProfileManager fresh = new AgentProfileManager();
+        fresh.loadState(state);
+
+        AgentProfile copilot = fresh.getProfile(AgentProfileManager.COPILOT_PROFILE_ID);
+        assertNotNull(copilot);
+        assertEquals("view,edit,rg", copilot.getExcludedBuiltInTools());
+    }
+
+    @Test
+    @DisplayName("loadState applies customCliModels override")
+    void loadStateAppliesCustomCliModels() {
+        AgentProfileManager.PersistedState state = new AgentProfileManager.PersistedState();
+        AgentProfileManager.ProfileOverride o = new AgentProfileManager.ProfileOverride();
+        o.profileId = AgentProfileManager.CLAUDE_CLI_PROFILE_ID;
+        o.customCliModels = List.of("claude-opus-4-6");
+        state.overrides.add(o);
+
+        AgentProfileManager fresh = new AgentProfileManager();
+        fresh.loadState(state);
+
+        AgentProfile claude = fresh.getProfile(AgentProfileManager.CLAUDE_CLI_PROFILE_ID);
+        assertNotNull(claude);
+        assertEquals(List.of("claude-opus-4-6"), claude.getCustomCliModels());
+    }
+
+    @Test
+    @DisplayName("loadState applies prependInstructionsTo override")
+    void loadStateAppliesPrependInstructionsTo() {
+        AgentProfileManager.PersistedState state = new AgentProfileManager.PersistedState();
+        AgentProfileManager.ProfileOverride o = new AgentProfileManager.ProfileOverride();
+        o.profileId = AgentProfileManager.KIRO_PROFILE_ID;
+        o.prependInstructionsTo = "AGENTS.md";
+        state.overrides.add(o);
+
+        AgentProfileManager fresh = new AgentProfileManager();
+        fresh.loadState(state);
+
+        AgentProfile kiro = fresh.getProfile(AgentProfileManager.KIRO_PROFILE_ID);
+        assertNotNull(kiro);
+        assertEquals("AGENTS.md", kiro.getPrependInstructionsTo());
+    }
+
+    @Test
+    @DisplayName("loadExtraCliArgs for non-Kiro agent (OpenCode) returns empty by default")
+    void loadExtraCliArgsOpenCodeDefault() {
+        assertEquals("", manager.loadExtraCliArgs(AgentProfileManager.OPENCODE_PROFILE_ID));
+    }
+
+    @Test
+    @DisplayName("saveExtraCliArgs + loadExtraCliArgs roundtrip for OpenCode")
+    void saveExtraCliArgsOpenCodeRoundtrip() {
+        manager.saveExtraCliArgs(AgentProfileManager.OPENCODE_PROFILE_ID, "--debug");
+        assertEquals("--debug", manager.loadExtraCliArgs(AgentProfileManager.OPENCODE_PROFILE_ID));
+    }
+
+    @Test
+    @DisplayName("hasUserData returns true when only stripNonEssentialPath is true")
+    void hasUserDataStripNonEssentialPathReturnsTrue() throws Exception {
+        Method hasUserDataMethod = AgentProfileManager.class.getDeclaredMethod(
+            "hasUserData", AgentProfileManager.ProfileOverride.class);
+        hasUserDataMethod.setAccessible(true);
+        AgentProfileManager.ProfileOverride o = new AgentProfileManager.ProfileOverride();
+        o.stripNonEssentialPath = true;
+        assertTrue((boolean) hasUserDataMethod.invoke(null, o));
+    }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentProfileTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentProfileTest.java
@@ -159,7 +159,76 @@ class AgentProfileTest {
         assertTrue(dest.isBuiltIn()); // builtIn is NOT copied by copyFrom
     }
 
-    // ── getClientCssClass() ───────────────────────────────────────────────────
+    @Test
+    @DisplayName("getExtraCliArgs default is empty string")
+    void getExtraCliArgsDefaultEmpty() {
+        assertEquals("", profile.getExtraCliArgs());
+    }
+
+    @Test
+    @DisplayName("setExtraCliArgs / getExtraCliArgs roundtrip")
+    void setAndGetExtraCliArgs() {
+        profile.setExtraCliArgs("--foo --bar");
+        assertEquals("--foo --bar", profile.getExtraCliArgs());
+    }
+
+    @Test
+    @DisplayName("setExtraCliArgs null guard via getExtraCliArgs")
+    void getExtraCliArgsNeverNull() {
+        // Field is initialized to "" — even after copyFrom with a null-field profile it should be ""
+        AgentProfile other = new AgentProfile();
+        profile.copyFrom(other);
+        assertNotNull(profile.getExtraCliArgs());
+    }
+
+    @Test
+    @DisplayName("copyFrom copies extraCliArgs from source")
+    void copyFromCopiesExtraCliArgs() {
+        AgentProfile src = new AgentProfile();
+        src.setExtraCliArgs("--v3 --debug");
+        AgentProfile dest = new AgentProfile();
+        dest.copyFrom(src);
+        assertEquals("--v3 --debug", dest.getExtraCliArgs());
+    }
+
+    // ── parsedExtraCliArgs() ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("parsedExtraCliArgs returns empty list when extraCliArgs is blank")
+    void parsedExtraCliArgsEmptyWhenBlank() {
+        profile.setExtraCliArgs("");
+        assertTrue(profile.parsedExtraCliArgs().isEmpty());
+    }
+
+    @Test
+    @DisplayName("parsedExtraCliArgs returns empty list when extraCliArgs is whitespace-only")
+    void parsedExtraCliArgsEmptyWhenWhitespace() {
+        profile.setExtraCliArgs("   ");
+        assertTrue(profile.parsedExtraCliArgs().isEmpty());
+    }
+
+    @Test
+    @DisplayName("parsedExtraCliArgs tokenizes simple flags")
+    void parsedExtraCliArgsSimpleFlags() {
+        profile.setExtraCliArgs("--foo --bar");
+        assertEquals(List.of("--foo", "--bar"), profile.parsedExtraCliArgs());
+    }
+
+    @Test
+    @DisplayName("parsedExtraCliArgs handles quoted values")
+    void parsedExtraCliArgsQuotedValue() {
+        profile.setExtraCliArgs("--flag \"value with spaces\"");
+        assertEquals(List.of("--flag", "value with spaces"), profile.parsedExtraCliArgs());
+    }
+
+    @Test
+    @DisplayName("parsedExtraCliArgs single token")
+    void parsedExtraCliArgsSingleToken() {
+        profile.setExtraCliArgs("--v3");
+        assertEquals(List.of("--v3"), profile.parsedExtraCliArgs());
+    }
+
+
 
     @Test
     @DisplayName("getClientCssClass returns 'copilot' when binaryName contains 'copilot'")

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentProfileTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentProfileTest.java
@@ -228,7 +228,55 @@ class AgentProfileTest {
         assertEquals(List.of("--v3"), profile.parsedExtraCliArgs());
     }
 
+    // ── getKiroAgentEngine / setKiroAgentEngine ──────────────────────────────
 
+    @Test
+    @DisplayName("getKiroAgentEngine default is 'v2'")
+    void getKiroAgentEngineDefault() {
+        assertEquals("v2", profile.getKiroAgentEngine());
+    }
+
+    @Test
+    @DisplayName("setKiroAgentEngine / getKiroAgentEngine roundtrip")
+    void setAndGetKiroAgentEngine() {
+        profile.setKiroAgentEngine("v3");
+        assertEquals("v3", profile.getKiroAgentEngine());
+    }
+
+    @Test
+    @DisplayName("getKiroAgentEngine returns 'v2' when field is null (null-guard)")
+    void getKiroAgentEngineNullGuard() throws Exception {
+        var field = AgentProfile.class.getDeclaredField("kiroAgentEngine");
+        field.setAccessible(true);
+        field.set(profile, null);
+        assertEquals("v2", profile.getKiroAgentEngine());
+    }
+
+    @Test
+    @DisplayName("getKiroAgentEngine returns 'v2' when field is blank (blank-guard)")
+    void getKiroAgentEngineBlankGuard() {
+        profile.setKiroAgentEngine("   ");
+        assertEquals("v2", profile.getKiroAgentEngine());
+    }
+
+    @Test
+    @DisplayName("copyFrom copies kiroAgentEngine from source")
+    void copyFromCopiesKiroAgentEngine() {
+        AgentProfile src = new AgentProfile();
+        src.setKiroAgentEngine("v3");
+        AgentProfile dest = new AgentProfile();
+        dest.copyFrom(src);
+        assertEquals("v3", dest.getKiroAgentEngine());
+    }
+
+    @Test
+    @DisplayName("getExtraCliArgs returns empty string when field is null (null-guard via reflection)")
+    void getExtraCliArgsNullGuardViaReflection() throws Exception {
+        var field = AgentProfile.class.getDeclaredField("extraCliArgs");
+        field.setAccessible(true);
+        field.set(profile, null);
+        assertEquals("", profile.getExtraCliArgs());
+    }
 
     @Test
     @DisplayName("getClientCssClass returns 'copilot' when binaryName contains 'copilot'")


### PR DESCRIPTION
Prepares KiroClient for kiro-cli agent-engine v3 and adds extra CLI args and wires them into sandbox preview for all agents.

there's the v2/v3 selection on the settings for Kiro (defaults to v2):
<img width="1039" height="511" alt="image" src="https://github.com/user-attachments/assets/fef3e2db-1e95-4c52-a149-c72dbdb81308" />

The extra args helps if you need to add stuff like `--debug` or `-v` for verbosity (depending on the agent)

I don't know when is the V2 going to be deprecated, but at least this PR prepares for that.

https://kiro.dev/docs/cli/v3/