### PR TITLE
draft: feat(kiro): surface slash commands and v3 agents in the UI

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/AcpClient.java
@@ -638,7 +638,13 @@ public abstract class AcpClient extends AbstractClient {
         }
     }
 
-    private void updateCommands(List<NewSessionResponse.AvailableCommand> commands) {
+    /**
+     * Replaces the current slash command list with full command details (name + description).
+     * Both the name list (for matching) and the detail list (for autocomplete descriptions)
+     * are refreshed. Called by subclasses (e.g., {@link KiroClient}) that parse commands from
+     * proprietary notifications and want descriptions surfaced in the prompt autocomplete.
+     */
+    protected void updateCommands(List<NewSessionResponse.AvailableCommand> commands) {
         List<String> names = new ArrayList<>();
         availableCommandDetails.clear();
         for (NewSessionResponse.AvailableCommand cmd : commands) {
@@ -1212,6 +1218,17 @@ public abstract class AcpClient extends AbstractClient {
     @Override
     public final void setCurrentAgentSlug(@Nullable String slug) {
         currentAgentSlug = slug;
+        onAgentSlugChanged(slug);
+    }
+
+    /**
+     * Hook invoked after the current agent slug changes. Default is a no-op. Subclasses whose
+     * agent selection must be applied to a live session (e.g. Kiro v3 via {@code session/set_mode})
+     * override this to push the change to the running agent process. {@code setCurrentAgentSlug}
+     * is {@code final}, so this hook is the extension point for reacting to selection changes.
+     */
+    protected void onAgentSlugChanged(@Nullable String slug) {
+        // no-op by default
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
@@ -1,5 +1,7 @@
 package com.github.catatafishen.agentbridge.client.acp;
 
+import com.github.catatafishen.agentbridge.acp.protocol.NewSessionResponse;
+import com.github.catatafishen.agentbridge.client.AbstractClient;
 import com.github.catatafishen.agentbridge.model.ContentBlock;
 import com.github.catatafishen.agentbridge.model.PromptResponse;
 import com.github.catatafishen.agentbridge.model.SessionUpdate;
@@ -288,19 +290,36 @@ public final class KiroClient extends AcpClient {
 
     private void handleCommandsAvailable(JsonObject params) {
         if (params != null && params.has("commands")) {
-            JsonArray commands = params.getAsJsonArray("commands");
+            List<NewSessionResponse.AvailableCommand> commands = parseCommandsAvailable(params);
             LOG.info("Kiro slash commands available: " + commands.size());
-            List<String> names = new java.util.ArrayList<>();
-            for (var el : commands) {
-                if (el.isJsonObject()) {
-                    JsonObject cmd = el.getAsJsonObject();
-                    if (cmd.has("name")) {
-                        names.add(cmd.get("name").getAsString());
-                    }
-                }
-            }
-            updateCommandNames(names);
+            updateCommands(commands);
         }
+    }
+
+    /**
+     * Parses a Kiro {@code _kiro.dev/commands/available} notification payload into
+     * {@link NewSessionResponse.AvailableCommand} records, preserving each command's
+     * description so the prompt autocomplete can display it. Entries without a usable
+     * {@code name} are skipped. Pure and side-effect free for unit testing.
+     */
+    static List<NewSessionResponse.AvailableCommand> parseCommandsAvailable(JsonObject params) {
+        List<NewSessionResponse.AvailableCommand> result = new java.util.ArrayList<>();
+        if (params == null || !params.has("commands")) {
+            return result;
+        }
+        JsonArray commands = params.getAsJsonArray("commands");
+        for (var el : commands) {
+            if (!el.isJsonObject()) continue;
+            JsonObject cmd = el.getAsJsonObject();
+            if (!cmd.has("name") || cmd.get("name").isJsonNull()) continue;
+            String name = cmd.get("name").getAsString();
+            if (name.isBlank()) continue;
+            String description = cmd.has("description") && !cmd.get("description").isJsonNull()
+                ? cmd.get("description").getAsString()
+                : "";
+            result.add(new NewSessionResponse.AvailableCommand(name, description, null));
+        }
+        return result;
     }
 
     public void executeSlashCommand(String command, java.util.function.Consumer<Boolean> callback) {
@@ -524,27 +543,95 @@ public final class KiroClient extends AcpClient {
     }
 
     /**
-     * For v3, sends {@code session/set_mode} with {@code "intellij-task"} immediately after
-     * session creation. This is the v3 replacement for the {@code --agent intellij-task} CLI flag
-     * (which is not supported in v3).
+     * The default Kiro agent (mode) slug — matches the {@code --agent intellij-task} CLI flag used
+     * on v2 and the initial {@code session/set_mode} sent on v3.
+     */
+    static final String DEFAULT_AGENT_SLUG = "intellij-task";
+
+    /**
+     * Whether the active Kiro profile is running the v3 agent engine. Agent (mode) selection is
+     * only exposed and applied for v3, which drives it through {@code session/set_mode}; v2 pins
+     * the agent via the {@code --agent} CLI flag and cannot switch without restarting.
+     */
+    private boolean isV3Engine() {
+        AgentProfile profile = AgentProfileManager
+            .getInstance().getProfile(AgentProfileManager.KIRO_PROFILE_ID);
+        return profile != null && "v3".equals(profile.getKiroAgentEngine());
+    }
+
+    /**
+     * On v3, Kiro exposes its agents as standard ACP session modes (parsed from {@code session/new}
+     * into {@link #getAvailableModes()}); surface them as selectable agents. On v2 the agent is
+     * fixed at launch via {@code --agent}, so no runtime selection is offered.
+     */
+    @Override
+    public List<AbstractClient.AgentMode> getAvailableAgents() {
+        return isV3Engine() ? getAvailableModes() : List.of();
+    }
+
+    /**
+     * On v3 the default selected agent is {@code intellij-task} (seeded into the current agent slug
+     * so the session menu highlights it). On v2 agent selection is not exposed, so there is no
+     * default agent slug.
+     */
+    @Override
+    public @org.jetbrains.annotations.Nullable String defaultAgentSlug() {
+        return isV3Engine() ? DEFAULT_AGENT_SLUG : null;
+    }
+
+    /**
+     * For v3, applies the currently selected agent via {@code session/set_mode} immediately after
+     * session creation. This is the v3 replacement for the {@code --agent} CLI flag (which v3 does
+     * not support). Falls back to {@link #DEFAULT_AGENT_SLUG} when no agent has been selected yet.
      */
     @Override
     protected void onSessionCreated(String sessionId) {
-        AgentProfile profile = AgentProfileManager
-            .getInstance().getProfile(AgentProfileManager.KIRO_PROFILE_ID);
-        if (profile == null || !"v3".equals(profile.getKiroAgentEngine())) {
+        if (!isV3Engine()) {
             return;
         }
+        applyKiroMode(sessionId, resolveSelectedAgentSlug());
+    }
+
+    /**
+     * For v3, pushes an agent selection made while a session is live to Kiro via
+     * {@code session/set_mode}. No-op on v2 or when there is no active session (the selection is
+     * then applied later by {@link #onSessionCreated}).
+     */
+    @Override
+    protected void onAgentSlugChanged(@org.jetbrains.annotations.Nullable String slug) {
+        if (!isV3Engine() || slug == null || slug.isBlank()) {
+            return;
+        }
+        String sessionId = getActiveSessionId();
+        if (sessionId != null && !sessionId.isBlank()) {
+            applyKiroMode(sessionId, slug);
+        }
+    }
+
+    private String resolveSelectedAgentSlug() {
+        String slug = getCurrentAgentSlug();
+        return (slug == null || slug.isBlank()) ? DEFAULT_AGENT_SLUG : slug;
+    }
+
+    /**
+     * Builds the {@code session/set_mode} request params for the given session and mode.
+     * The Kiro (standard ACP) field name is {@code modeId}. Pure for unit testing.
+     */
+    static JsonObject buildSetModeParams(String sessionId, String modeId) {
         JsonObject params = new JsonObject();
         params.addProperty("sessionId", sessionId);
-        params.addProperty("mode", "intellij-task");
-        transport.sendRequest("session/set_mode", params)
+        params.addProperty("modeId", modeId);
+        return params;
+    }
+
+    private void applyKiroMode(String sessionId, String modeId) {
+        transport.sendRequest("session/set_mode", buildSetModeParams(sessionId, modeId))
             .orTimeout(10, TimeUnit.SECONDS)
             .whenComplete((result, ex) -> {
                 if (ex != null) {
-                    LOG.warn("Kiro v3: session/set_mode failed for intellij-task: " + ex.getMessage());
+                    LOG.warn("Kiro v3: session/set_mode failed for " + modeId + ": " + ex.getMessage());
                 } else {
-                    LOG.info("Kiro v3: session/set_mode intellij-task applied for session " + sessionId);
+                    LOG.info("Kiro v3: session/set_mode " + modeId + " applied for session " + sessionId);
                 }
             });
     }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientAgentsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientAgentsTest.java
@@ -1,0 +1,41 @@
+package com.github.catatafishen.agentbridge.client.acp;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link KiroClient#buildSetModeParams(String, String)} — the pure builder for
+ * the v3 {@code session/set_mode} request that applies agent (mode) selection.
+ */
+class KiroClientAgentsTest {
+
+    @Test
+    @DisplayName("uses standard ACP 'modeId' field, not the legacy 'mode' field")
+    void usesModeIdField() {
+        JsonObject params = KiroClient.buildSetModeParams("session-123", "intellij-task");
+
+        assertTrue(params.has("modeId"), "expected 'modeId' key");
+        assertFalse(params.has("mode"), "must not use the legacy 'mode' key");
+        assertEquals("intellij-task", params.get("modeId").getAsString());
+    }
+
+    @Test
+    @DisplayName("includes the session id")
+    void includesSessionId() {
+        JsonObject params = KiroClient.buildSetModeParams("session-abc", "kiro_planner");
+
+        assertEquals("session-abc", params.get("sessionId").getAsString());
+        assertEquals("kiro_planner", params.get("modeId").getAsString());
+    }
+
+    @Test
+    @DisplayName("default agent slug is intellij-task")
+    void defaultAgentSlugConstant() {
+        assertEquals("intellij-task", KiroClient.DEFAULT_AGENT_SLUG);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientCommandsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientCommandsTest.java
@@ -1,0 +1,82 @@
+package com.github.catatafishen.agentbridge.client.acp;
+
+import com.github.catatafishen.agentbridge.acp.protocol.NewSessionResponse;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link KiroClient#parseCommandsAvailable(JsonObject)} — the pure parser that
+ * turns a Kiro {@code _kiro.dev/commands/available} payload into command records with
+ * descriptions preserved for the prompt autocomplete.
+ */
+class KiroClientCommandsTest {
+
+    private static JsonObject json(String s) {
+        return JsonParser.parseString(s).getAsJsonObject();
+    }
+
+    @Test
+    @DisplayName("parses name and description for each command")
+    void parsesNameAndDescription() {
+        List<NewSessionResponse.AvailableCommand> commands = KiroClient.parseCommandsAvailable(json("""
+            {"commands":[
+              {"name":"compact","description":"Compact the conversation"},
+              {"name":"clear","description":"Clear the session"}
+            ]}"""));
+
+        assertEquals(2, commands.size());
+        assertEquals("compact", commands.get(0).name());
+        assertEquals("Compact the conversation", commands.get(0).description());
+        assertEquals("clear", commands.get(1).name());
+        assertEquals("Clear the session", commands.get(1).description());
+    }
+
+    @Test
+    @DisplayName("missing description defaults to empty string")
+    void missingDescriptionDefaultsToEmpty() {
+        List<NewSessionResponse.AvailableCommand> commands = KiroClient.parseCommandsAvailable(json("""
+            {"commands":[{"name":"help"}]}"""));
+
+        assertEquals(1, commands.size());
+        assertEquals("help", commands.get(0).name());
+        assertEquals("", commands.get(0).description());
+    }
+
+    @Test
+    @DisplayName("skips entries with missing, null, or blank names")
+    void skipsInvalidNames() {
+        List<NewSessionResponse.AvailableCommand> commands = KiroClient.parseCommandsAvailable(json("""
+            {"commands":[
+              {"description":"no name"},
+              {"name":null,"description":"null name"},
+              {"name":"  ","description":"blank name"},
+              {"name":"valid","description":"ok"}
+            ]}"""));
+
+        assertEquals(1, commands.size());
+        assertEquals("valid", commands.get(0).name());
+    }
+
+    @Test
+    @DisplayName("skips non-object array entries")
+    void skipsNonObjectEntries() {
+        List<NewSessionResponse.AvailableCommand> commands = KiroClient.parseCommandsAvailable(json("""
+            {"commands":["string-entry",42,{"name":"valid"}]}"""));
+
+        assertEquals(1, commands.size());
+        assertEquals("valid", commands.get(0).name());
+    }
+
+    @Test
+    @DisplayName("missing commands array yields an empty list")
+    void missingCommandsArrayYieldsEmpty() {
+        assertTrue(KiroClient.parseCommandsAvailable(json("{}")).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary

Makes Kiro's slash commands and v3 agents visible and selectable from the
IntelliJ UI, instead of being silently dropped or hardcoded.

## What changed

**Slash commands** — `handleCommandsAvailable` now parses each
`_kiro.dev/commands/available` entry into an `AvailableCommand` (name +
description) via the new pure `parseCommandsAvailable` helper, and routes
them through the existing `updateCommands(...)` path. Previously the
description was discarded by `updateCommandNames`, so command descriptions
now reach `availableCommandDetails` and show up in the prompt autocomplete.
`AcpClient.updateCommands` was promoted to `protected` so subclasses can
reuse it.

**Agents** — Kiro v3 advertises its agents as standard ACP session modes in
the `session/new` response. `getAvailableAgents()` now returns those modes
for v3 (empty on v2, which still pins the agent via `--agent`), and
`defaultAgentSlug()` seeds the selection with `intellij-task`. Agent
selection is applied with `session/set_mode` using the correct `modeId`
field (previously an incorrect hardcoded `"mode":"intellij-task"`), both at
session creation and live via a new `onAgentSlugChanged` hook on `AcpClient`
(needed because `setCurrentAgentSlug` is final).

## Files

- `AcpClient.java` — promote `updateCommands` to protected, add
  `onAgentSlugChanged` hook
- `KiroClient.java` — command parsing, v3 agent modes, corrected `set_mode`
  params

## Testing

- `KiroClientCommandsTest` — unit tests for the pure command parser
- `KiroClientAgentsTest` — unit tests for the `set_mode` params builder

## Screenshots

The agents:
<img width="914" height="444" alt="image" src="https://github.com/user-attachments/assets/892986ef-7303-4de3-9d4f-e938933a83a7" />

The commands:
<img width="893" height="442" alt="image" src="https://github.com/user-attachments/assets/af9e722a-c28e-424d-83f0-c70afc160aba" />
