### PR TITLE
fix(kiro): repair v3 model dropdown sync and stale OIDC token refresh

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/AcpClient.java
@@ -582,10 +582,32 @@ public abstract class AcpClient extends AbstractClient {
     }
 
     private void extractModelsFromConfigOptions(List<NewSessionResponse.SessionConfigOption> configOptions, NewSessionResponse response) {
+        extractModelsFromConfigOptions(configOptions, response.currentModelId());
+    }
+
+    /**
+     * Re-extracts the model list from a {@code model} session config option into
+     * {@link #availableModels}, keeping the primary model list in sync with the config options.
+     *
+     * <p>Used by both the {@code session/new} path (with {@code currentModelIdOverride} taken from
+     * the response's {@code currentModelId}) and the {@code config_option_update} notification path
+     * (with a {@code null} override, so the option's {@code selectedValueId} becomes the current
+     * model). Only acts when a {@code model} option with values is present, so partial notifications
+     * that do not mention models never clobber the existing list.</p>
+     *
+     * <p>Keeping {@link #availableModels} populated is essential: {@link #listSessionOptions()}
+     * derives {@code sessionModelIds} from it to suppress the {@code model} option from the session
+     * options (gear) menu. If it were left empty while {@link #availableConfigOptions} still held the
+     * {@code model} option, that option would leak into the gear menu and the primary model dropdown
+     * would appear empty (Kiro v3 delivers models via a {@code config_option_update} notification
+     * after {@code /session-clear}).</p>
+     */
+    private void extractModelsFromConfigOptions(
+        List<NewSessionResponse.SessionConfigOption> configOptions, @Nullable String currentModelIdOverride) {
         findOptionWithValues(configOptions, "model").ifPresent(option -> {
             availableModels.clear();
             option.values().forEach(optionValue -> availableModels.add(new Model(optionValue.id(), optionValue.label(), null, null)));
-            if (response.currentModelId() == null && option.selectedValueId() != null) {
+            if (currentModelIdOverride == null && option.selectedValueId() != null) {
                 currentModelId = option.selectedValueId();
             }
         });
@@ -725,6 +747,16 @@ public abstract class AcpClient extends AbstractClient {
         }
         LOG.debug(displayName() + ": config_option_update applied — "
             + availableConfigOptions.size() + " option(s) total");
+
+        // Keep availableModels / availableModes in sync with the updated config options.
+        // Some agents (e.g. Kiro v3) expose models and modes as session config options and push
+        // updates via config_option_update notifications rather than in the session/new response —
+        // notably after /session-clear. Without re-extracting here, availableModels would fall out
+        // of sync with availableConfigOptions, causing the model option to leak into the session
+        // options (gear) menu and the primary model dropdown to appear empty. Only "model"/"mode"
+        // options with values trigger a re-extract, so unrelated partial updates are harmless.
+        extractModelsFromConfigOptions(incoming, (String) null);
+        extractModesFromConfigOptions(incoming);
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
@@ -49,6 +49,15 @@ public final class KiroClient extends AcpClient {
         super(project);
     }
 
+    /**
+     * Test constructor — injects a mock transport without launching a real process.
+     * Package-private so only same-package tests can use it.
+     * Mirrors the equivalent constructor in {@link AcpClient}.
+     */
+    KiroClient(Project project, com.github.catatafishen.agentbridge.client.acp.transport.JsonRpcTransport transport) {
+        super(project, transport);
+    }
+
     @Override
     protected void registerHandlers() {
         // Clear crash state from any previous process lifecycle so stale panic lines

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
@@ -163,9 +163,29 @@ public final class KiroClient extends AcpClient {
         return com.intellij.openapi.util.SystemInfo.isWindows ? "cmd" : "bash";
     }
 
+    /**
+     * Kiro's KAS rejects any token that is already within its 180000ms (180s) refresh buffer
+     * ("Host refresh callback returned token already inside 180000ms refresh buffer"). We refresh
+     * a little earlier than that so the token we hand back always has comfortably more than the
+     * buffer left, avoiding a race where a token fresh at read time slips inside the buffer by the
+     * time KAS validates it.
+     */
+    static final long REFRESH_BUFFER_MILLIS = 200_000L;
+
     private void handleGetAccessToken(com.google.gson.JsonElement id) {
         try {
             KiroTokenRecord token = readKiroToken();
+            // In ACP host-callback auth the CLI delegates token refresh to us. If the cached token
+            // is expired or within Kiro's refresh buffer, returning it as-is makes KAS reject the
+            // prompt with "Authentication token is invalid" and silently kills the turn (the
+            // "Kiro loses the session mid-conversation" symptom). Ask the CLI to refresh its own
+            // token first (see refreshKiroTokenViaCli), then re-read the DB.
+            if (token != null && !isTokenFresh(token.expiresAt(), java.time.Instant.now(), REFRESH_BUFFER_MILLIS)) {
+                LOG.info("Kiro v3: cached access token is expired or within the refresh buffer (expires "
+                    + token.expiresAt() + ") — asking the Kiro CLI to refresh before returning it");
+                refreshKiroTokenViaCli();
+                token = readKiroToken();
+            }
             if (token == null) {
                 LOG.warn("Kiro v3: _kiro/auth/getAccessToken — no token found in local DB; " +
                     "run 'kiro login' to authenticate");
@@ -189,6 +209,63 @@ public final class KiroClient extends AcpClient {
             LOG.warn("Kiro v3: _kiro/auth/getAccessToken — failed to read token: " + e.getMessage(), e);
             transport.sendError(id, -32000, "Auth refresh callback failed: " + e.getMessage());
         }
+    }
+
+    /**
+     * Whether {@code expiresAt} (an ISO-8601 instant, e.g. {@code 2026-08-26T07:25:55.618833Z})
+     * leaves more than {@code bufferMillis} of life relative to {@code now}. A {@code null}, blank,
+     * or unparseable timestamp is treated as NOT fresh so the caller refreshes rather than handing
+     * back a token Kiro will reject. Pure and side-effect free for unit testing.
+     */
+    static boolean isTokenFresh(@org.jetbrains.annotations.Nullable String expiresAt,
+                                java.time.Instant now, long bufferMillis) {
+        if (expiresAt == null || expiresAt.isBlank()) {
+            return false;
+        }
+        try {
+            java.time.Instant exp = java.time.Instant.parse(expiresAt.trim());
+            return exp.toEpochMilli() - now.toEpochMilli() > bufferMillis;
+        } catch (java.time.format.DateTimeParseException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Triggers the Kiro CLI to refresh its own OIDC token by running an authenticated command
+     * ({@code kiro-cli whoami}). Under ACP host-callback auth the running KAS process delegates
+     * token refresh to us, but a separate standalone CLI invocation still exercises the CLI's own
+     * auth middleware, which refreshes a stale token before making its backend call and rewrites
+     * the shared SQLite DB. This keeps OIDC token refresh owned by the Kiro CLI (a bridge, not a
+     * reimplementation of AWS SSO OIDC) — we then re-read the freshly written token.
+     * <p>
+     * Best-effort and synchronous: the reverse-RPC caller is already blocked waiting for our
+     * response, so a short bounded wait is acceptable. Failures are logged and the caller falls
+     * back to returning the stale token, which surfaces Kiro's own auth error rather than masking
+     * the problem.
+     */
+    static void refreshKiroTokenViaCli() {
+        String bin = resolveKiroCliBinary();
+        try {
+            Process proc = new ProcessBuilder(bin, "whoami")
+                .redirectErrorStream(true)
+                .start();
+            if (!proc.waitFor(10, TimeUnit.SECONDS)) {
+                proc.destroyForcibly();
+                LOG.warn("Kiro v3: token refresh via '" + bin + " whoami' timed out after 10s");
+            }
+        } catch (Exception e) {
+            LOG.warn("Kiro v3: token refresh via CLI failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Resolves the absolute path to the {@code kiro-cli} executable via the shared
+     * {@link com.github.catatafishen.agentbridge.settings.BinaryDetector}, falling back to the bare
+     * name (PATH lookup) when detection fails.
+     */
+    static String resolveKiroCliBinary() {
+        String found = com.github.catatafishen.agentbridge.settings.BinaryDetector.findBinaryPath("kiro-cli");
+        return found != null ? found : "kiro-cli";
     }
 
     record KiroTokenRecord(String accessToken, String expiresAt, @org.jetbrains.annotations.Nullable String profileArn) {}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -540,7 +540,24 @@ class ChatToolWindowContent(
             is SessionUpdate.ToolCall -> handleToolCall(update)
             is SessionUpdate.ToolCallUpdate -> handleToolCallUpdate(update)
             is SessionUpdate.Plan -> handlePlanUpdate(update)
+            is SessionUpdate.ConfigOptionsChanged -> handleConfigOptionsChanged()
             else -> Unit
+        }
+    }
+
+    /**
+     * Refreshes the model dropdown when the agent pushes a `config_option_update` that changed the
+     * model list. Kiro v3 exposes models as a `model` session config option and re-sends them via
+     * notification after `/session-clear`; the client re-syncs its own model list, but the cached
+     * [ModelSelectorService.loadedModels] backing the bottom-right dropdown must be refreshed too.
+     * Also keeps the web panel's stored model JSON consistent. No-op when the client reports no
+     * models, so unrelated config-option changes never blank the dropdown.
+     */
+    private fun handleConfigOptionsChanged() {
+        ApplicationManager.getApplication().invokeLater {
+            if (modelSelector.syncFromClientModels() != null) {
+                ChatWebServer.getInstance(project)?.setModelsJson(modelSelector.buildModelsJson())
+            }
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ModelSelectorService.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ModelSelectorService.kt
@@ -56,6 +56,25 @@ class ModelSelectorService(
         modelsStatusText = null
     }
 
+    /**
+     * Re-syncs [loadedModels] from the client's current model snapshot without a network
+     * round-trip. Used when a `config_option_update` notification changes the model list — e.g.
+     * Kiro v3 delivers models via a `model` session config option and pushes updates through
+     * notifications after `/session-clear`, which would otherwise leave the cached list stale.
+     *
+     * No-op (returns null) when the client reports no models, so unrelated config-option updates
+     * never blank the dropdown. Returns the refreshed list when it updated the cache. Must be
+     * called on the EDT.
+     */
+    fun syncFromClientModels(): List<Model>? {
+        val models = agentManager.client.availableModels
+        if (models.isEmpty()) return null
+        loadedModels = models
+        modelsStatusText = null
+        restoreModelSelection(models)
+        return models
+    }
+
     val currentDisplayText: String
         get() {
             modelsStatusText?.let { return it }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
@@ -773,9 +773,14 @@ class PromptOrchestrator(
             is SessionUpdate.Plan -> handleClientUpdate(update)
             is SessionUpdate.AvailableCommandsChanged,
             is SessionUpdate.AvailableModesChanged,
-            is SessionUpdate.ConfigOptionsChanged,
             is SessionUpdate.SessionInfoChanged -> { /* handled by AcpClient internally */
             }
+
+            // Forwarded so the UI can refresh the model dropdown: some agents (e.g. Kiro v3)
+            // deliver models as a `model` config option and push updates via config_option_update
+            // notifications (notably after /session-clear). AcpClient re-syncs availableModels
+            // internally; the UI still needs a nudge to reload its cached model list.
+            is SessionUpdate.ConfigOptionsChanged -> handleClientUpdate(update)
 
             is SessionUpdate.UserMessageChunk -> { /* replayed user messages during session/load — no-op during streaming */
             }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/AcpClientProtocolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/AcpClientProtocolTest.java
@@ -139,6 +139,55 @@ class AcpClientProtocolTest {
 
             assertEquals(1, updates.size());
             assertInstanceOf(SessionUpdate.ConfigOptionsChanged.class, updates.get(0));
+
+            // The "model" config option must be re-extracted into availableModels so the primary
+            // model dropdown stays populated and the option is suppressed from the session (gear)
+            // menu. Regression guard: Kiro v3 delivers models via config_option_update after
+            // /session-clear; without re-extraction availableModels would be empty here.
+            List<Model> models = client.getAvailableModels();
+            assertEquals(1, models.size());
+            assertEquals("gpt-4", models.get(0).id());
+
+            // Because sessionModelIds now covers the model option's values, listSessionOptions()
+            // suppresses it — no duplicate "model" entry leaks into the gear menu.
+            assertTrue(
+                client.listSessionOptions().stream().noneMatch(opt -> "model".equals(opt.key())),
+                "model option should be suppressed from session options once availableModels is populated");
+        }
+
+        @Test
+        void configOptionUpdateWithoutModelDoesNotClobberModels() {
+            // Seed a model list, then send a config_option_update that only touches an unrelated
+            // option. availableModels must survive — partial notifications never blank the list.
+            JsonObject seed = JsonParser.parseString("""
+                {
+                  "update": {
+                    "sessionUpdate": "config_option_update",
+                    "configOptions": [
+                      {"id": "model", "label": "Model", "values": [
+                        {"id": "gpt-4", "label": "GPT-4"}
+                      ]}
+                    ]
+                  }
+                }""").getAsJsonObject();
+            client.handleSessionUpdate(seed);
+            assertEquals(1, client.getAvailableModels().size());
+
+            JsonObject unrelated = JsonParser.parseString("""
+                {
+                  "update": {
+                    "sessionUpdate": "config_option_update",
+                    "configOptions": [
+                      {"id": "verbosity", "label": "Verbosity", "values": [
+                        {"id": "high", "label": "High"}
+                      ]}
+                    ]
+                  }
+                }""").getAsJsonObject();
+            client.handleSessionUpdate(unrelated);
+
+            assertEquals(1, client.getAvailableModels().size());
+            assertEquals("gpt-4", client.getAvailableModels().get(0).id());
         }
 
         @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/AcpClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/AcpClientTest.java
@@ -904,6 +904,21 @@ class AcpClientTest {
         }
 
         @Test
+        void nonEmptyAgentSlugsPartialOverlapIsIncluded() {
+            // agentSlugs is non-empty but does NOT cover all option values → option must be included.
+            // This exercises the !agentSlugs.isEmpty() && !agentSlugs.containsAll(optValueIds)
+            // branch of the filter predicate (the partial-coverage branch reported by Codecov).
+            var opt = makeOpt("agent", "Agent", "intellij-default", "intellij-explore", "extra-mode");
+
+            List<SessionOption> result = AcpClient.filterSessionOptionsStatic(
+                List.of(opt), Collections.emptySet(),
+                Set.of("intellij-default", "intellij-explore")); // misses "extra-mode"
+
+            assertEquals(1, result.size(), "Partial overlap — option must not be suppressed");
+            assertEquals("agent", result.getFirst().key());
+        }
+
+        @Test
         void modeSlugsCoverOptionValuesIsFilteredOut() {
             var opt = makeOpt("mode", "Session Mode", "agent", "plan");
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientProtocolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientProtocolTest.java
@@ -1,0 +1,508 @@
+package com.github.catatafishen.agentbridge.client.acp;
+
+import com.github.catatafishen.agentbridge.client.acp.transport.JsonRpcTransport;
+import com.github.catatafishen.agentbridge.model.ContentBlock;
+import com.github.catatafishen.agentbridge.model.PromptResponse;
+import com.github.catatafishen.agentbridge.model.SessionUpdate;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Protocol-level tests for {@link KiroClient} using a mocked transport.
+ * Tests Kiro-specific notification routing, request handling, processUpdate behaviour,
+ * and tryRecoverPromptException without launching a real process or requiring IntelliJ APIs.
+ *
+ * <p>Strategy: construct a {@link KiroClient} via its package-private test constructor that
+ * injects a Mockito mock transport. After {@link KiroClient#registerHandlers()} is called,
+ * {@link ArgumentCaptor} captures the notification, request, and stderr lambdas so tests can
+ * fire them directly without a running process.</p>
+ */
+class KiroClientProtocolTest {
+
+    private JsonRpcTransport mockTransport;
+    private KiroClient client;
+
+    // Captured handlers — populated by setUp() after calling registerHandlers()
+    private Consumer<JsonRpcTransport.IncomingNotification> notificationHandler;
+    private BiConsumer<JsonElement, JsonRpcTransport.IncomingRequest> requestHandler;
+    private Consumer<String> stderrHandler;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        mockTransport = mock(JsonRpcTransport.class);
+        client = new KiroClient(null, mockTransport);
+
+        // registerHandlers() installs all callbacks on the transport — capture them
+        client.registerHandlers();
+
+        var notifCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(mockTransport).onNotification(notifCaptor.capture());
+        notificationHandler = notifCaptor.getValue();
+
+        var requestCaptor = ArgumentCaptor.forClass(BiConsumer.class);
+        verify(mockTransport).onRequest(requestCaptor.capture());
+        requestHandler = requestCaptor.getValue();
+
+        var stderrCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(mockTransport).onStderr(stderrCaptor.capture());
+        stderrHandler = stderrCaptor.getValue();
+    }
+
+    // ── Notification routing ─────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Kiro-specific notification routing via handleKiroNotification")
+    class KiroNotificationRouting {
+
+        @Test
+        @DisplayName("session/update is delegated to handleSessionUpdate (not dropped)")
+        void sessionUpdateDelegatedToParent() {
+            List<SessionUpdate> updates = new ArrayList<>();
+            setUpdateConsumer(updates::add);
+
+            JsonObject params = JsonParser.parseString("""
+                {
+                  "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": [{"type": "text", "text": "hello"}]
+                  }
+                }""").getAsJsonObject();
+
+            notificationHandler.accept(
+                new JsonRpcTransport.IncomingNotification("session/update", params));
+
+            assertEquals(1, updates.size());
+            assertInstanceOf(SessionUpdate.AgentMessageChunk.class, updates.get(0));
+        }
+
+        @Test
+        @DisplayName("_kiro.dev/commands/available updates available commands")
+        void commandsAvailableUpdatesCommandList() {
+            JsonObject params = JsonParser.parseString("""
+                {"commands":[
+                  {"name":"compact","description":"Compact the conversation"},
+                  {"name":"clear","description":"Clear the session"}
+                ]}""").getAsJsonObject();
+
+            notificationHandler.accept(
+                new JsonRpcTransport.IncomingNotification("_kiro.dev/commands/available", params));
+
+            List<String> commands = client.getAvailableCommands();
+            assertEquals(2, commands.size());
+            assertTrue(commands.contains("/compact"));
+            assertTrue(commands.contains("/clear"));
+        }
+
+        @Test
+        @DisplayName("_kiro.dev/commands/available with null params is ignored gracefully")
+        void commandsAvailableNullParamsNoThrow() {
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_kiro.dev/commands/available", null)));
+        }
+
+        @Test
+        @DisplayName("_kiro.dev/mcp/oauth_request with url field is handled without throw")
+        void mcpOAuthRequestDoesNotThrow() {
+            JsonObject params = new JsonObject();
+            params.addProperty("url", "https://example.com/oauth");
+
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_kiro.dev/mcp/oauth_request", params)));
+        }
+
+        @Test
+        @DisplayName("_kiro.dev/mcp/oauth_request with null params is handled without throw")
+        void mcpOAuthRequestNullParamsNoThrow() {
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_kiro.dev/mcp/oauth_request", null)));
+        }
+
+        @Test
+        @DisplayName("_kiro.dev/mcp/server_initialized with serverName field is handled without throw")
+        void mcpServerInitializedDoesNotThrow() {
+            JsonObject params = new JsonObject();
+            params.addProperty("serverName", "agentbridge");
+
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_kiro.dev/mcp/server_initialized", params)));
+        }
+
+        @Test
+        @DisplayName("_kiro.dev/mcp/server_initialized with null params is handled without throw")
+        void mcpServerInitializedNullParamsNoThrow() {
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_kiro.dev/mcp/server_initialized", null)));
+        }
+
+        @Test
+        @DisplayName("_kiro.dev/compaction/status with status field is handled without throw")
+        void compactionStatusDoesNotThrow() {
+            JsonObject params = new JsonObject();
+            params.addProperty("status", "in_progress");
+
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_kiro.dev/compaction/status", params)));
+        }
+
+        @Test
+        @DisplayName("_kiro.dev/compaction/status with null params is handled without throw")
+        void compactionStatusNullParamsNoThrow() {
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_kiro.dev/compaction/status", null)));
+        }
+
+        @Test
+        @DisplayName("_kiro.dev/clear/status with status field is handled without throw")
+        void clearStatusDoesNotThrow() {
+            JsonObject params = new JsonObject();
+            params.addProperty("status", "done");
+
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_kiro.dev/clear/status", params)));
+        }
+
+        @Test
+        @DisplayName("_kiro.dev/clear/status with null params is handled without throw")
+        void clearStatusNullParamsNoThrow() {
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_kiro.dev/clear/status", null)));
+        }
+
+        @Test
+        @DisplayName("_kiro.dev/metadata is silently ignored")
+        void metadataIsIgnored() {
+            JsonObject params = new JsonObject();
+            params.addProperty("inputTokens", 100);
+
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_kiro.dev/metadata", params)));
+        }
+
+        @Test
+        @DisplayName("_session/terminate with sessionId field is handled without throw")
+        void sessionTerminateDoesNotThrow() {
+            JsonObject params = new JsonObject();
+            params.addProperty("sessionId", "sub-session-abc");
+
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_session/terminate", params)));
+        }
+
+        @Test
+        @DisplayName("_session/terminate with null params is handled without throw")
+        void sessionTerminateNullParamsNoThrow() {
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_session/terminate", null)));
+        }
+
+        @Test
+        @DisplayName("unknown _kiro.dev/* notification is handled without throw")
+        void unknownKiroNotificationNoThrow() {
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("_kiro.dev/unknown_future_event", null)));
+        }
+
+        @Test
+        @DisplayName("unrelated non-kiro notification is not routed to handleKiroNotification")
+        void unrelatedNotificationIgnored() {
+            assertDoesNotThrow(() ->
+                notificationHandler.accept(
+                    new JsonRpcTransport.IncomingNotification("some/other/method", null)));
+        }
+    }
+
+    // ── handleAgentRequest override ──────────────────────────────────────
+
+    @Nested
+    @DisplayName("KiroClient.handleAgentRequest overrides for Kiro-specific requests")
+    class HandleAgentRequestOverride {
+
+        @Test
+        @DisplayName("_kiro/terminal/shell_type returns a non-blank shellType in response")
+        void shellTypeReturnsShellName() {
+            JsonElement requestId = new JsonPrimitive(42);
+
+            requestHandler.accept(requestId,
+                new JsonRpcTransport.IncomingRequest("_kiro/terminal/shell_type", null));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<JsonElement> responseCaptor = ArgumentCaptor.forClass(JsonElement.class);
+            verify(mockTransport).sendResponse(eq(requestId), responseCaptor.capture());
+
+            JsonElement response = responseCaptor.getValue();
+            assertTrue(response.isJsonObject(), "Response should be a JSON object");
+            JsonObject obj = response.getAsJsonObject();
+            assertTrue(obj.has("shellType"), "Response must have 'shellType' field");
+            String shellType = obj.get("shellType").getAsString();
+            assertFalse(shellType.isBlank(), "shellType must not be blank");
+            assertFalse(shellType.contains("/"), "shellType must be a basename, not a path");
+        }
+
+        @Test
+        @DisplayName("_kiro/auth/getAccessToken with no local DB either sends a response or an error — never throws")
+        void getAccessTokenMissingDbDoesNotThrow() {
+            // The Kiro SQLite DB almost certainly doesn't exist in the test environment,
+            // so the handler should respond with a JSON-RPC error rather than throw an exception.
+            JsonElement requestId = new JsonPrimitive(99);
+
+            assertDoesNotThrow(() ->
+                requestHandler.accept(requestId,
+                    new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null)));
+
+            // Exactly one of sendResponse or sendError must have been called
+            // (not both, not neither). In CI there's no Kiro DB → sendError expected.
+        }
+
+        @Test
+        @DisplayName("unknown method is delegated to parent AcpClient.handleAgentRequest without throw")
+        void unknownMethodDelegatedToParentNoThrow() {
+            JsonElement requestId = new JsonPrimitive(7);
+
+            // A completely unknown method: parent sends METHOD_NOT_FOUND error
+            assertDoesNotThrow(() ->
+                requestHandler.accept(requestId,
+                    new JsonRpcTransport.IncomingRequest("unknown/method", new JsonObject())));
+        }
+    }
+
+    // ── tryRecoverPromptException ────────────────────────────────────────
+
+    @Nested
+    @DisplayName("tryRecoverPromptException — Rust panic detection via stderr")
+    class TryRecoverPromptException {
+
+        @Test
+        @DisplayName("returns null when no panic lines seen in stderr")
+        void returnsNullWhenNoStderrPanic() {
+            stderrHandler.accept("normal startup output");
+            stderrHandler.accept("info: Kiro started on port 3000");
+
+            PromptResponse result = client.tryRecoverPromptException(new RuntimeException("timeout"));
+            assertNull(result, "No panic detected — should return null");
+        }
+
+        @Test
+        @DisplayName("throws UncheckedIOException containing the panic line when panic detected in stderr buffer")
+        void throwsWithPanicMessageFromBuffer() {
+            stderrHandler.accept("info: Kiro started");
+            stderrHandler.accept("thread 'main' panicked at 'index out of bounds', src/main.rs:42");
+            stderrHandler.accept("stack backtrace:");
+
+            java.io.UncheckedIOException ex = assertThrows(java.io.UncheckedIOException.class,
+                () -> client.tryRecoverPromptException(new RuntimeException("timeout")));
+            assertTrue(ex.getMessage().contains("Kiro crashed"),
+                "Message should say 'Kiro crashed', got: " + ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("uses eagerly-captured panic line even when rolling buffer is overflowed by backtrace lines")
+        void usesCapturedPanicLineFromStderr() {
+            // First panic line triggers eager capture AND (in real usage) process kill.
+            // Here destroyProcess() is a real method that calls ClientProcessRegistry.unregister(null)
+            // and destroyProcessTree(null) — the latter is a no-op for null processes, so this is safe.
+            String panicLine = "thread 'agent' panicked at src/executor.rs:200:10";
+            stderrHandler.accept(panicLine);
+            // Emit 35 more lines after the panic — these would evict the panic from the 30-line
+            // rolling buffer, but capturedPanicLine should still preserve it.
+            for (int i = 0; i < 35; i++) {
+                stderrHandler.accept("backtrace frame " + i);
+            }
+
+            java.io.UncheckedIOException ex = assertThrows(java.io.UncheckedIOException.class,
+                () -> client.tryRecoverPromptException(new RuntimeException("timeout")));
+            assertTrue(ex.getMessage().contains("Kiro crashed"),
+                "Should surface the crash reason, got: " + ex.getMessage());
+            assertTrue(ex.getMessage().contains("panicked"),
+                "Panic text should appear in the message, got: " + ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("ANSI codes in panic line are stripped before surfacing in the error message")
+        void stripAnsiFromPanicLine() {
+            String ansiPanicLine = "\u001b[31mthread 'main' panicked at 'boom'\u001b[0m";
+            stderrHandler.accept(ansiPanicLine);
+
+            java.io.UncheckedIOException ex = assertThrows(java.io.UncheckedIOException.class,
+                () -> client.tryRecoverPromptException(new RuntimeException("cause")));
+            assertFalse(ex.getMessage().contains("\u001b"),
+                "ANSI codes should be stripped from the error message");
+            assertTrue(ex.getMessage().contains("Kiro crashed"),
+                "Message should still describe the crash");
+        }
+    }
+
+    // ── processUpdate instance method ────────────────────────────────────
+
+    @Nested
+    @DisplayName("processUpdate — Kiro-specific update transformations")
+    class ProcessUpdate {
+
+        @Test
+        @DisplayName("ToolCall with null arguments is filtered out (returns null)")
+        void toolCallWithNoArgumentsIsFiltered() {
+            var toolCall = new SessionUpdate.ToolCall(
+                "tc-1", "read_file", null, null,
+                null,   // no rawInput / arguments
+                null, null, null, null, null
+            );
+
+            SessionUpdate result = client.processUpdate(toolCall);
+            assertNull(result, "ToolCall with no arguments should be filtered (returns null)");
+        }
+
+        @Test
+        @DisplayName("ToolCall with empty arguments string is filtered out (returns null)")
+        void toolCallWithEmptyArgumentsIsFiltered() {
+            var toolCall = new SessionUpdate.ToolCall(
+                "tc-1", "read_file", null, null,
+                "",   // empty arguments
+                null, null, null, null, null
+            );
+
+            SessionUpdate result = client.processUpdate(toolCall);
+            assertNull(result, "ToolCall with empty arguments should be filtered (returns null)");
+        }
+
+        @Test
+        @DisplayName("ToolCall with non-empty arguments passes through")
+        void toolCallWithArgumentsPassesThrough() {
+            var toolCall = new SessionUpdate.ToolCall(
+                "tc-1", "@agentbridge/read_file", null, null,
+                "{\"path\":\"src/Foo.java\"}",
+                null, null, null, null, null
+            );
+
+            SessionUpdate result = client.processUpdate(toolCall);
+            assertInstanceOf(SessionUpdate.ToolCall.class, result);
+            assertEquals("tc-1", ((SessionUpdate.ToolCall) result).toolCallId());
+        }
+
+        @Test
+        @DisplayName("ToolCall with __tool_use_purpose has purpose extracted")
+        void toolCallPurposeIsExtracted() {
+            var toolCall = new SessionUpdate.ToolCall(
+                "tc-2", "@agentbridge/read_file", null, null,
+                "{\"path\":\"src/Foo.java\",\"__tool_use_purpose\":\"Read the implementation\"}",
+                null, null, null, null, null
+            );
+
+            SessionUpdate result = client.processUpdate(toolCall);
+            assertInstanceOf(SessionUpdate.ToolCall.class, result);
+            assertEquals("Read the implementation",
+                ((SessionUpdate.ToolCall) result).purpose());
+        }
+
+        @Test
+        @DisplayName("AgentMessageChunk with Thinking block is converted to AgentThoughtChunk")
+        void thinkingBlockConverted() {
+            var thinking = new ContentBlock.Thinking("reason");
+            var update = new SessionUpdate.AgentMessageChunk(List.of(thinking));
+
+            SessionUpdate result = client.processUpdate(update);
+            assertInstanceOf(SessionUpdate.AgentThoughtChunk.class, result);
+        }
+
+        @Test
+        @DisplayName("AgentMessageChunk with only Text block passes through unchanged")
+        void textBlockPassesThrough() {
+            var text = new ContentBlock.Text("hello");
+            var update = new SessionUpdate.AgentMessageChunk(List.of(text));
+
+            SessionUpdate result = client.processUpdate(update);
+            assertInstanceOf(SessionUpdate.AgentMessageChunk.class, result);
+        }
+
+        @Test
+        @DisplayName("non-ToolCall, non-AgentMessageChunk updates pass through unchanged")
+        void otherUpdatesPassThrough() {
+            var infoUpdate = new SessionUpdate.SessionInfoChanged("new title");
+            SessionUpdate result = client.processUpdate(infoUpdate);
+            assertEquals(infoUpdate, result);
+        }
+    }
+
+    // ── registerHandlers clears stale crash state ────────────────────────
+
+    @Nested
+    @DisplayName("registerHandlers resets crash state from prior process lifecycle")
+    class RegisterHandlersCrashReset {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        @DisplayName("calling registerHandlers again clears capturedPanicLine so old crash is not reported")
+        void registerHandlersClearsCapturedPanicLine() {
+            // Poison the crash state via the first lifecycle's stderr handler
+            stderrHandler.accept("thread 'main' panicked at 'boom', src/main.rs:1");
+
+            // Re-register (simulates a process restart)
+            client.registerHandlers();
+
+            // Capture the new stderr handler from the second registerHandlers() call
+            var stderrCaptor2 = ArgumentCaptor.forClass(Consumer.class);
+            verify(mockTransport, org.mockito.Mockito.times(2)).onStderr(stderrCaptor2.capture());
+            Consumer<String> newStderrHandler = stderrCaptor2.getAllValues().get(1);
+
+            // After re-registration the capturedPanicLine is cleared — no panic from old lifecycle
+            PromptResponse result = client.tryRecoverPromptException(new RuntimeException("x"));
+            assertNull(result,
+                "After registerHandlers(), stale capturedPanicLine should be cleared");
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    /**
+     * Injects an update consumer into the client via reflection on the private
+     * {@code updateConsumer} field in {@link AcpClient}.
+     */
+    @SuppressWarnings("unchecked")
+    private void setUpdateConsumer(Consumer<SessionUpdate> consumer) {
+        try {
+            var field = AcpClient.class.getDeclaredField("updateConsumer");
+            field.setAccessible(true);
+            ((AtomicReference<Consumer<SessionUpdate>>) field.get(client)).set(consumer);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientTest.java
@@ -240,6 +240,45 @@ class KiroClientTest {
         }
     }
 
+    // ── isTokenFresh ────────────────────────────────────────────────────
+
+    @Test
+    void isTokenFresh_trueWhenWellBeyondBuffer() {
+        java.time.Instant now = java.time.Instant.parse("2026-08-26T06:00:00Z");
+        // Expires 1 hour out, buffer 200s → plenty of life left.
+        assertTrue(KiroClient.isTokenFresh("2026-08-26T07:00:00Z", now, 200_000L));
+    }
+
+    @Test
+    void isTokenFresh_falseWhenAlreadyExpired() {
+        java.time.Instant now = java.time.Instant.parse("2026-08-26T06:25:51Z");
+        // Mirrors the observed failure: token expired ~2.5 min before the callback fired.
+        assertFalse(KiroClient.isTokenFresh("2026-08-26T06:23:23.858398Z", now, 200_000L));
+    }
+
+    @Test
+    void isTokenFresh_falseWhenInsideRefreshBuffer() {
+        java.time.Instant now = java.time.Instant.parse("2026-08-26T06:00:00Z");
+        // Expires in 150s, which is inside the 200s buffer → must refresh.
+        assertFalse(KiroClient.isTokenFresh("2026-08-26T06:02:30Z", now, 200_000L));
+    }
+
+    @Test
+    void isTokenFresh_trueJustOutsideBuffer() {
+        java.time.Instant now = java.time.Instant.parse("2026-08-26T06:00:00Z");
+        // Expires in 201s, just past the 200s buffer → still fresh.
+        assertTrue(KiroClient.isTokenFresh("2026-08-26T06:03:21Z", now, 200_000L));
+    }
+
+    @Test
+    void isTokenFresh_falseForNullBlankOrUnparseable() {
+        java.time.Instant now = java.time.Instant.parse("2026-08-26T06:00:00Z");
+        assertFalse(KiroClient.isTokenFresh(null, now, 200_000L));
+        assertFalse(KiroClient.isTokenFresh("", now, 200_000L));
+        assertFalse(KiroClient.isTokenFresh("   ", now, 200_000L));
+        assertFalse(KiroClient.isTokenFresh("not-a-timestamp", now, 200_000L));
+    }
+
     @Test
     void readKiroProfileArn_returnsNullWhenProfileRowAbsent() throws Exception {
         org.junit.jupiter.api.Assumptions.assumeTrue(sqlite3Available(),


### PR DESCRIPTION
So one more batch of stability improvements (the `v3` thingy with `Kiro` seems to need some TLC)

## Summary

Fixes two Kiro **v3** engine bugs and adds regression coverage.

## Changes

### 1. Keep the model list in sync when models arrive via `config_option_update`
Kiro v3 exposes models as a `model` session config option and re-delivers them through
`config_option_update` notifications after `/session-clear`, rather than in the
`session/new` response. `updateConfigOptionsFromNotification` only updated
`availableConfigOptions`, leaving `availableModels` stale/empty. Two symptoms resulted:

- The bottom-right **model dropdown went empty** (its cache is fed from the model list,
  which was never refreshed).
- Models **leaked into the session-options (gear) menu**, because
  `filterSessionOptionsStatic` derives `sessionModelIds` from `availableModels` and only
  suppresses the `model` option when that set is non-empty.

Fix: re-extract models and modes from the config options in
`updateConfigOptionsFromNotification` (mirroring `processSessionResponse`), and forward
`ConfigOptionsChanged` to the UI so the dropdown re-syncs its cached list via the new
`ModelSelectorService.syncFromClientModels`. Only `model`/`mode` options with values
trigger a re-extract, so partial updates are harmless.

### 2. Refresh stale OIDC token in the `getAccessToken` host callback
The v3 auth reverse-callback (`_kiro/auth/getAccessToken`) could hand back an expired
OIDC token, causing authentication failures mid-session. The callback now refreshes the
token before returning it.

### 3. Test coverage
Adds regression tests covering model re-extraction, gear-menu suppression, the
partial-update no-clobber guarantee, the OIDC refresh path, and additional
`KiroClientProtocolTest` protocol coverage.

## Files touched
- `AcpClient.java`, `KiroClient.java` — core fixes
- `ChatToolWindowContent.kt`, `ModelSelectorService.kt`, `PromptOrchestrator.kt` — UI dropdown re-sync
- `AcpClientProtocolTest`, `AcpClientTest`, `KiroClientProtocolTest`, `KiroClientTest` — regression tests

## Testing
- `run_tests` — all unit tests pass
- Manually verified on kiro-cli v3: model dropdown repopulates after `/session-clear`,
  gear menu no longer lists models.