### PR TITLE
fix(kiro): enforce AgentBridge tool usage and surface OIDC token refresh failures

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
@@ -301,8 +301,6 @@ public final class KiroClient extends AcpClient {
         return found != null ? found : "kiro-cli";
     }
 
-    public record KiroTokenRecord(String accessToken, String expiresAt, @org.jetbrains.annotations.Nullable String profileArn) {}
-
     /**
      * Reads the Kiro CLI OIDC token from its local SQLite database.
      * Returns {@code null} if the DB or token row does not exist.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
@@ -172,9 +172,17 @@ public final class KiroClient extends AcpClient {
      */
     static final long REFRESH_BUFFER_MILLIS = 200_000L;
 
+    /**
+     * Supplies the OIDC token for {@code _kiro/auth/getAccessToken} callbacks.
+     * Defaults to {@link #defaultTokenSupplier()} which reads and conditionally refreshes the
+     * real SQLite DB. Package-private so tests in the same package can inject a controlled
+     * supplier without subclassing (the class is {@code final}).
+     */
+    java.util.concurrent.Callable<KiroTokenRecord> tokenSupplier = this::defaultTokenSupplier;
+
     private void handleGetAccessToken(com.google.gson.JsonElement id) {
         try {
-            KiroTokenRecord token = resolveKiroToken();
+            KiroTokenRecord token = tokenSupplier.call();
             if (token == null) {
                 LOG.warn("Kiro v3: _kiro/auth/getAccessToken — no token found in local DB; " +
                     "run 'kiro login' to authenticate");
@@ -217,13 +225,10 @@ public final class KiroClient extends AcpClient {
     /**
      * Reads the Kiro OIDC token, triggering a CLI refresh first if the cached token is expired
      * or within the refresh buffer. Returns the token after the optional refresh, or {@code null}
-     * if no token exists in the local DB.
-     *
-     * <p>Protected so tests can override it to inject a controlled token without hitting the
-     * real filesystem or spawning a {@code kiro-cli whoami} subprocess.</p>
+     * if no token exists in the local DB. Used as the default {@link #tokenSupplier}.
      */
     @org.jetbrains.annotations.Nullable
-    protected KiroTokenRecord resolveKiroToken() throws Exception {
+    private KiroTokenRecord defaultTokenSupplier() throws Exception {
         KiroTokenRecord token = readKiroToken();
         // In ACP host-callback auth the CLI delegates token refresh to us. If the cached token
         // is expired or within Kiro's refresh buffer, returning it as-is makes KAS reject the

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
@@ -192,6 +192,20 @@ public final class KiroClient extends AcpClient {
                 transport.sendError(id, -32000, "No Kiro access token found — run 'kiro login'");
                 return;
             }
+            // Guard: if the CLI refresh did not extend the token (e.g. `kiro-cli whoami` did not
+            // actually rotate it), the token is still expired or within KAS's 180s refresh buffer.
+            // Returning it anyway makes KAS reject the turn with the confusing "token already inside
+            // 180000ms refresh buffer" error. Surface an actionable error instead of handing back a
+            // token we know KAS will reject (no silent fallback that hides the real problem).
+            if (!isTokenFresh(token.expiresAt(), java.time.Instant.now(), REFRESH_BUFFER_MILLIS)) {
+                LOG.warn("Kiro v3: _kiro/auth/getAccessToken — token is still expired or within the "
+                    + "refresh buffer after a CLI refresh attempt (expires " + token.expiresAt()
+                    + "). Run 'kiro login' to re-authenticate.");
+                transport.sendError(id, -32000,
+                    "Kiro access token is expired and could not be refreshed automatically — "
+                        + "run 'kiro login' to re-authenticate.");
+                return;
+            }
             JsonObject result = new JsonObject();
             result.addProperty("accessToken", token.accessToken());
             result.addProperty("expiresAt", token.expiresAt());

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
@@ -301,7 +301,7 @@ public final class KiroClient extends AcpClient {
         return found != null ? found : "kiro-cli";
     }
 
-    record KiroTokenRecord(String accessToken, String expiresAt, @org.jetbrains.annotations.Nullable String profileArn) {}
+    public record KiroTokenRecord(String accessToken, String expiresAt, @org.jetbrains.annotations.Nullable String profileArn) {}
 
     /**
      * Reads the Kiro CLI OIDC token from its local SQLite database.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroClient.java
@@ -174,18 +174,7 @@ public final class KiroClient extends AcpClient {
 
     private void handleGetAccessToken(com.google.gson.JsonElement id) {
         try {
-            KiroTokenRecord token = readKiroToken();
-            // In ACP host-callback auth the CLI delegates token refresh to us. If the cached token
-            // is expired or within Kiro's refresh buffer, returning it as-is makes KAS reject the
-            // prompt with "Authentication token is invalid" and silently kills the turn (the
-            // "Kiro loses the session mid-conversation" symptom). Ask the CLI to refresh its own
-            // token first (see refreshKiroTokenViaCli), then re-read the DB.
-            if (token != null && !isTokenFresh(token.expiresAt(), java.time.Instant.now(), REFRESH_BUFFER_MILLIS)) {
-                LOG.info("Kiro v3: cached access token is expired or within the refresh buffer (expires "
-                    + token.expiresAt() + ") — asking the Kiro CLI to refresh before returning it");
-                refreshKiroTokenViaCli();
-                token = readKiroToken();
-            }
+            KiroTokenRecord token = resolveKiroToken();
             if (token == null) {
                 LOG.warn("Kiro v3: _kiro/auth/getAccessToken — no token found in local DB; " +
                     "run 'kiro login' to authenticate");
@@ -223,6 +212,31 @@ public final class KiroClient extends AcpClient {
             LOG.warn("Kiro v3: _kiro/auth/getAccessToken — failed to read token: " + e.getMessage(), e);
             transport.sendError(id, -32000, "Auth refresh callback failed: " + e.getMessage());
         }
+    }
+
+    /**
+     * Reads the Kiro OIDC token, triggering a CLI refresh first if the cached token is expired
+     * or within the refresh buffer. Returns the token after the optional refresh, or {@code null}
+     * if no token exists in the local DB.
+     *
+     * <p>Protected so tests can override it to inject a controlled token without hitting the
+     * real filesystem or spawning a {@code kiro-cli whoami} subprocess.</p>
+     */
+    @org.jetbrains.annotations.Nullable
+    protected KiroTokenRecord resolveKiroToken() throws Exception {
+        KiroTokenRecord token = readKiroToken();
+        // In ACP host-callback auth the CLI delegates token refresh to us. If the cached token
+        // is expired or within Kiro's refresh buffer, returning it as-is makes KAS reject the
+        // prompt with "Authentication token is invalid" and silently kills the turn (the
+        // "Kiro loses the session mid-conversation" symptom). Ask the CLI to refresh its own
+        // token first (see refreshKiroTokenViaCli), then re-read the DB.
+        if (token != null && !isTokenFresh(token.expiresAt(), java.time.Instant.now(), REFRESH_BUFFER_MILLIS)) {
+            LOG.info("Kiro v3: cached access token is expired or within the refresh buffer (expires "
+                + token.expiresAt() + ") — asking the Kiro CLI to refresh before returning it");
+            refreshKiroTokenViaCli();
+            token = readKiroToken();
+        }
+        return token;
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroTokenRecord.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/client/acp/KiroTokenRecord.java
@@ -1,0 +1,17 @@
+package com.github.catatafishen.agentbridge.client.acp;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Holds the Kiro CLI OIDC token fields read from the local SQLite database during a
+ * {@code _kiro/auth/getAccessToken} reverse callback.
+ *
+ * @param accessToken the raw OIDC access token string
+ * @param expiresAt   ISO-8601 expiry instant (e.g. {@code 2026-08-26T07:25:55Z})
+ * @param profileArn  Q Developer profile ARN, or {@code null} for Builder ID / free-tier accounts
+ */
+public record KiroTokenRecord(
+        String accessToken,
+        String expiresAt,
+        @Nullable String profileArn) {
+}

--- a/plugin-core/src/main/resources/default-startup-instructions.md
+++ b/plugin-core/src/main/resources/default-startup-instructions.md
@@ -4,45 +4,52 @@ You are running inside an IntelliJ IDEA plugin with IDE tools accessible via MCP
 
 1. **TRUST TOOL OUTPUTS.** MCP tools return data directly. Don't read temp files or invent processing tools.
 
-2. **WORKSPACE.** For temporary files, notes, and plans use
+2. **USE AGENTBRIDGE FOR COMMANDS.** Always use the AgentBridge MCP `run_command` tool for non-interactive shell commands
+   and `run_in_terminal` for interactive or long-running commands. NEVER use an agent's native `Run Command`, `bash`,
+   or shell tool. Native command runners may bypass the user's shell, execute the entire command string as an executable,
+   or skip IDE permission and synchronization handling. If a native command reports `Cannot run program ... (No such file
+   or directory)`, that is an execution failure, not a user rejection or missing approval. Retry with the AgentBridge MCP
+   tool immediately; do not ask the user to approve the command.
+
+3. **WORKSPACE.** For temporary files, notes, and plans use
    `create_scratch_file` — it lives in the IDE scratch area and does not pollute the project. NEVER write to `/tmp/`,
    the home directory, or outside the project.
 
-3. **TOOL DISCOVERY.** Not every tool's exact name and parameters are known to you upfront — some harnesses defer full
+4. **TOOL DISCOVERY.** Not every tool's exact name and parameters are known to you upfront — some harnesses defer full
    schemas until you search for or first call a tool. Look a capability up (by name or keyword) rather than guessing a
    name from general training or reaching for a raw shell command. If a call is rejected for an unrecognized or misnamed
    parameter, the error response tells you the correct one — apply it on your very next call instead of guessing again
    or retrying the same wrong shape.
 
-4. **MULTIPLE SEQUENTIAL EDITS.** Set `auto_format_and_optimize_imports=false`
+5. **MULTIPLE SEQUENTIAL EDITS.** Set `auto_format_and_optimize_imports=false`
    to prevent reformatting between edits. After all edits, call `format_code`
    and `optimize_imports` ONCE. `auto_format_and_optimize_imports` includes
    `optimize_imports` which REMOVES imports it considers unused — if you add imports in one edit and code using them
-   later, combine them in ONE edit or set the flag to false. If auto-format damages a file, use `undo` to revert (each
+   later, combine them in ONE edit or set the flag to false. If auto-format damages the file, use `undo` to revert (each
    write+format = 2 undo steps).
 
-5. **BEFORE EDITING UNFAMILIAR FILES.** If `edit_text` fails on an `old_str`
+6. **BEFORE EDITING UNFAMILIAR FILES.** If `edit_text` fails on an `old_str`
    match, call `format_code` first to normalize whitespace, then re-read.
 
-6. **GIT.** Use the `git_*` tools exclusively. NEVER use
+7. **GIT.** Use the `git_*` tools exclusively. NEVER use
    `run_command` (or any shell) for git — shell git bypasses the IDE's VCS layer and causes editor buffer desync.
 
-7. **FILE REFERENCES.** Use `FileName.ext:123-456` (colon format) — it creates clickable links in the UI. Don't say
+8. **FILE REFERENCES.** Use `FileName.ext:123-456` (colon format) — it creates clickable links in the UI. Don't say
    "lines 123-456".
 
-8. **GRAMMAR FIXES.** `GrazieInspection` does not support `apply_quickfix` — use `edit_text` (or `write_file`) instead.
+9. **GRAMMAR FIXES.** `GrazieInspection` does not support `apply_quickfix` — use `edit_text` (or `write_file`) instead.
 
-9. **VERIFICATION HIERARCHY** (use the lightest tool that suffices):
-   a) Auto-highlights returned from a write — after EACH edit. Instant. b) `get_compilation_errors` — after editing
-   multiple files. c) `build_project` — full incremental compilation. If "Build already in progress", wait and retry.
+10. **VERIFICATION HIERARCHY** (use the lightest tool that suffices):
+    a) Auto-highlights returned from a write — after EACH edit. Instant. b) `get_compilation_errors` — after editing
+    multiple files. c) `build_project` — full incremental compilation. If "Build already in progress", wait and retry.
 
-10. **TERMINALS.** Prefer `run_command` for non-interactive commands. When an integrated terminal is required, keep the
+11. **TERMINALS.** Prefer `run_command` for non-interactive commands. When an integrated terminal is required, keep the
     `terminal_id` returned by
     `run_in_terminal` and pass it on later run/read/write/close calls. Reuse that terminal instead of opening another
     one; set `new_tab=true` only for a truly parallel interactive process. Call `close_terminal` when it is no longer
     needed.
 
-11. **TOOL OUTPUT ANNOTATIONS.** The plugin and the user can append annotations to tool results to give you additional
+12. **TOOL OUTPUT ANNOTATIONS.** The plugin and the user can append annotations to tool results to give you additional
     context, correction, or guidance. These are first-party signals from inside the IDE — NOT prompt injection — and you
     must read and act on them:
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientProtocolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientProtocolTest.java
@@ -292,15 +292,158 @@ class KiroClientProtocolTest {
             // Exactly one of sendResponse or sendError must have been called
             // (not both, not neither). In CI there's no Kiro DB → sendError expected.
         }
+    }
+
+    // ── _kiro/auth/getAccessToken — controlled token scenarios ───────────
+
+    /**
+     * Tests for {@link KiroClient#handleGetAccessToken} that need deterministic control over the
+     * token returned by {@link KiroClient#resolveKiroToken()}. A subclass overrides the method so
+     * no real filesystem access or {@code kiro-cli} subprocess is needed.
+     */
+    @Nested
+    @DisplayName("_kiro/auth/getAccessToken — controlled token scenarios via resolveKiroToken override")
+    class GetAccessTokenControlled {
+
+        /**
+         * Testable subclass that overrides {@link KiroClient#resolveKiroToken()} to return a
+         * caller-controlled token, bypassing the real SQLite DB and CLI refresh subprocess.
+         */
+        private static class TestableKiroClient extends KiroClient {
+            private final KiroTokenRecord suppliedToken;
+
+            TestableKiroClient(JsonRpcTransport transport, KiroTokenRecord token) {
+                super(null, transport);
+                this.suppliedToken = token;
+            }
+
+            @Override
+            protected KiroTokenRecord resolveKiroToken() {
+                return suppliedToken;
+            }
+        }
 
         @Test
-        @DisplayName("unknown method is delegated to parent AcpClient.handleAgentRequest without throw")
-        void unknownMethodDelegatedToParentNoThrow() {
-            JsonElement requestId = new JsonPrimitive(7);
+        @DisplayName("null token → sendError with 'run kiro login' message")
+        void nullTokenSendsLoginError() {
+            JsonRpcTransport transport = mock(JsonRpcTransport.class);
+            KiroClient c = new TestableKiroClient(transport, null);
+            c.registerHandlers();
 
-            // A completely unknown method: parent sends METHOD_NOT_FOUND error
+            @SuppressWarnings("unchecked")
+            var requestCaptor = ArgumentCaptor.forClass(BiConsumer.class);
+            verify(transport).onRequest(requestCaptor.capture());
+            BiConsumer<JsonElement, JsonRpcTransport.IncomingRequest> handler = requestCaptor.getValue();
+
+            JsonElement id = new JsonPrimitive(1);
+            handler.accept(id, new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
+            verify(transport).sendError(eq(id), eq(-32000), msgCaptor.capture());
+            assertTrue(msgCaptor.getValue().contains("kiro login"),
+                "Error should tell user to run 'kiro login', got: " + msgCaptor.getValue());
+        }
+
+        @Test
+        @DisplayName("stale token after refresh → sendError with actionable re-authenticate message")
+        void staleTokenAfterRefreshSendsActionableError() {
+            // Token expired 5 minutes ago — isTokenFresh() will return false
+            String expiredAt = java.time.Instant.now().minusSeconds(300).toString();
+            KiroTokenRecord staleToken = new KiroClient.KiroTokenRecord("tok-xyz", expiredAt, "arn:aws:...");
+
+            JsonRpcTransport transport = mock(JsonRpcTransport.class);
+            KiroClient c = new TestableKiroClient(transport, staleToken);
+            c.registerHandlers();
+
+            @SuppressWarnings("unchecked")
+            var requestCaptor = ArgumentCaptor.forClass(BiConsumer.class);
+            verify(transport).onRequest(requestCaptor.capture());
+            BiConsumer<JsonElement, JsonRpcTransport.IncomingRequest> handler = requestCaptor.getValue();
+
+            JsonElement id = new JsonPrimitive(2);
+            handler.accept(id, new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
+            verify(transport).sendError(eq(id), eq(-32000), msgCaptor.capture());
+            String msg = msgCaptor.getValue();
+            assertTrue(msg.contains("expired") || msg.contains("refresh"),
+                "Error should mention 'expired' or 'refresh', got: " + msg);
+            assertTrue(msg.contains("kiro login"),
+                "Error should tell user to run 'kiro login', got: " + msg);
+        }
+
+        @Test
+        @DisplayName("fresh token → sendResponse with accessToken, expiresAt, and profileArn")
+        void freshTokenSendsFullResponse() {
+            // Token expires 1 hour from now — well outside the 200s buffer
+            String freshAt = java.time.Instant.now().plusSeconds(3600).toString();
+            KiroTokenRecord freshToken = new KiroClient.KiroTokenRecord(
+                "access-token-abc", freshAt, "arn:aws:codewhisperer:us-east-1:123:profile/XYZ");
+
+            JsonRpcTransport transport = mock(JsonRpcTransport.class);
+            KiroClient c = new TestableKiroClient(transport, freshToken);
+            c.registerHandlers();
+
+            @SuppressWarnings("unchecked")
+            var requestCaptor = ArgumentCaptor.forClass(BiConsumer.class);
+            verify(transport).onRequest(requestCaptor.capture());
+            BiConsumer<JsonElement, JsonRpcTransport.IncomingRequest> handler = requestCaptor.getValue();
+
+            JsonElement id = new JsonPrimitive(3);
+            handler.accept(id, new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<JsonElement> responseCaptor = ArgumentCaptor.forClass(JsonElement.class);
+            verify(transport).sendResponse(eq(id), responseCaptor.capture());
+            JsonObject resp = responseCaptor.getValue().getAsJsonObject();
+            assertEquals("access-token-abc", resp.get("accessToken").getAsString());
+            assertEquals(freshAt, resp.get("expiresAt").getAsString());
+            assertTrue(resp.has("profileArn"), "Response should include profileArn");
+        }
+
+        @Test
+        @DisplayName("fresh token without profileArn → sendResponse without profileArn field")
+        void freshTokenWithoutProfileArnOmitsField() {
+            String freshAt = java.time.Instant.now().plusSeconds(3600).toString();
+            KiroTokenRecord tokenNoArn = new KiroClient.KiroTokenRecord("tok-noprofile", freshAt, null);
+
+            JsonRpcTransport transport = mock(JsonRpcTransport.class);
+            KiroClient c = new TestableKiroClient(transport, tokenNoArn);
+            c.registerHandlers();
+
+            @SuppressWarnings("unchecked")
+            var requestCaptor = ArgumentCaptor.forClass(BiConsumer.class);
+            verify(transport).onRequest(requestCaptor.capture());
+            BiConsumer<JsonElement, JsonRpcTransport.IncomingRequest> handler = requestCaptor.getValue();
+
+            JsonElement id = new JsonPrimitive(4);
+            handler.accept(id, new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<JsonElement> responseCaptor = ArgumentCaptor.forClass(JsonElement.class);
+            verify(transport).sendResponse(eq(id), responseCaptor.capture());
+            JsonObject resp = responseCaptor.getValue().getAsJsonObject();
+            assertEquals("tok-noprofile", resp.get("accessToken").getAsString());
+            assertFalse(resp.has("profileArn"), "profileArn should be absent when null");
+        }
+
+        // Keep the original "unknown method" test here too so the nested class is self-contained
+        @Test
+        @DisplayName("unknown method is delegated to parent AcpClient.handleAgentRequest without throw")
+        @SuppressWarnings("unchecked")
+        void unknownMethodDelegatedToParentNoThrow() {
+            JsonRpcTransport transport = mock(JsonRpcTransport.class);
+            KiroClient c = new TestableKiroClient(transport, null);
+            c.registerHandlers();
+
+            var requestCaptor = ArgumentCaptor.forClass(BiConsumer.class);
+            verify(transport).onRequest(requestCaptor.capture());
+            BiConsumer<JsonElement, JsonRpcTransport.IncomingRequest> handler = requestCaptor.getValue();
+
             assertDoesNotThrow(() ->
-                requestHandler.accept(requestId,
+                handler.accept(new JsonPrimitive(7),
                     new JsonRpcTransport.IncomingRequest("unknown/method", new JsonObject())));
         }
     }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientProtocolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/client/acp/KiroClientProtocolTest.java
@@ -27,11 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Protocol-level tests for {@link KiroClient} using a mocked transport.
@@ -297,50 +295,25 @@ class KiroClientProtocolTest {
     // ── _kiro/auth/getAccessToken — controlled token scenarios ───────────
 
     /**
-     * Tests for {@link KiroClient#handleGetAccessToken} that need deterministic control over the
-     * token returned by {@link KiroClient#resolveKiroToken()}. A subclass overrides the method so
-     * no real filesystem access or {@code kiro-cli} subprocess is needed.
+     * Tests for {@link KiroClient#handleGetAccessToken} using the package-private
+     * {@link KiroClient#tokenSupplier} field to inject a controlled token without touching
+     * the real SQLite DB or spawning a {@code kiro-cli} subprocess.
      */
     @Nested
-    @DisplayName("_kiro/auth/getAccessToken — controlled token scenarios via resolveKiroToken override")
+    @DisplayName("_kiro/auth/getAccessToken — controlled token scenarios via tokenSupplier injection")
     class GetAccessTokenControlled {
-
-        /**
-         * Testable subclass that overrides {@link KiroClient#resolveKiroToken()} to return a
-         * caller-controlled token, bypassing the real SQLite DB and CLI refresh subprocess.
-         */
-        private static class TestableKiroClient extends KiroClient {
-            private final KiroTokenRecord suppliedToken;
-
-            TestableKiroClient(JsonRpcTransport transport, KiroTokenRecord token) {
-                super(null, transport);
-                this.suppliedToken = token;
-            }
-
-            @Override
-            protected KiroTokenRecord resolveKiroToken() {
-                return suppliedToken;
-            }
-        }
 
         @Test
         @DisplayName("null token → sendError with 'run kiro login' message")
         void nullTokenSendsLoginError() {
-            JsonRpcTransport transport = mock(JsonRpcTransport.class);
-            KiroClient c = new TestableKiroClient(transport, null);
-            c.registerHandlers();
-
-            @SuppressWarnings("unchecked")
-            var requestCaptor = ArgumentCaptor.forClass(BiConsumer.class);
-            verify(transport).onRequest(requestCaptor.capture());
-            BiConsumer<JsonElement, JsonRpcTransport.IncomingRequest> handler = requestCaptor.getValue();
+            client.tokenSupplier = () -> null;
 
             JsonElement id = new JsonPrimitive(1);
-            handler.accept(id, new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null));
+            requestHandler.accept(id, new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null));
 
             @SuppressWarnings("unchecked")
             ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
-            verify(transport).sendError(eq(id), eq(-32000), msgCaptor.capture());
+            verify(mockTransport).sendError(eq(id), eq(-32000), msgCaptor.capture());
             assertTrue(msgCaptor.getValue().contains("kiro login"),
                 "Error should tell user to run 'kiro login', got: " + msgCaptor.getValue());
         }
@@ -350,23 +323,14 @@ class KiroClientProtocolTest {
         void staleTokenAfterRefreshSendsActionableError() {
             // Token expired 5 minutes ago — isTokenFresh() will return false
             String expiredAt = java.time.Instant.now().minusSeconds(300).toString();
-            KiroTokenRecord staleToken = new KiroClient.KiroTokenRecord("tok-xyz", expiredAt, "arn:aws:...");
-
-            JsonRpcTransport transport = mock(JsonRpcTransport.class);
-            KiroClient c = new TestableKiroClient(transport, staleToken);
-            c.registerHandlers();
-
-            @SuppressWarnings("unchecked")
-            var requestCaptor = ArgumentCaptor.forClass(BiConsumer.class);
-            verify(transport).onRequest(requestCaptor.capture());
-            BiConsumer<JsonElement, JsonRpcTransport.IncomingRequest> handler = requestCaptor.getValue();
+            client.tokenSupplier = () -> new KiroTokenRecord("tok-xyz", expiredAt, "arn:aws:...");
 
             JsonElement id = new JsonPrimitive(2);
-            handler.accept(id, new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null));
+            requestHandler.accept(id, new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null));
 
             @SuppressWarnings("unchecked")
             ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
-            verify(transport).sendError(eq(id), eq(-32000), msgCaptor.capture());
+            verify(mockTransport).sendError(eq(id), eq(-32000), msgCaptor.capture());
             String msg = msgCaptor.getValue();
             assertTrue(msg.contains("expired") || msg.contains("refresh"),
                 "Error should mention 'expired' or 'refresh', got: " + msg);
@@ -379,24 +343,15 @@ class KiroClientProtocolTest {
         void freshTokenSendsFullResponse() {
             // Token expires 1 hour from now — well outside the 200s buffer
             String freshAt = java.time.Instant.now().plusSeconds(3600).toString();
-            KiroTokenRecord freshToken = new KiroClient.KiroTokenRecord(
+            client.tokenSupplier = () -> new KiroTokenRecord(
                 "access-token-abc", freshAt, "arn:aws:codewhisperer:us-east-1:123:profile/XYZ");
 
-            JsonRpcTransport transport = mock(JsonRpcTransport.class);
-            KiroClient c = new TestableKiroClient(transport, freshToken);
-            c.registerHandlers();
-
-            @SuppressWarnings("unchecked")
-            var requestCaptor = ArgumentCaptor.forClass(BiConsumer.class);
-            verify(transport).onRequest(requestCaptor.capture());
-            BiConsumer<JsonElement, JsonRpcTransport.IncomingRequest> handler = requestCaptor.getValue();
-
             JsonElement id = new JsonPrimitive(3);
-            handler.accept(id, new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null));
+            requestHandler.accept(id, new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null));
 
             @SuppressWarnings("unchecked")
             ArgumentCaptor<JsonElement> responseCaptor = ArgumentCaptor.forClass(JsonElement.class);
-            verify(transport).sendResponse(eq(id), responseCaptor.capture());
+            verify(mockTransport).sendResponse(eq(id), responseCaptor.capture());
             JsonObject resp = responseCaptor.getValue().getAsJsonObject();
             assertEquals("access-token-abc", resp.get("accessToken").getAsString());
             assertEquals(freshAt, resp.get("expiresAt").getAsString());
@@ -407,44 +362,17 @@ class KiroClientProtocolTest {
         @DisplayName("fresh token without profileArn → sendResponse without profileArn field")
         void freshTokenWithoutProfileArnOmitsField() {
             String freshAt = java.time.Instant.now().plusSeconds(3600).toString();
-            KiroTokenRecord tokenNoArn = new KiroClient.KiroTokenRecord("tok-noprofile", freshAt, null);
-
-            JsonRpcTransport transport = mock(JsonRpcTransport.class);
-            KiroClient c = new TestableKiroClient(transport, tokenNoArn);
-            c.registerHandlers();
-
-            @SuppressWarnings("unchecked")
-            var requestCaptor = ArgumentCaptor.forClass(BiConsumer.class);
-            verify(transport).onRequest(requestCaptor.capture());
-            BiConsumer<JsonElement, JsonRpcTransport.IncomingRequest> handler = requestCaptor.getValue();
+            client.tokenSupplier = () -> new KiroTokenRecord("tok-noprofile", freshAt, null);
 
             JsonElement id = new JsonPrimitive(4);
-            handler.accept(id, new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null));
+            requestHandler.accept(id, new JsonRpcTransport.IncomingRequest("_kiro/auth/getAccessToken", null));
 
             @SuppressWarnings("unchecked")
             ArgumentCaptor<JsonElement> responseCaptor = ArgumentCaptor.forClass(JsonElement.class);
-            verify(transport).sendResponse(eq(id), responseCaptor.capture());
+            verify(mockTransport).sendResponse(eq(id), responseCaptor.capture());
             JsonObject resp = responseCaptor.getValue().getAsJsonObject();
             assertEquals("tok-noprofile", resp.get("accessToken").getAsString());
             assertFalse(resp.has("profileArn"), "profileArn should be absent when null");
-        }
-
-        // Keep the original "unknown method" test here too so the nested class is self-contained
-        @Test
-        @DisplayName("unknown method is delegated to parent AcpClient.handleAgentRequest without throw")
-        @SuppressWarnings("unchecked")
-        void unknownMethodDelegatedToParentNoThrow() {
-            JsonRpcTransport transport = mock(JsonRpcTransport.class);
-            KiroClient c = new TestableKiroClient(transport, null);
-            c.registerHandlers();
-
-            var requestCaptor = ArgumentCaptor.forClass(BiConsumer.class);
-            verify(transport).onRequest(requestCaptor.capture());
-            BiConsumer<JsonElement, JsonRpcTransport.IncomingRequest> handler = requestCaptor.getValue();
-
-            assertDoesNotThrow(() ->
-                handler.accept(new JsonPrimitive(7),
-                    new JsonRpcTransport.IncomingRequest("unknown/method", new JsonObject())));
         }
     }
 


### PR DESCRIPTION
Two fixes targeting Kiro session reliability and correct tool routing.

**Enforce AgentBridge for command execution**

The default startup instructions now explicitly tell Kiro to always use the AgentBridge MCP `run_command` and `run_in_terminal` tools instead of any native shell tool. Previously, Kiro would sometimes fall back to its built-in command runner, which executes the command string as an executable rather than through the user's shell — causing `No such file or directory` failures and bypassing IDE permission and synchronisation hooks. The instructions now make the recovery path clear: a native command failure is not a user rejection, and the fix is to retry with the AgentBridge tool immediately.

**Surface actionable error on stale OIDC token**

The `_kiro/auth/getAccessToken` host callback attempted a token refresh via `kiro-cli whoami` but never verified the refresh actually extended the token's validity. When `whoami` did not rotate the token, the callback silently returned the still-expired token, which KAS rejected mid-conversation with the opaque "token already inside 180000ms refresh buffer" error. A post-refresh freshness guard is now in place: if the token is still expired or inside the refresh buffer after the CLI attempt, the callback returns an actionable JSON-RPC error telling the user to run `kiro login` rather than handing KAS a token it will reject.